### PR TITLE
misc/gemini-cli: clean fetch workdir before bundling

### DIFF
--- a/misc/gemini-cli/Makefile
+++ b/misc/gemini-cli/Makefile
@@ -20,6 +20,7 @@ PACKAGE_NAME=	@google/gemini-cli
 
 do-fetch:
 	@if ! [ -f ${DISTDIR}/${PORTNAME}-${DISTVERSION}${EXTRACT_SUFX} ]; then ( \
+		${RM} -rf ${WRKDIR}/${PORTNAME}-${DISTVERSION} && \
 		${MKDIR} -p ${WRKDIR}/${PORTNAME}-${DISTVERSION} && \
 		cd ${WRKDIR}/${PORTNAME}-${DISTVERSION} && \
 		if [ -f ${FILESDIR}/package-lock.json ]; then \


### PR DESCRIPTION
AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Bug Fixes:
- Remove any existing gemini-cli work directory before creating a new one during the fetch phase to avoid stale files in the bundled artifact.