### PR TITLE
games/gnome-games: only depend on aisleriot on amd64

### DIFF
--- a/games/gnome-games/Makefile
+++ b/games/gnome-games/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-games
 PORTVERSION=	3.24.0
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	games gnome
 MASTER_SITES=   # empty
 DISTFILES=      # empty
@@ -29,9 +29,12 @@ RUN_DEPENDS=	five-or-more:games/five-or-more \
 		hitori:games/hitori \
 		lightsoff:games/lightsoff \
 		quadrapassel:games/quadrapassel \
-		aisleriot>=0:games/aisleriot \
 		swell-foop:games/swell-foop \
 		tali:games/tali
+
+.if ${ARCH} == amd64
+RUN_DEPENDS+=	aisleriot>=0:games/aisleriot
+.endif
 
 do-install:
 	${MKDIR} ${WRKSRC}


### PR DESCRIPTION
aisleriot has dependencies that do not support i386, so limit it to amd64 only.

## Summary by Sourcery

Build:
- Update the gnome-games port Makefile to conditionally add aisleriot as a runtime dependency only on amd64 and increment PORTREVISION accordingly.