### PR TITLE
editors/ted: fix build by adding -lfreetype to link step

### DIFF
--- a/editors/ted/Makefile
+++ b/editors/ted/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	ted
 PORTVERSION=	2.23
-PORTREVISION=	3
+PORTREVISION=	4
 CATEGORIES=	editors
 MASTER_SITES=	ftp://ftp.nluug.nl/pub/editors/ted/ \
 		http://fossies.org/linux/misc/
@@ -47,6 +47,9 @@ GTK2_USES_OFF=		motif
 GTK2_CONFIGURE_OFF=	--with-MOTIF
 
 .include <bsd.port.pre.mk>
+
+post-configure:
+	@${REINPLACE_CMD} -e 's|-lXft|-lXft -lfreetype|g' ${WRKSRC}/Ted/makefile
 
 post-extract:
 	@cd ${WRKSRC}/tedPackage && ${TAR} xf TedDatadir.tar


### PR DESCRIPTION
pkg-config --libs xft on this system returns only -lXft without -lfreetype, but ted (via appFontConfig.c) calls FreeType functions directly. Add a post-configure hook to patch the generated Ted/makefile to add -lfreetype after -lXft so the linker can resolve FT_New_Face and friends.

## Summary by Sourcery

Fix the ted port build by ensuring the linker links against FreeType when using Xft.

Bug Fixes:
- Add a post-configure hook to inject -lfreetype into the generated Ted makefile's linker flags after -lXft so FreeType symbols are resolved.

Build:
- Bump PORTREVISION for the ted port to reflect the build fix.