### PR TITLE
www/qt6-webengine: add NSS/NSPR include paths to CXXFLAGS

### DIFF
--- a/www/qt6-webengine/Makefile
+++ b/www/qt6-webengine/Makefile
@@ -81,7 +81,9 @@ USE_XORG+=	x11 xcb xcomposite xcursor xdamage xext xfixes xi xkbfile \
 CMAKE_ON+=	QT_FEATURE_qtwebengine_build
 CMAKE_OFF+=	QT_FEATURE_qtpdf_build
 
-CXXFLAGS+=	-I${LOCALBASE}/include/libepoll-shim
+CXXFLAGS+=	-I${LOCALBASE}/include/libepoll-shim \
+		-I${LOCALBASE}/include/nss \
+		-I${LOCALBASE}/include/nspr
 
 SYS_LIBS=	freetype harfbuzz-ng libdrm libpng libxml libxslt openh264 opus
 .endif


### PR DESCRIPTION
Chromium's crypto/ code includes NSS headers directly (pk11pub.h, secoidt.h) but these are installed to ${LOCALBASE}/include/nss/ and ${LOCALBASE}/include/nspr/, not ${LOCALBASE}/include/. Add both to CXXFLAGS so the GN toolchain can find them, mirroring the existing libepoll-shim path fix. Fixes build failure on i386.

AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Extend qt6-webengine CXXFLAGS with NSS and NSPR include paths alongside the existing libepoll-shim path to fix build failures on some architectures.