### PR TITLE
devel/git-svn: use ports Perl path

### DIFF
--- a/devel/git/Makefile
+++ b/devel/git/Makefile
@@ -142,6 +142,8 @@ RUN_DEPENDS+=	cvsps:devel/cvsps
 USES+=		tk
 MAKE_ARGS+=	TCL_PATH=${TCLSH} TCLTK_PATH=${WISH}
 . elif ${SUBPORT} == svn
+USES+=		perl5
+CONFIGURE_ARGS+=	--with-perl=${PERL}
 RUN_DEPENDS+=	p5-Term-ReadKey>=0:devel/p5-Term-ReadKey
 .  if ${WITH_SUBVERSION_VER:U} == LTS
 RUN_DEPENDS+=	p5-subversion-lts>=0:devel/p5-subversion


### PR DESCRIPTION
## Summary
- add perl5 to the git-svn subport
- pass the ports Perl path to Git configure so generated git-svn uses /usr/local/bin/perl

## Validation
- bmake patch
- bmake build
- bmake fake
- bmake package
- git diff --check

Magus port: 2163320

## Summary by Sourcery

Add explicit Perl dependency and configuration for the git-svn subport to ensure it uses the ports Perl path.

New Features:
- Ensure the git-svn subport is configured to use the ports-provided Perl interpreter.

Enhancements:
- Declare a Perl runtime dependency for the git-svn subport to align with its configured interpreter path.