### PR TITLE
devel/git-tools: fix plist and shebang

### DIFF
--- a/devel/git-tools/Makefile
+++ b/devel/git-tools/Makefile
@@ -1,17 +1,18 @@
 PORTNAME=	git-tools
-DISTVERSIONPREFIX=	v
 PORTVERSION=	2020.09
+DISTVERSIONPREFIX=	v
 CATEGORIES=	devel
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Assorted git-related scripts and tools
+WWW=		https://github.com/MestreLion/git-tools
 
 LICENSE=	gpl3
 
 RUN_DEPENDS=	bash:shells/bash \
 		git:devel/git
 
-USES=		pathfix python:run
+USES=		pathfix python:run shebangfix
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	MestreLion
@@ -25,11 +26,15 @@ CMDS=	git-branches-rename \
 	git-restore-mtime \
 	git-strip-merge
 
+PLIST_FILES=	${CMDS:S|^|bin/|} \
+		${CMDS:S|^|share/man/man1/|:S|$|.1.gz|}
+
+SHEBANG_FILES=	git-restore-mtime
+
 do-install:
 .for f in ${CMDS}
 	${INSTALL_SCRIPT} ${WRKSRC}/${f} ${PREFIX}/bin/$f
-	${INSTALL_MAN} ${WRKSRC}/man1/${f}.1 ${PREFIX}/man/man1/${f}.1
+	${INSTALL_MAN} ${WRKSRC}/man1/${f}.1 ${PREFIX}/share/man/man1/${f}.1
 .endfor
-
 
 .include <bsd.port.mk>

--- a/devel/git-tools/pkg-descr
+++ b/devel/git-tools/pkg-descr
@@ -1,3 +1,2 @@
-Assorted git-related scripts and tools
-
-WWW: https://github.com/MestreLion/git-tools
+Assorted git-related scripts and tools for branch renaming, partial cloning,
+repository scans, rebase workflows, restoring mtimes, and stripping merges.


### PR DESCRIPTION
## Summary
- add shebangfix for git-restore-mtime
- list installed scripts and manpages in PLIST_FILES
- install manpages under share/man and move WWW into the Makefile

## Validation
- bmake patch
- bmake fake
- bmake package
- bmake test
- git diff --check
- portlint -C (only MPORT_MAINTAINER_MODE warning)

Magus port: 2163322

## Summary by Sourcery

Fix packaging and metadata for git-tools port to correctly install scripts and manpages.

Bug Fixes:
- Ensure installed scripts and their manpages are properly tracked via PLIST_FILES.
- Install manpages under share/man to match expected filesystem layout.
- Add shebangfix handling for git-restore-mtime to ensure a correct runtime interpreter.

Enhancements:
- Move the port WWW homepage definition from pkg-descr into the Makefile for clearer metadata management.