### PR TITLE
fix rubygem activionview4

### DIFF
--- a/cad/z88/Makefile
+++ b/cad/z88/Makefile
@@ -1,6 +1,7 @@
 PORTNAME=	z88
 DISTVERSIONPREFIX=	v
 DISTVERSION=	15
+PORTREVISION=	1
 CATEGORIES=	cad
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -51,7 +52,7 @@ do-install:
 	for x in ${Z88_BIN_SUFFIXES}; do ${INSTALL_PROGRAM} ${INSTALL_WRKSRC}/z88$$x ${PREFIX}/bin; done
 	${INSTALL_DATA} ${Z88_DATA:S,^,${INSTALL_WRKSRC}/,} ${DATADIR}
 	${INSTALL_SCRIPT} ${FILESDIR}/z88 ${PREFIX}/bin
-	${SED} -i '' 's,%%DATADIR%%,${DATADIR},' ${PREFIX}/bin/z88
+	${SED} -i '' 's,%%DATADIR%%,${LOCALBASE}/share/${PORTNAME},' ${PREFIX}/bin/z88
 	${SED} -i '' 's,%%Z88_DATA%%,${Z88_DATA},' ${PREFIX}/bin/z88
 
 do-install-DOCS-on:

--- a/devel/rubygem-actionview4/Makefile
+++ b/devel/rubygem-actionview4/Makefile
@@ -12,6 +12,7 @@ WWW=		https://rubyonrails.org/ \
 LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/MIT-LICENSE
 
+BUILD_DEPENDS=	${RUN_DEPENDS}
 RUN_DEPENDS=	rubygem-activesupport4>=${PORTVERSION}:devel/rubygem-activesupport4 \
 		rubygem-builder>=3.1<4:devel/rubygem-builder \
 		rubygem-erubis>=2.7.0<2.8:www/rubygem-erubis \


### PR DESCRIPTION
## Summary by Sourcery

Update ports metadata and dependencies for z88 and rubygem-actionview4.

Bug Fixes:
- Correct the z88 launcher script to reference the installed data directory via LOCALBASE instead of DATADIR.
- Ensure rubygem-actionview4 declares its runtime dependencies as build-time dependencies as well.