### PR TITLE
lang/spidermonkey128: fix i386 alignment build

### DIFF
--- a/lang/spidermonkey128/Makefile
+++ b/lang/spidermonkey128/Makefile
@@ -58,10 +58,6 @@ CONFIGURE_TARGET=	x86_64-portbld-freebsd13.4
 CONFIGURE_TARGET=${ARCH}-portbld-freebsd13.4
 .endif
 
-.if ${ARCH} == i386
-MAKE_JOBS_UNSAFE=	yes
-.endif
-
 .if ${CHOSEN_COMPILER_TYPE} == gcc
 CONFIGURE_ENV+=	LLVM_CONFIG=${LLVM_CONFIG} \
 		LLVM_OBJDUMP=llvm-objdump${LLVM_VERSION}

--- a/lang/spidermonkey128/files/patch-js_public_Utility.h
+++ b/lang/spidermonkey128/files/patch-js_public_Utility.h
@@ -1,0 +1,32 @@
+commit 57b30241311091b5a6a5a0bb1c19a8e073860fc3
+Author: Christoph Moench-Tegeder <cmt@burggraben.net>
+
+    do not assert on alignment when not having the bits
+
+    the underlying issue seemed to be win-only anyways?
+
+diff --git js/public/Utility.h js/public/Utility.h
+index 0d745e9df785..f0ca7ea37162 100644
+--- js/public/Utility.h
++++ js/public/Utility.h
+@@ -480,6 +480,7 @@ static inline void js_free(void* p) {
+  * Note: Do not add a ; at the end of a use of JS_DECLARE_NEW_METHODS,
+  * or the build will break.
+  */
++#if !defined(__i386__)
+ #define JS_DECLARE_NEW_METHODS(NEWNAME, ALLOCATOR, QUALIFIERS)              \
+   template <class T, typename... Args>                                      \
+   QUALIFIERS T* MOZ_HEAP_ALLOCATOR NEWNAME(Args&&... args) {                \
+@@ -490,3 +491,12 @@ static inline void js_free(void* p) {
+     return MOZ_LIKELY(memory) ? new (memory) T(std::forward<Args>(args)...) \
+                               : nullptr;                                    \
+   }
++#else
++#define JS_DECLARE_NEW_METHODS(NEWNAME, ALLOCATOR, QUALIFIERS)              \
++  template <class T, typename... Args>                                      \
++  QUALIFIERS T* MOZ_HEAP_ALLOCATOR NEWNAME(Args&&... args) {                \
++    void* memory = ALLOCATOR(sizeof(T));                                    \
++    return MOZ_LIKELY(memory) ? new (memory) T(std::forward<Args>(args)...) \
++                              : nullptr;                                    \
++  }
++#endif


### PR DESCRIPTION
## Summary
- apply the existing Firefox Utility.h workaround to skip the max_align_t static assertion on i386
- remove the earlier i386 MAKE_JOBS_UNSAFE workaround because the Magus failure is a deterministic alignment assertion, not a parallel build race

## Validation
- bmake patch
- bmake check-license
- portlint (0 fatal errors; existing warnings about pkg-descr length, BUILD_DEPENDS tuple style, and patch generation format)
- git diff --check origin/master...HEAD

Magus port 2166880 failed on i386 with JS_DECLARE_NEW_METHODS asserting that alignof(js::DebuggerFrame::GeneratorInfo) is 8 while alignof(__max_align_t) is 4.

## Summary by Sourcery

Fix i386 build alignment issues in spidermonkey128 and clean up an obsolete parallel-build workaround.

Bug Fixes:
- Work around an i386 alignment assertion in JS_DECLARE_NEW_METHODS by disabling the max_align_t-based alignment check on that architecture.

Enhancements:
- Remove the i386-specific MAKE_JOBS_UNSAFE flag to re-enable parallel builds now that the underlying failure is addressed.