### PR TITLE
devel/tinysparql: disable example tests by default

### DIFF
--- a/devel/tinysparql/Makefile
+++ b/devel/tinysparql/Makefile
@@ -4,11 +4,11 @@ CATEGORIES=	devel
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
-MAINTAINER= 	ports@MidnightBSD.org
+MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	RDF triple store library with SPARQL 1.1 interface
 WWW=		https://gitlab.gnome.org/GNOME/tinysparql
 
-LICENSE= 	lgpl2.1 gpl2 bsd3
+LICENSE=	lgpl2.1 gpl2 bsd3
 LICENSE_COMB=	multi
 
 BUILD_DEPENDS=	a2x:textproc/asciidoc
@@ -16,10 +16,11 @@ LIB_DEPENDS=	libdbus-1.so:devel/dbus \
 		libsoup-3.0.so:devel/libsoup3 \
 		libstemmer.so:textproc/snowballstemmer \
 		libicutu.so:devel/icu \
-		libjson-glib-1.0.so:devel/json-glib \
+		libjson-glib-1.0.so:devel/json-glib
 
 USES=		gettext gnome localbase:ldflags meson pkgconfig python:build sqlite tar:xz
 USE_GNOME=	glib20 introspection:build libxml2 pygobject3
+USE_LDCONFIG=	yes
 
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 MESON_ARGS=	-Dsystemd_user_services=false \

--- a/devel/tinysparql/files/patch-examples_meson.build
+++ b/devel/tinysparql/files/patch-examples_meson.build
@@ -1,0 +1,9 @@
+--- examples/meson.build.orig	2024-12-13 13:08:09 UTC
++++ examples/meson.build
+@@ -1,5 +1,5 @@
+ subdir('libtinysparql')
+
+-if get_option('introspection').enabled()
++if get_option('tests') and get_option('introspection').enabled()
+     subdir('python')
+ endif


### PR DESCRIPTION
## Summary
- gate tinysparql Python examples on the upstream tests option
- fix LIB_DEPENDS continuation and add USE_LDCONFIG for installed shared libraries
- clean up adjacent Makefile tab spacing

## Validation
- bmake patch
- bmake build
- bmake test
- bmake package
- git diff --check --cached
- portlint -C

## Summary by Sourcery

Gate tinysparql’s Python example tests on the upstream tests option and tidy the port configuration.

Enhancements:
- Disable building/running tinysparql Python example tests by default, controlled via the upstream tests option.
- Register installed shared libraries with the runtime linker via USE_LDCONFIG.
- Clean up Makefile formatting and fix the LIB_DEPENDS continuation line.