### PR TITLE
sysutils/filelight: refresh distinfo

### DIFF
--- a/sysutils/filelight/distinfo
+++ b/sysutils/filelight/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1746557955
-SHA256 (KDE/release-service/25.04.1/filelight-25.04.1.tar.xz) = 169db1fe356d1d65850d903c537899ad1342e2a73d1800d2b7fbfba31f0e344b
-SIZE (KDE/release-service/25.04.1/filelight-25.04.1.tar.xz) = 689256
+TIMESTAMP = 1778909877
+SHA256 (KDE/release-service/25.12.0/filelight-25.12.0.tar.xz) = 355386cc10e88808eebf76fbc84094bc24b90d76afe28a9bda41b6b49381a5ab
+SIZE (KDE/release-service/25.12.0/filelight-25.12.0.tar.xz) = 691124


### PR DESCRIPTION
## Summary
- refresh sysutils/filelight distinfo for KDE Applications 25.12.0
- fixes Magus port 2168750 fetch failure where filelight-25.12.0.tar.xz was missing from distinfo

## Validation
- bmake -C sysutils/filelight -V KDE_APPLICATIONS_VERSION -V DISTVERSION -V DISTFILES
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- git diff --check

Package created: /usr/mports/Packages/amd64/All/filelight-25.12.0.mport

## Notes
- FreeBSD /usr/ports/sysutils/filelight is already on KDE Applications 26.04.0, while this tree currently resolves KDE_APPLICATIONS_VERSION to 25.12.0.
- The local meinproc6/libxml2 runtime mismatch encountered during validation was resolved by rebuilding and reinstalling devel/kf6-kdoctools with bmake deinstall reinstall.