### PR TITLE
update libatomic_ops to 7.10.0

### DIFF
--- a/devel/libatomic_ops/Makefile
+++ b/devel/libatomic_ops/Makefile
@@ -1,11 +1,11 @@
 PORTNAME=	libatomic_ops
-DISTVERSION=	7.8.2
+DISTVERSION=	7.10.0
 CATEGORIES=	devel
-MASTER_SITES=	https://github.com/ivmai/libatomic_ops/releases/download/v${DISTVERSION}/
+MASTER_SITES=	https://github.com/bdwgc/libatomic_ops/releases/download/v${DISTVERSION}/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Atomic operations access library
-WWW=		https://github.com/ivmai/libatomic_ops
+WWW=		https://github.com/bdwgc/libatomic_ops
 
 LICENSE=	bsd2 gpl2
 LICENSE_COMB=	multi

--- a/devel/libatomic_ops/distinfo
+++ b/devel/libatomic_ops/distinfo
@@ -1,2 +1,2 @@
-SHA256 (libatomic_ops-7.8.2.tar.gz) = d305207fe207f2b3fb5cb4c019da12b44ce3fcbc593dfd5080d867b1a2419b51
-SIZE (libatomic_ops-7.8.2.tar.gz) = 524637
+SHA256 (libatomic_ops-7.10.0.tar.gz) = 0db3ebff755db170f65e74a64ec4511812e9ee3185c232eeffeacd274190dfb0
+SIZE (libatomic_ops-7.10.0.tar.gz) = 543312


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump libatomic_ops DISTVERSION to 7.10.0 and adjust MASTER_SITES and WWW to the new upstream GitHub organization.