### PR TITLE
editors/neovim-gtk: fix fake-inst path contamination and missing gdk-…

### DIFF
--- a/editors/neovim-gtk/Makefile
+++ b/editors/neovim-gtk/Makefile
@@ -14,14 +14,16 @@ LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
 RUN_DEPENDS=	neovim>=0:editors/neovim
 
 USES=		cargo pkgconfig gnome desktop-file-utils
-USE_GNOME=	atk pango gtk40 glib20
+USE_GNOME=	pango gtk40 glib20 gdkpixbuf
 USE_GITHUB=	yes
 GH_ACCOUNT=	Lyude
+
+CARGO_ENV+=	PREFIX=${LOCALBASE}
 
 post-install:
 	( cd ${WRKSRC} && ${COPYTREE_SHARE} runtime ${PREFIX}/share/nvim-gtk )
 	${MKDIR} ${PREFIX}/share/applications
-	${SED} -e "s|Exec=nvim-gtk|Exec=${PREFIX}/bin/nvim-gtk|" ${WRKSRC}/desktop/org.daa.NeovimGtk.desktop >${PREFIX}/share/applications/org.daa.NeovimGtk.desktop
+	${INSTALL_DATA} ${WRKSRC}/desktop/org.daa.NeovimGtk.desktop ${PREFIX}/share/applications/
 	${MKDIR} ${PREFIX}/share/icons/hicolor/128x128/apps/
 	${INSTALL_DATA} ${WRKSRC}/desktop/org.daa.NeovimGtk_128.png ${PREFIX}/share/icons/hicolor/128x128/apps/org.daa.NeovimGtk.png
 	${MKDIR} ${PREFIX}/share/icons/hicolor/48x48/apps/


### PR DESCRIPTION
…pixbuf dep

- Add gdkpixbuf to USE_GNOME: binary links libgdk_pixbuf-2.0.so.0 but it was not declared as a dependency
- Add CARGO_ENV+=PREFIX=${LOCALBASE}: build.rs reads PREFIX to construct a compile-time RUNTIME_PATH; during make fake MAKE_ENV sets PREFIX to the fake-inst directory, baking a wrong path into the binary
- Replace SED desktop file install with INSTALL_DATA: the sed expansion of ${PREFIX} wrote the fake-inst path into Exec= in the .desktop file; bare 'Exec=nvim-gtk' is valid per the desktop file spec
- Remove atk from USE_GNOME: flagged as an unnecessary explicit dep

## Summary by Sourcery

Update neovim-gtk port metadata and install behavior to fix runtime path contamination and declare the correct GNOME dependencies.

Bug Fixes:
- Declare the missing gdk-pixbuf GNOME dependency required by the neovim-gtk binary.
- Prevent fake-install PREFIX from being baked into the neovim-gtk runtime path by setting PREFIX to LOCALBASE for cargo builds.
- Stop writing a fake-install path into the .desktop Exec entry by installing the upstream desktop file unchanged.

Enhancements:
- Remove the unnecessary explicit atk dependency from the GNOME component list.