### PR TITLE
sysutils/rust-coreutils: use cargo target in install

### DIFF
--- a/sysutils/rust-coreutils/Makefile
+++ b/sysutils/rust-coreutils/Makefile
@@ -26,7 +26,7 @@ post-build:
 	${INSTALL_SCRIPT} ${FILESDIR}/symlink-install-helper.sh.in ${CARGO_TARGET_DIR}/symlink-install-helper.sh
 	@${REINPLACE_CMD} -e 's|%%GREP%%|${GREP}|g' \
 		${CARGO_TARGET_DIR}/symlink-install-helper.sh
-	@${REINPLACE_CMD} -e 's|%%CARGO_TARGET_DIR%%|${CARGO_TARGET_DIR}/x86_64-unknown-freebsd/|g' \
+	@${REINPLACE_CMD} -e 's|%%CARGO_TARGET_DIR%%|${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/|g' \
 		${CARGO_TARGET_DIR}/symlink-install-helper.sh
 	@${REINPLACE_CMD} -e 's|%%SED%%|${SED}|g' \
 		${CARGO_TARGET_DIR}/symlink-install-helper.sh
@@ -42,7 +42,7 @@ post-build:
 		${CARGO_TARGET_DIR}/symlink-install-helper.sh
 
 do-install:
-	${INSTALL_PROGRAM} ${CARGO_TARGET_DIR}/x86_64-unknown-freebsd/release/coreutils \
+	${INSTALL_PROGRAM} ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/release/coreutils \
 		${PREFIX}/bin/${BINPREFIX}coreutils
 	${CARGO_TARGET_DIR}/symlink-install-helper.sh
 


### PR DESCRIPTION
## Summary
- use CARGO_BUILD_TARGET for the built binary path during install
- use CARGO_BUILD_TARGET in the symlink helper path
- fixes Magus port 2168930 on i386 where fake looked under target/x86_64-unknown-freebsd

## Validation
- bmake -V CARGO_BUILD_TARGET ARCH=i386
- bmake -n do-install ARCH=i386
- bmake fake
- bmake package
- portlint -C
- git diff --check

Tests are disabled by the port: NO_TEST=yes.

## Summary by Sourcery

Bug Fixes:
- Fix incorrect hard-coded x86_64 target paths during install by using CARGO_BUILD_TARGET for the built binary and symlink helper script.