### PR TITLE
Devel/valgrind

### DIFF
--- a/devel/valgrind/Makefile
+++ b/devel/valgrind/Makefile
@@ -1,6 +1,7 @@
 PORTNAME=	valgrind
 PORTVERSION=	3.22.0
 PORTEPOCH=	1
+PORTREVISION=	1
 CATEGORIES=	devel
 MASTER_SITES=	SOURCEWARE/valgrind
 
@@ -42,7 +43,9 @@ MPI_LIB_DEPENDS=	libmpich.so:net/mpich
 
 .include <bsd.mport.options.mk>
 
-.if ${OSVERSION} > 300000
+.if ${OSVERSION} >= 400000
+CONFIGURE_TARGET=${ARCH}-portbld-freebsd14.0
+.elif ${OSVERSION} > 300000
 CONFIGURE_TARGET=${ARCH}-portbld-freebsd12.4
 .else
 CONFIGURE_TARGET=${ARCH}-portbld-freebsd11.4

--- a/devel/valgrind/Makefile
+++ b/devel/valgrind/Makefile
@@ -44,7 +44,7 @@ MPI_LIB_DEPENDS=	libmpich.so:net/mpich
 .include <bsd.mport.options.mk>
 
 .if ${OSVERSION} >= 400000
-CONFIGURE_TARGET=${ARCH}-portbld-freebsd14.0
+CONFIGURE_TARGET=${ARCH}-portbld-freebsd13.2
 .elif ${OSVERSION} > 300000
 CONFIGURE_TARGET=${ARCH}-portbld-freebsd12.4
 .else

--- a/devel/valgrind/files/patch-configure.ac
+++ b/devel/valgrind/files/patch-configure.ac
@@ -32,8 +32,8 @@
             esac
             ;;
 +        4.*)
-+           AC_MSG_RESULT([FreeBSD 14.x (${kernel})])
-+           AC_DEFINE([FREEBSD_VERS], FREEBSD_14, [FreeBSD version])
-+           freebsd_vers=$freebsd_14
++           AC_MSG_RESULT([FreeBSD 13.x (${kernel})])
++           AC_DEFINE([FREEBSD_VERS], FREEBSD_13_2, [FreeBSD version])
++           freebsd_vers=$freebsd_13_2
 +           ;;
          13.*)

--- a/devel/valgrind/files/patch-configure.ac
+++ b/devel/valgrind/files/patch-configure.ac
@@ -1,8 +1,8 @@
 --- configure.ac.orig	2022-10-24 07:07:43.000000000 -0400
-+++ configure.ac	2023-03-13 12:41:19.794227000 -0400
-@@ -405,17 +405,17 @@
++++ configure.ac
+@@ -405,28 +405,33 @@
          kernel=`uname -r`
- 
+
          case "${kernel}" in
 -        10.*)
 +        1.*)
@@ -21,3 +21,19 @@
             case "${kernel}" in
             12.[[0-1]]-*)
                AC_MSG_RESULT([FreeBSD 12.x (${kernel})])
+               AC_DEFINE([FREEBSD_VERS], FREEBSD_12, [FreeBSD version])
+               freebsd_vers=$freebsd_12
+               ;;
+            *)
+               AC_MSG_RESULT([FreeBSD 12.x (${kernel})])
+               AC_DEFINE([FREEBSD_VERS], FREEBSD_12_2, [FreeBSD version])
+               freebsd_vers=$freebsd_12_2
+               ;;
+            esac
+            ;;
++        4.*)
++           AC_MSG_RESULT([FreeBSD 14.x (${kernel})])
++           AC_DEFINE([FREEBSD_VERS], FREEBSD_14, [FreeBSD version])
++           freebsd_vers=$freebsd_14
++           ;;
+         13.*)


### PR DESCRIPTION
## Summary by Sourcery

Adjust valgrind FreeBSD port configuration for newer OS versions and bump the port revision.

Enhancements:
- Update CONFIGURE_TARGET selection to support OSVERSION >= 400000 using the FreeBSD 13.2 target triplet.
- Retain and reorder existing CONFIGURE_TARGET settings to cover OSVERSION ranges down to 11.4.

Build:
- Bump PORTREVISION to 1 to reflect the updated port configuration.