### PR TITLE
devel/qt5-script: fix CMake include path

### DIFF
--- a/devel/qt5-script/Makefile
+++ b/devel/qt5-script/Makefile
@@ -1,10 +1,13 @@
 PORTNAME=	script
 PORTVERSION=	${QT5_VERSION}${QT5_KDE_PATCH}
+PORTREVISION=	1
 CATEGORIES=	devel
 PKGNAMEPREFIX=	qt5-
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Qt 4-compatible scripting module
+
+LICENSE=	lgpl2.1
 
 USES=		compiler:c++11-lang perl5 qmake qt-dist:5,script
 USE_PERL5=	extract
@@ -23,7 +26,9 @@ post-patch:
 
 # Fix version mismatches for CMake
 post-configure:
-	@${REINPLACE_CMD} -e '/${QT5_VERSION} $${_Qt5Script_FIND_VERSION_EXACT}/s|${QT5_VERSION}|'"$$(${MAKE} -C ../qt5-core -VQT5_VERSION)"'|' \
+	@${REINPLACE_CMD} \
+		-e '/${QT5_VERSION} $${_Qt5Script_FIND_VERSION_EXACT}/s|${QT5_VERSION}|'"$$(${MAKE} -C ../qt5-core -VQT5_VERSION)"'|' \
+		-e 's|/usr/include/qt5|${PREFIX}/${QT_INCDIR_REL}|g' \
 		${WRKSRC}/lib/cmake/Qt5Script/Qt5ScriptConfig.cmake
 
 .include <bsd.port.mk>


### PR DESCRIPTION
## Summary
- normalize generated Qt5Script CMake include paths from /usr/include/qt5 to the Qt include directory under PREFIX
- bump PORTREVISION for the package metadata/content change
- make the inherited lgpl2.1 license explicit so portlint understands the port

## Magus
Fixes port 2166813 (lang/kf5-kross) i386 configure failure. Kross fails while consuming Qt5ScriptConfig.cmake from qt5-script because Qt5::Script references /usr/include/qt5/, which does not exist.

## Validation
- bmake configure in devel/qt5-script
- bmake fake in devel/qt5-script
- staged Qt5ScriptConfig.cmake contains no /usr/include/qt5 references
- bmake repackage created qt5-script-5.15.19p0_1.mport
- bmake check-license
- git diff --check
- portlint -C (0 fatal errors; existing patch-format warnings only)

Note: full local lang/kf5-kross configure could not be completed because installing the freshly built qt5-script package is blocked by a local mport database error: Stub database could not be detatched.

## Summary by Sourcery

Normalize Qt5Script CMake include paths to respect the configured PREFIX and update port metadata accordingly.

Bug Fixes:
- Correct Qt5Script CMake configuration to avoid hardcoded /usr/include/qt5 paths that break consumers on systems without that directory.

Enhancements:
- Explicitly declare the lgpl2.1 license in the qt5-script port metadata.

Chores:
- Bump PORTREVISION for the qt5-script port to reflect the packaging and metadata changes.