### PR TITLE
lang/spidermonkey128: fix fdlibm typedefs on i386

### DIFF
--- a/lang/spidermonkey128/files/patch-modules_fdlibm_src_math__private.h
+++ b/lang/spidermonkey128/files/patch-modules_fdlibm_src_math__private.h
@@ -1,0 +1,21 @@
+commit 7a20fbf537ee0867244109d1ea48a8ad9de2e4ea
+Author: Christoph Moench-Tegeder <cmt@burggraben.net>
+
+    align typedefs with our libm for historical CPUs
+
+diff --git modules/fdlibm/src/math_private.h modules/fdlibm/src/math_private.h
+index f4373f27834a..3b898241660f 100644
+--- modules/fdlibm/src/math_private.h
++++ modules/fdlibm/src/math_private.h
+@@ -33,3 +33,11 @@
++#ifdef __LP64__
+ typedef double      __double_t;
++#else
++typedef long double __double_t;
++#endif
+ typedef __double_t  double_t;
++#ifdef __LP64__
+ typedef float       __float_t;
++#else
++typedef long double __float_t;
++#endif


### PR DESCRIPTION
## Summary
- add the existing Firefox fdlibm typedef guard to spidermonkey128
- align __double_t and __float_t with libm on 32-bit builds
- fixes Magus port 2166880 i386 build failure in modules/fdlibm/src/math_private.h

## Validation
- bmake patch
- targeted i386 typedef compile reproduces the unpatched conflict and passes with the guarded typedefs
- git diff --cached --check
- portlint -C (0 fatal errors; existing warnings only)

Note: full local bmake ARCH=i386 build cannot complete on this amd64 host because rustc lacks the i686-unknown-freebsd std library; Magus builds this natively on i386.

## Summary by Sourcery

Bug Fixes:
- Resolve i386 build failures in spidermonkey128 by aligning fdlibm __double_t and __float_t typedefs with the system libm on 32-bit platforms.