### PR TITLE
net/gstreamer1-plugins-sctp: fix usrsctp on MidnightBSD

### DIFF
--- a/multimedia/gstreamer1-plugins-bad/files/patch-ext_sctp_usrsctp_meson.build
+++ b/multimedia/gstreamer1-plugins-bad/files/patch-ext_sctp_usrsctp_meson.build
@@ -1,0 +1,11 @@
+--- ext/sctp/usrsctp/meson.build.orig	2025-03-11 20:14:44 UTC
++++ ext/sctp/usrsctp/meson.build
+@@ -60,7 +60,7 @@ if system in ['linux', 'android']
+     compile_args += [
+         '-D_GNU_SOURCE',
+     ]
+-elif system == 'freebsd'
++elif system in ['freebsd', 'midnightbsd']
+     compile_args += [compiler.get_supported_arguments([
+             '-Wno-address-of-packed-member',
+         ])]


### PR DESCRIPTION
## Summary
- treat MidnightBSD like FreeBSD when configuring bundled usrsctp
- fixes SCTP plugin configure failure from Magus port 2167625 on i386

## Validation
- bmake patch
- bmake configure
- bmake
- bmake fake
- bmake package
- bmake test (No tests defined)
- git diff --cached --check before commit

Note: portlint -C still reports the existing Makefile section-order fatal: extra item MASTERDIR placed in the LICENSE section.

## Summary by Sourcery

Bug Fixes:
- Fix SCTP plugin configuration failures on MidnightBSD by aligning usrsctp meson configuration handling with FreeBSD.