### PR TITLE
irc/irssi-scripts: fix installed script shebangs

### DIFF
--- a/irc/irssi-scripts/Makefile
+++ b/irc/irssi-scripts/Makefile
@@ -14,8 +14,8 @@ RUN_DEPENDS=	irssi:irc/irssi
 WRKSRC=		${WRKDIR}/${PORTNAME}
 
 USES=		shebangfix tar:xz
-#SHEBANG_FILES=	scripts/*.pl
-#perl_OLD_CMD=	/usr/pkg/bin/perl /usr/bin/irssi
+SHEBANG_FILES=	scripts/*.pl
+perl_OLD_CMD=	/usr/pkg/bin/perl /usr/bin/irssi
 NO_BUILD=	yes
 NO_ARCH=	yes
 


### PR DESCRIPTION
Enable shebangfix for the packaged Perl scripts and map legacy /usr/pkg/bin/perl and /usr/bin/irssi shebangs to the local Perl interpreter.

AI-Assisted-by: OpenAI Codex <noreply@openai.com>

## Summary by Sourcery

Bug Fixes:
- Correct legacy Perl and irssi shebangs in packaged scripts to point to the local Perl interpreter.