### PR TITLE
boehm-gc: bump to 8.2.10

### DIFF
--- a/devel/boehm-gc-threaded/pkg-plist
+++ b/devel/boehm-gc-threaded/pkg-plist
@@ -25,7 +25,7 @@ lib/libcord.so.1.5.1
 lib/libgc.a
 lib/libgc.so
 lib/libgc.so.1
-lib/libgc.so.1.5.4
+lib/libgc.so.1.5.5
 lib/libgccpp.a
 lib/libgccpp.so
 lib/libgccpp.so.1

--- a/devel/boehm-gc/Makefile
+++ b/devel/boehm-gc/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	gc
-PORTVERSION=	8.2.8
+PORTVERSION=	8.2.10
 CATEGORIES=	devel
-MASTER_SITES=	https://github.com/ivmai/bdwgc/releases/download/v${PORTVERSION}/
+MASTER_SITES=	https://github.com/bdwgc/bdwgc/releases/download/v${PORTVERSION}/
 PKGNAMEPREFIX=	boehm-
 .ifdef GC_VARIANT
 PKGNAMESUFFIX=	-${GC_VARIANT}
@@ -13,7 +13,7 @@ WWW=		https://www.hboehm.info/gc/
 
 LICENSE=	BDWGC
 LICENSE_NAME=	Boehm-Demers-Weiser Garbage Collector License
-LICENSE_TEXT=	License can be found at http://www.hboehm.info/gc/license.txt
+LICENSE_TEXT=	License can be found at https://www.hboehm.info/gc/license.txt
 LICENSE_PERMS=	dist-mirror dist-sell pkg-mirror pkg-sell auto-accept
 
 SKIP_FAKE_CHECK=	.*/share/doc/gc/gc\.man\.bak$
@@ -39,7 +39,7 @@ PLIST=		${NONEXISTENT}
 PLIST_FILES=	${INSTLIBS:S,^,lib/lib,:S,$,-${GC_VARIANT}.so,} \
 		${INSTLIBS:S,^,lib/lib,:S,$,-${GC_VARIANT}.so.1,} \
 		lib/libcord-${GC_VARIANT}.so.1.5.1 \
-		lib/libgc-${GC_VARIANT}.so.1.5.4 \
+		lib/libgc-${GC_VARIANT}.so.1.5.5 \
 		lib/libgccpp-${GC_VARIANT}.so.1.5.0 \
 		lib/libgctba-${GC_VARIANT}.so.1.5.0 \
 		libdata/pkgconfig/bdw-gc-${GC_VARIANT}.pc

--- a/devel/boehm-gc/distinfo
+++ b/devel/boehm-gc/distinfo
@@ -1,2 +1,2 @@
-SHA256 (gc-8.2.8.tar.gz) = 7649020621cb26325e1fb5c8742590d92fb48ce5c259b502faf7d9fb5dabb160
-SIZE (gc-8.2.8.tar.gz) = 1219553
+SHA256 (gc-8.2.10.tar.gz) = 832cf4f7cf676b59582ed3b1bbd90a8d0e0ddbc3b11cb3b2096c5177ce39cc47
+SIZE (gc-8.2.10.tar.gz) = 1229219

--- a/devel/boehm-gc/pkg-plist
+++ b/devel/boehm-gc/pkg-plist
@@ -24,7 +24,7 @@ lib/libcord.so.1.5.1
 lib/libgc.a
 lib/libgc.so
 lib/libgc.so.1
-lib/libgc.so.1.5.4
+lib/libgc.so.1.5.5
 lib/libgccpp.a
 lib/libgccpp.so
 lib/libgccpp.so.1


### PR DESCRIPTION
## Summary by Sourcery

Bump boehm-gc port to version 8.2.10 and update related URLs and library version references

Enhancements:
- Update PORTVERSION to 8.2.10
- Adjust MASTER_SITES to bdwgc GitHub repository
- Switch license TEXT URL to secure https link
- Update PLIST entries to new libgc version 1.5.5