### PR TITLE
graphics/libksane: update distinfo to 25.12.0

### DIFF
--- a/graphics/libksane/distinfo
+++ b/graphics/libksane/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1746557903
-SHA256 (KDE/release-service/25.04.1/libksane-25.04.1.tar.xz) = 5c3b83c73ac7fd7680be99332da06e467de6c6d49ceec1b7ae372b1666379023
-SIZE (KDE/release-service/25.04.1/libksane-25.04.1.tar.xz) = 156068
+TIMESTAMP = 1771739734
+SHA256 (KDE/release-service/25.12.0/libksane-25.12.0.tar.xz) = b4fde4c6a9151679ed52e4d572ed6688dd4b489aa2a23534d8f132cfbdd3ab90
+SIZE (KDE/release-service/25.12.0/libksane-25.12.0.tar.xz) = 155936


### PR DESCRIPTION
distinfo still referenced 25.04.1 while KDE_APPLICATIONS6_VERSION is 25.12.0.

## Summary by Sourcery

Build:
- Align libksane distinfo checksums and version references with KDE_APPLICATIONS6_VERSION 25.12.0.