### PR TITLE
graphics/plasma6-spectacle: lower OpenCV version requirement to 4.6

### DIFF
--- a/graphics/plasma6-spectacle/Makefile
+++ b/graphics/plasma6-spectacle/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	spectacle
 DISTVERSION=	${KDE_PLASMA_VERSION}
+PORTREVISION=	1
 CATEGORIES=	graphics kde kde-plasma
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/graphics/plasma6-spectacle/files/patch-CMakeLists.txt
+++ b/graphics/plasma6-spectacle/files/patch-CMakeLists.txt
@@ -1,0 +1,11 @@
+--- CMakeLists.txt.orig	2025-01-01 00:00:00 UTC
++++ CMakeLists.txt
+@@ -88,7 +88,7 @@ find_package(XCB REQUIRED COMPONENTS
+     XCBIMAGE
+ )
+ find_package(X11 REQUIRED)
+-find_package(OpenCV 4.7 REQUIRED)
++find_package(OpenCV 4.6 REQUIRED)
+ 
+ find_package(PipeWire 0.3)
+ find_package(epoxy)


### PR DESCRIPTION
Spectacle requires OpenCV 4.7 but mports only has 4.6.0. Lower the minimum version requirement to match what is available.

## Summary by Sourcery

Build:
- Update the plasma6-spectacle port to require a lower OpenCV version compatible with the mports tree and bump PORTREVISION accordingly.