### PR TITLE
graphics/libkexiv2: update distinfo to 25.12.0

### DIFF
--- a/graphics/libkexiv2/distinfo
+++ b/graphics/libkexiv2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1746557902
-SHA256 (KDE/release-service/25.04.1/libkexiv2-25.04.1.tar.xz) = f0669527d1fe7ef22c3ef7c8270ef29deafb0923ec782a22f1ced1b775367190
-SIZE (KDE/release-service/25.04.1/libkexiv2-25.04.1.tar.xz) = 60676
+TIMESTAMP = 1771739734
+SHA256 (KDE/release-service/25.12.0/libkexiv2-25.12.0.tar.xz) = 1deb0fa6f270b588aa3ddd946c42b00a974f79d2fc079f1125ccc8ff0e99b996
+SIZE (KDE/release-service/25.12.0/libkexiv2-25.12.0.tar.xz) = 60116


### PR DESCRIPTION
KDE_APPLICATIONS6_VERSION is 25.12.0 but distinfo still referenced 25.04.1.

## Summary by Sourcery

Build:
- Refresh libkexiv2 distinfo checksums and version to 25.12.0.