### PR TITLE
boehm-gc: bump to 8.2.12

### DIFF
--- a/devel/boehm-gc-threaded/pkg-plist
+++ b/devel/boehm-gc-threaded/pkg-plist
@@ -25,7 +25,7 @@ lib/libcord.so.1.5.1
 lib/libgc.a
 lib/libgc.so
 lib/libgc.so.1
-lib/libgc.so.1.5.5
+lib/libgc.so.1.5.6
 lib/libgccpp.a
 lib/libgccpp.so
 lib/libgccpp.so.1

--- a/devel/boehm-gc/Makefile
+++ b/devel/boehm-gc/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gc
-PORTVERSION=	8.2.10
+PORTVERSION=	8.2.12
 CATEGORIES=	devel
 MASTER_SITES=	https://github.com/bdwgc/bdwgc/releases/download/v${PORTVERSION}/
 PKGNAMEPREFIX=	boehm-
@@ -39,7 +39,7 @@ PLIST=		${NONEXISTENT}
 PLIST_FILES=	${INSTLIBS:S,^,lib/lib,:S,$,-${GC_VARIANT}.so,} \
 		${INSTLIBS:S,^,lib/lib,:S,$,-${GC_VARIANT}.so.1,} \
 		lib/libcord-${GC_VARIANT}.so.1.5.1 \
-		lib/libgc-${GC_VARIANT}.so.1.5.5 \
+		lib/libgc-${GC_VARIANT}.so.1.5.6 \
 		lib/libgccpp-${GC_VARIANT}.so.1.5.0 \
 		lib/libgctba-${GC_VARIANT}.so.1.5.0 \
 		libdata/pkgconfig/bdw-gc-${GC_VARIANT}.pc

--- a/devel/boehm-gc/distinfo
+++ b/devel/boehm-gc/distinfo
@@ -1,2 +1,2 @@
-SHA256 (gc-8.2.10.tar.gz) = 832cf4f7cf676b59582ed3b1bbd90a8d0e0ddbc3b11cb3b2096c5177ce39cc47
-SIZE (gc-8.2.10.tar.gz) = 1229219
+SHA256 (gc-8.2.12.tar.gz) = 42e5194ad06ab6ffb806c83eb99c03462b495d979cda782f3c72c08af833cd4e
+SIZE (gc-8.2.12.tar.gz) = 1231996

--- a/devel/boehm-gc/files/patch-doc_gc.man
+++ b/devel/boehm-gc/files/patch-doc_gc.man
@@ -1,8 +1,8 @@
---- doc/gc.man.orig	2014-05-22 20:47:28 UTC
+--- doc/gc.man.orig	2026-02-06 05:27:28 UTC
 +++ doc/gc.man
-@@ -88,6 +88,48 @@ This may temporarily write protect pages
- .LP
- Other facilities not discussed here include limited facilities to support incremental collection on machines without appropriate VM support, provisions for providing more explicit object layout information to the garbage collector, more direct support for ``weak'' pointers, support for ``abortable'' garbage collections during idle time, etc.
+@@ -137,6 +137,48 @@ for providing more explicit object layout information to the garbage
+ collector, more direct support for ``weak'' pointers, support for
+ ``abortable'' garbage collections during idle time, etc.
  .LP
 +.SH "PORT INFORMATION"
 +.LP
@@ -47,5 +47,5 @@
 +This may or may not make a difference.
 +.LP
  .SH "SEE ALSO"
- The README and gc.h files in the distribution.  More detailed definitions of the functions exported by the collector are given there.  (The above list is not complete.)
- .LP
+ The README and gc.h files in the distribution.  More detailed definitions of
+ the functions exported by the collector are given there.  (The above list is

--- a/devel/boehm-gc/pkg-plist
+++ b/devel/boehm-gc/pkg-plist
@@ -24,7 +24,7 @@ lib/libcord.so.1.5.1
 lib/libgc.a
 lib/libgc.so
 lib/libgc.so.1
-lib/libgc.so.1.5.5
+lib/libgc.so.1.5.6
 lib/libgccpp.a
 lib/libgccpp.so
 lib/libgccpp.so.1


### PR DESCRIPTION
## Summary by Sourcery

Bump the Boehm GC port to version 8.2.12 and align packaging and documentation with the new upstream release.

Enhancements:
- Update the Boehm GC port to use upstream release 8.2.12 instead of 8.2.10.
- Adjust the libgc shared library version in the plist to match the new upstream SONAME.

Documentation:
- Refresh the gc.man patch to match the updated upstream manpage and add a FreeBSD-specific "PORT INFORMATION" section.