### PR TITLE
lang/spidermonkey128: fix typed array i386 alignment

### DIFF
--- a/lang/spidermonkey128/files/patch-js_src_vm_TypedArrayObject-inl.h
+++ b/lang/spidermonkey128/files/patch-js_src_vm_TypedArrayObject-inl.h
@@ -1,0 +1,11 @@
+--- js/src/vm/TypedArrayObject-inl.h.orig	2025-08-18 20:29:39 UTC
++++ js/src/vm/TypedArrayObject-inl.h
+@@ -404,7 +404,7 @@ class ElementSpecific {
+-    // `malloc` returns memory at least as strictly aligned as for max_align_t
+-    // and the alignment of max_align_t is a multiple of the size of `T`,
+-    // so `SharedMem::cast` will be called with properly aligned memory.
+-    static_assert(alignof(std::max_align_t) % sizeof(T) == 0);
++    // ArrayBuffer data is aligned to ARRAY_BUFFER_ALIGNMENT, which is a
++    // multiple of the size of `T`, so `SharedMem::cast` will be called with
++    // properly aligned memory.
++    static_assert(ArrayBufferObject::ARRAY_BUFFER_ALIGNMENT % sizeof(T) == 0);


### PR DESCRIPTION
## Summary
- fix the new i386 TypedArrayObject static assertion failure from Magus port 2166880
- use ArrayBufferObject::ARRAY_BUFFER_ALIGNMENT instead of std::max_align_t for the typed array alignment assertion

## Validation
- Magus log pulled for port 2166880: failure was alignof(std::max_align_t) % sizeof(T) for double, long long, and unsigned long long on i386
- bmake patch
- bmake build
- bmake fake
- bmake package
- bmake check-license
- portlint (0 fatal errors; existing warnings about pkg-descr length, BUILD_DEPENDS tuple style, and existing patch generation format)
- git diff --check
- c++ -m32 static assertion check for double, long long, and unsigned long long

## Summary by Sourcery

Bug Fixes:
- Fix static assertion failure for typed array alignment on i386 by basing the check on ArrayBufferObject::ARRAY_BUFFER_ALIGNMENT instead of std::max_align_t.