### PR TITLE
lang/spidermonkey128: disable parallel build on i386

### DIFF
--- a/lang/spidermonkey128/Makefile
+++ b/lang/spidermonkey128/Makefile
@@ -58,6 +58,10 @@ CONFIGURE_TARGET=	x86_64-portbld-freebsd13.4
 CONFIGURE_TARGET=${ARCH}-portbld-freebsd13.4
 .endif
 
+.if ${ARCH} == i386
+MAKE_JOBS_UNSAFE=	yes
+.endif
+
 .if ${CHOSEN_COMPILER_TYPE} == gcc
 CONFIGURE_ENV+=	LLVM_CONFIG=${LLVM_CONFIG} \
 		LLVM_OBJDUMP=llvm-objdump${LLVM_VERSION}


### PR DESCRIPTION
## Summary
- disable make jobs for i386 builds of spidermonkey128
- leave other architectures using normal parallel builds

## Validation
- bmake patch
- bmake ARCH=i386 -V MAKE_JOBS_UNSAFE -V MAKE_JOBS_NUMBER -V _MAKE_JOBS
- bmake -n build confirms amd64 still uses gmake -j
- bmake ARCH=i386 -n build confirms i386 omits -j
- git diff --check
- portlint -C (0 fatal errors; pre-existing warnings remain)

Magus port: 2166880

## Summary by Sourcery

Enhancements:
- Mark the spidermonkey128 i386 build as MAKE_JOBS_UNSAFE to force single-threaded make.