### PR TITLE
x11/xwayland-satellite: avoid exporting LLVM compiler

### DIFF
--- a/x11/xwayland-satellite/Makefile
+++ b/x11/xwayland-satellite/Makefile
@@ -14,7 +14,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 LIB_DEPENDS=	libxcb-cursor.so:x11/xcb-util-cursor
 RUN_DEPENDS=	Xwayland:x11-servers/xwayland
 
-USES=		cargo llvm pkgconfig xorg
+USES=		cargo llvm:noexport pkgconfig xorg
 USE_GITHUB=	yes
 USE_XORG=	xcb
 GH_ACCOUNT=	Supreeeme


### PR DESCRIPTION
## Summary
- use llvm:noexport for x11/xwayland-satellite
- keep llvm-config19 available for clang-sys while leaving Cargo's linker as the system compiler
- fixes Magus port 2170400 i386 fake-stage failure where Cargo looked for clang under FAKE_DESTDIR

## Validation
- bmake clean
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake check-license
- portlint
- git diff --check

Package created: /usr/mports/Packages/amd64/All/xwayland-satellite-0.5.1_1.mport

## Notes
- Confirmed resolved CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER changed from /usr/local/llvm19/bin/clang to cc locally.
- FreeBSD /usr/ports/x11/xwayland-satellite is newer at 0.8.1_2; this PR is limited to fixing the current MidnightBSD 0.5.1_1 Magus failure.

## Summary by Sourcery

Enhancements:
- Adjust xwayland-satellite port to use llvm:noexport so LLVM binaries are not exposed as the default compiler during the build.