### PR TITLE
Devel/apache ant java8

### DIFF
--- a/devel/apache-ant/Makefile
+++ b/devel/apache-ant/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	apache-ant
 DISTVERSION=	1.10.13
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	devel java
 MASTER_SITES=	APACHE/ant/binaries:bin \
 		https://deb.debian.org/debian/pool/main/a/ant/:man
@@ -15,6 +15,7 @@ WWW=		https://ant.apache.org/
 LICENSE=	Apache-2.0
 
 USES=		cpe java tar:bzip2
+JAVA_VERSION=	8
 CPE_VENDOR=	apache
 CPE_PRODUCT=	ant
 

--- a/lang/spidermonkey78/Makefile
+++ b/lang/spidermonkey78/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	spidermonkey
 DISTVERSION=	78.15.0
+PORTREVISION=	2
 CATEGORIES=	lang
 MASTER_SITES=	MOZILLA/firefox/releases/${DISTVERSION}esr/source
 PKGNAMESUFFIX=	${SP_VER}
@@ -80,6 +81,7 @@ BUILD_DEPENDS+=	${LOCALBASE}/bin/clang${LLVM_DEFAULT}:devel/llvm${LLVM_DEFAULT}
 
 post-patch:
 	@${REINPLACE_CMD} -e 's|%%LOCALBASE%%|${LOCALBASE}|g' ${WRKSRC}/js/moz.configure
+	@${REINPLACE_CMD} -e 's|icu-i18n|icu-uc icu-i18n|g' ${WRKSRC}/js/moz.configure
 	${REINPLACE_CMD} -e "s|midnightbsd${OSREL}|freebsd11.4|g" \
 		${WRKSRC}/build/autoconf/config.guess ${WRKSRC}/build/autoconf/config.sub
 	${REINPLACE_CMD} -e 's|DragonFly|MidnightBSD|g' \


### PR DESCRIPTION
## Summary by Sourcery

Update Apache Ant and Spidermonkey ports to adjust Java and ICU build configuration.

Enhancements:
- Pin the apache-ant port to use Java 8 explicitly.
- Adjust Spidermonkey 78 build configuration to link against icu-uc in addition to icu-i18n.