### PR TITLE
editors/gnome-latex: fix build with libgedit tepl

### DIFF
--- a/editors/gnome-latex/Makefile
+++ b/editors/gnome-latex/Makefile
@@ -15,15 +15,18 @@ BUILD_DEPENDS=	itstool:textproc/itstool \
 LIB_DEPENDS=	libgee-0.8.so:devel/libgee \
 		libfribidi.so:converters/fribidi \
 		libenchant-2.so:textproc/enchant2 \
-		libtepl-6.so:x11-toolkits/tepl6 \
+		libgedit-amtk-5.so:x11-toolkits/amtk \
+		libgedit-gtksourceview-300.so:x11-toolkits/libgedit-gtksourceview \
+		libgedit-tepl-6.so:x11-toolkits/tepl6 \
 		libgspell-1.so:textproc/gspell
 
 USES=		compiler:c11 desktop-file-utils gettext gmake gnome \
 		pkgconfig tar:xz tex vala:build
 GNU_CONFIGURE=	yes
 GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
-USE_GNOME=	cairo dconf intltool gtksourceview4
+USE_GNOME=	cairo dconf gtk30 intltool
 USE_TEX=	latex dvipsk
+INSTALLS_ICONS=	yes
 INSTALL_TARGET=	install-strip
 
 OPTIONS_DEFINE=	NLS
@@ -36,5 +39,14 @@ GLIB_SCHEMAS=	org.gnome.gnome-latex.gschema.xml
 .include <bsd.port.pre.mk>
 
 CFLAGS+=	-Wno-error=incompatible-function-pointer-types
+
+post-patch:
+	${REINPLACE_CMD} -e 's|amtk-5|libgedit-amtk-5|g' \
+		-e 's|gtksourceview-4|libgedit-gtksourceview-300|g' \
+		-e 's|tepl-6|libgedit-tepl-6|g' \
+		${WRKSRC}/configure
+	${REINPLACE_CMD} -e 's|GtkSource-4|GtkSource-300|g' \
+		${WRKSRC}/src/liblatexila/Makefile.in \
+		${WRKSRC}/src/Makefile.in
 
 .include <bsd.port.post.mk>

--- a/editors/gnome-latex/files/patch-src_completion.c
+++ b/editors/gnome-latex/files/patch-src_completion.c
@@ -1,0 +1,26 @@
+--- src/completion.c.orig
++++ src/completion.c
+@@ -78,0 +79,20 @@
++
++static gchar *
++get_line_indentation (const GtkTextIter *iter)
++{
++	GtkTextIter start = *iter;
++	GtkTextIter end = *iter;
++
++	gtk_text_iter_set_line_offset (&start, 0);
++	while (!gtk_text_iter_equal (&end, &start))
++	{
++		gunichar ch = gtk_text_iter_get_char (&end);
++
++		if (ch != ' ' && ch != '\t')
++			break;
++
++		gtk_text_iter_forward_char (&end);
++	}
++
++	return gtk_text_iter_get_text (&start, &end);
++}
+@@ -1690 +1710 @@
+-	_tmp3_ = tepl_iter_get_line_indentation (&_tmp2_);
++	_tmp3_ = get_line_indentation (&_tmp2_);

