### PR TITLE
lang/spidermonkey78: add icu-uc to pkg-config check for ICU

### DIFF
--- a/lang/spidermonkey78/Makefile
+++ b/lang/spidermonkey78/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	spidermonkey
 DISTVERSION=	78.15.0
+PORTREVISION=	2
 CATEGORIES=	lang
 MASTER_SITES=	MOZILLA/firefox/releases/${DISTVERSION}esr/source
 PKGNAMESUFFIX=	${SP_VER}
@@ -80,6 +81,7 @@ BUILD_DEPENDS+=	${LOCALBASE}/bin/clang${LLVM_DEFAULT}:devel/llvm${LLVM_DEFAULT}
 
 post-patch:
 	@${REINPLACE_CMD} -e 's|%%LOCALBASE%%|${LOCALBASE}|g' ${WRKSRC}/js/moz.configure
+	@${REINPLACE_CMD} -e 's|icu-i18n|icu-uc icu-i18n|g' ${WRKSRC}/js/moz.configure
 	${REINPLACE_CMD} -e "s|midnightbsd${OSREL}|freebsd11.4|g" \
 		${WRKSRC}/build/autoconf/config.guess ${WRKSRC}/build/autoconf/config.sub
 	${REINPLACE_CMD} -e 's|DragonFly|MidnightBSD|g' \


### PR DESCRIPTION
ICU 74+ moved icu-uc from a public to a private dependency of icu-i18n in its pkg-config files. This causes the linker to miss libicuuc, leaving u_init, icu::UnicodeSet, and related symbols undefined.

Replace the icu-i18n pkg-config module with 'icu-uc icu-i18n' so both libraries are explicitly linked, mirroring the fix already applied in lang/spidermonkey128.

## Summary by Sourcery

Adjust ICU linkage for spidermonkey78 to ensure required ICU components are explicitly linked with newer ICU versions.

Bug Fixes:
- Fix missing ICU symbols at link time by explicitly depending on both icu-uc and icu-i18n in the pkg-config configuration for spidermonkey78.

Build:
- Bump spidermonkey78 port revision and update moz.configure patch to query both icu-uc and icu-i18n pkg-config modules.