### PR TITLE
cad/z88: fix staged path embedded in wrapper script

### DIFF
--- a/cad/z88/Makefile
+++ b/cad/z88/Makefile
@@ -1,6 +1,7 @@
 PORTNAME=	z88
 DISTVERSIONPREFIX=	v
 DISTVERSION=	15
+PORTREVISION=	1
 CATEGORIES=	cad
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -51,7 +52,7 @@ do-install:
 	for x in ${Z88_BIN_SUFFIXES}; do ${INSTALL_PROGRAM} ${INSTALL_WRKSRC}/z88$$x ${PREFIX}/bin; done
 	${INSTALL_DATA} ${Z88_DATA:S,^,${INSTALL_WRKSRC}/,} ${DATADIR}
 	${INSTALL_SCRIPT} ${FILESDIR}/z88 ${PREFIX}/bin
-	${SED} -i '' 's,%%DATADIR%%,${DATADIR},' ${PREFIX}/bin/z88
+	${SED} -i '' 's,%%DATADIR%%,${LOCALBASE}/share/${PORTNAME},' ${PREFIX}/bin/z88
 	${SED} -i '' 's,%%Z88_DATA%%,${Z88_DATA},' ${PREFIX}/bin/z88
 
 do-install-DOCS-on:


### PR DESCRIPTION
do-install runs with FAKE_DESTDIR prepended to PREFIX automatically, so ${DATADIR} expands to the staging path. Substitute ${LOCALBASE}/share/${PORTNAME} instead so the installed z88 wrapper script contains the correct runtime path. Bump PORTREVISION.

AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Fix the z88 wrapper script to embed the correct runtime data directory path and bump the port revision.

Bug Fixes:
- Ensure the z88 wrapper script uses the non-staged data directory path at runtime instead of the staging ${DATADIR} path.

Build:
- Bump PORTREVISION to 1 for the z88 port to reflect the fix.