--- a/editors/gnome-latex/files/patch-src_factory.c
+++ b/editors/gnome-latex/files/patch-src_factory.c
@@ -1,0 +1,22 @@
+--- src/factory.c.orig
++++ src/factory.c
+@@ -115,2 +115 @@
+-static void factory_real_fill_prefs_dialog (TeplAbstractFactory* base,
+-                                     TeplPrefsDialog* dialog);
++static TeplPrefsDialog* factory_real_create_prefs_dialog (TeplAbstractFactory* base);
+@@ -296,3 +295,2 @@
+-static void
+-factory_real_fill_prefs_dialog (TeplAbstractFactory* base,
+-                                TeplPrefsDialog* dialog)
++static TeplPrefsDialog*
++factory_real_create_prefs_dialog (TeplAbstractFactory* base)
+@@ -300,0 +299 @@
++	TeplPrefsDialog* dialog;
+@@ -302 +301 @@
+-	g_return_if_fail (dialog != NULL);
++	dialog = tepl_prefs_dialog_new ();
+@@ -303,0 +303 @@
++	return dialog;
+@@ -312 +312 @@
+-	((TeplAbstractFactoryClass *) klass)->fill_prefs_dialog = (void (*) (TeplAbstractFactory*, TeplPrefsDialog*)) factory_real_fill_prefs_dialog;
++	((TeplAbstractFactoryClass *) klass)->create_prefs_dialog = (TeplPrefsDialog* (*) (TeplAbstractFactory*)) factory_real_create_prefs_dialog;

--- a/editors/gnome-latex/files/patch-src_liblatexila_latexila-buffer.c
+++ b/editors/gnome-latex/files/patch-src_liblatexila_latexila-buffer.c
@@ -1,0 +1,18 @@
+--- src/liblatexila/latexila-buffer.c.orig
++++ src/liblatexila/latexila-buffer.c
+@@ -41,0 +42 @@
++	static gboolean style_scheme_settings_provided = FALSE;
+@@ -52,3 +53,10 @@
+-	tepl_buffer_provide_style_scheme_id_gsetting (buffer,
+-						      editor_settings, "scheme",
+-						      TRUE);
++	if (!style_scheme_settings_provided)
++	{
++		tepl_settings_provide_style_scheme_settings (tepl_settings_get_singleton (),
++							     editor_settings,
++							     "scheme",
++							     "scheme");
++		style_scheme_settings_provided = TRUE;
++	}
++
++	tepl_buffer_connect_style_scheme_settings (buffer);

--- a/editors/gnome-latex/files/patch-src_liblatexila_latexila-latex-commands.c
+++ b/editors/gnome-latex/files/patch-src_liblatexila_latexila-latex-commands.c
@@ -1,0 +1,26 @@
+--- src/liblatexila/latexila-latex-commands.c.orig
++++ src/liblatexila/latexila-latex-commands.c
+@@ -31,0 +32,20 @@
++
++static gchar *
++get_line_indentation (const GtkTextIter *iter)
++{
++	GtkTextIter start = *iter;
++	GtkTextIter end = *iter;
++
++	gtk_text_iter_set_line_offset (&start, 0);
++	while (!gtk_text_iter_equal (&end, &start))
++	{
++		gunichar ch = gtk_text_iter_get_char (&end);
++
++		if (ch != ' ' && ch != '\t')
++			break;
++
++		gtk_text_iter_forward_char (&end);
++	}
++
++	return gtk_text_iter_get_text (&start, &end);
++}
+@@ -494 +514 @@
+-		current_indent = tepl_iter_get_line_indentation (&selection_start);
++		current_indent = get_line_indentation (&selection_start);

--- a/editors/gnome-latex/files/patch-src_liblatexila_latexila-prefs.c
+++ b/editors/gnome-latex/files/patch-src_liblatexila_latexila-prefs.c
@@ -1,0 +1,14 @@
+--- src/liblatexila/latexila-prefs.c.orig
++++ src/liblatexila/latexila-prefs.c
+@@ -58,0 +59 @@
++	GtkWidget *style_scheme_chooser;
+@@ -74,0 +76,5 @@
++
++	style_scheme_chooser = GTK_WIDGET (tepl_style_scheme_chooser_simple_new (FALSE));
++	g_settings_bind (editor_settings, "scheme",
++			 style_scheme_chooser, "style-scheme-id",
++			 G_SETTINGS_BIND_DEFAULT);
+@@ -76,2 +82 @@
+-			   tepl_prefs_create_color_scheme_component (editor_settings,
+-								     "scheme"));
++			   style_scheme_chooser);

