### PR TITLE
i3lock-color 2.13.c.4 (Ported from FreeBSD)

### DIFF
--- a/x11/i3lock-color/Makefile
+++ b/x11/i3lock-color/Makefile
@@ -1,0 +1,56 @@
+PORTNAME=	i3lock-color
+DISTVERSION=	2.13.c.4
+CATEGORIES=	x11
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Enhanced i3lock with higher capacity
+WWW=		https://github.com/Raymo111/i3lock-color
+
+LICENSE=	bsd3
+
+BUILD_DEPENDS=	${LOCALBASE}/bin/pam_helper:security/pam_helper
+LIB_DEPENDS=	libev.so:devel/libev \
+		libfontconfig.so:x11-fonts/fontconfig \
+		libfreetype.so:print/freetype2 \
+		libxcb-image.so:x11/xcb-util-image \
+		libxcb-keysyms.so:x11/xcb-util-keysyms \
+		libxcb-util.so:x11/xcb-util \
+		libxcb-xrm.so:x11/xcb-util-xrm \
+		libxkbcommon.so:x11/libxkbcommon \
+		libxkbfile.so:x11/libxkbfile
+
+USES=		autoreconf gmake gnome iconv jpeg localbase pkgconfig tar:bzip2 xorg
+USE_CSTD=	c99
+USE_GCC=	yes
+USE_GITHUB=	yes
+GH_ACCOUNT=	Raymo111
+USE_GNOME=	cairo
+USE_XORG=	x11 xcb xext xinerama xorgproto xrandr xt
+
+GNU_CONFIGURE=	yes
+
+MAKE_ARGS=	PREFIX="${PREFIX}" X11LIB="${LOCALBASE}/lib" \
+		X11INC="${LOCALBASE}/include" CC="${CC}" \
+		MANDIR="${MANPREFIX}/man"
+
+LDFLAGS+=	${ICONV_LIB}
+
+CONFLICTS_INSTALL=	i3lock
+
+PLIST_FILES=	"@(,,4755) bin/i3lock" \
+		man/man1/i3lock.1.gz
+
+OPTIONS_DEFINE=	DOCS
+
+DOC_FILES=	CHANGELOG README.md
+DOCS_PLIST_FILES=	${DOC_FILES:S|^|${DOCSDIR_REL}/|}
+
+post-install:
+	@${STRIP_CMD} ${FAKE_DESTDIR}/usr/local/bin/i3lock
+	@${RM} ${FAKE_DESTDIR}/usr/local/etc/pam.d/i3lock
+
+post-install-DOCS-on:
+	${MKDIR} ${FAKE_DESTDIR}${DOCSDIR}
+	${INSTALL_DATA} ${DOC_FILES:S|^|${WRKSRC}/|} ${FAKE_DESTDIR}${DOCSDIR}
+
+.include <bsd.port.mk>

--- a/x11/i3lock-color/distinfo
+++ b/x11/i3lock-color/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1628201335
+SHA256 (Raymo111-i3lock-color-2.13.c.4_GH0.tar.gz) = 5df4cd3d515d938630ced981a7f0a6e01344d1ec51d10fd3c3d131d19283df69
+SIZE (Raymo111-i3lock-color-2.13.c.4_GH0.tar.gz) = 215078

--- a/x11/i3lock-color/pkg-descr
+++ b/x11/i3lock-color/pkg-descr
@@ -1,0 +1,1 @@
+An improved version of i3lock, with more capabilities.


### PR DESCRIPTION
Enhanced i3lock with higher capacity

Key points:

* MAIMTAINER= >> ports@MidnightBSD.org
*/*: Reset maintainership

* PREFIX >> /usr/local
I was unable to build with the ${PREFIX} macro in `post-install`: So I had to replace with `/usr/local/`. If I did wrong, please let me know.