--- a/editors/gnome-latex/files/patch-src_main__window.c
+++ b/editors/gnome-latex/files/patch-src_main__window.c
@@ -1,0 +1,48 @@
+--- src/main_window.c.orig
++++ src/main_window.c
+@@ -252 +252 @@
+-	TeplPanel* _side_panel;
++	TeplPanel1* _side_panel;
+@@ -450 +450 @@
+-static TeplPanel* main_window_get_side_panel (MainWindow* self);
++static TeplPanel1* main_window_get_side_panel (MainWindow* self);
+@@ -910 +910 @@
+-	TeplPanel* _tmp32_;
++	TeplPanel1* _tmp32_;
+@@ -912 +912 @@
+-	TeplPanel* _tmp34_;
++	TeplPanel1* _tmp34_;
+@@ -1442 +1442 @@
+-static TeplPanel*
++static TeplPanel1*
+@@ -1445,2 +1445,2 @@
+-	TeplPanel* side_panel = NULL;
+-	TeplPanel* _tmp0_;
++	TeplPanel1* side_panel = NULL;
++	TeplPanel1* _tmp0_;
+@@ -1460 +1460 @@
+-	TeplPanel* result = NULL;
++	TeplPanel1* result = NULL;
+@@ -1462 +1462 @@
+-	_tmp0_ = tepl_panel_new_for_left_side_panel ();
++	_tmp0_ = tepl_panel1_new_for_left_side_panel ();
+@@ -1468 +1468 @@
+-	tepl_panel_add_component (side_panel, (GtkWidget*) symbols, "symbols", _ ("Symbols"), "symbol_greek");
++	tepl_panel1_add_component (side_panel, (GtkWidget*) symbols, "symbols", _ ("Symbols"), "symbol_greek");
+@@ -1472 +1472 @@
+-	tepl_panel_add_component (side_panel, (GtkWidget*) file_browser, "file-browser", _ ("File Browser"), "document-open");
++	tepl_panel1_add_component (side_panel, (GtkWidget*) file_browser, "file-browser", _ ("File Browser"), "document-open");
+@@ -1478 +1478 @@
+-	tepl_panel_add_component (side_panel, (GtkWidget*) structure, "structure", _ ("Structure"), GTK_STOCK_INDEX);
++	tepl_panel1_add_component (side_panel, (GtkWidget*) structure, "structure", _ ("Structure"), GTK_STOCK_INDEX);
+@@ -1481,2 +1481,2 @@
+-	tepl_panel_provide_active_component_gsetting (side_panel, settings, "side-panel-component");
+-	tepl_panel_restore_state_from_gsettings (side_panel);
++	tepl_panel1_provide_active_component_gsetting (side_panel, settings, "side-panel-component");
++	tepl_panel1_restore_state_from_gsettings (side_panel);
+@@ -2802 +2802 @@
+-	TeplPanel* _tmp33_;
++	TeplPanel1* _tmp33_;
+@@ -2859 +2859 @@
+-	tepl_panel_save_state_to_gsettings (_tmp33_);
++	tepl_panel1_save_state_to_gsettings (_tmp33_);


### PR DESCRIPTION
Update the port to use the current libgedit AMTK, GtkSourceView, and Tepl pkg-config names, and patch generated sources for Tepl API changes.

AI-Assisted-by: OpenAI Codex <noreply@openai.com>

## Summary by Sourcery

Update the gnome-latex port to build against the newer libgedit-based AMTK, GtkSourceView, and Tepl APIs.

New Features:
- Hook gnome-latex into the libgedit-based Tepl style scheme and preferences dialog integration, including a new style scheme chooser widget.

Bug Fixes:
- Adjust Tepl panel, buffer, completion, and factory usage to match the updated Tepl API so the port builds successfully with current tepl and libgedit libraries.

Enhancements:
- Switch build and runtime dependencies to the libgedit AMTK, GtkSourceView, and Tepl pkg-config modules and update configure scripts accordingly.
- Enable icon installation and update GNOME component usage to the appropriate gtk3-based modules.