### PR TITLE
textproc/quickwit: fix i386 build

### DIFF
--- a/textproc/quickwit/Makefile
+++ b/textproc/quickwit/Makefile
@@ -14,7 +14,6 @@ LICENSE_FILE=	${WRKSRC}/LICENSE_AGPLv3.0.txt
 BUILD_DEPENDS=	${LOCALBASE}/bin/protoc:devel/protobuf
 LIB_DEPENDS=	libzstd.so:archivers/zstd
 
-BROKEN_i386=	fails to build
 USES=			cargo pkgconfig
 USE_GITHUB=		yes
 GH_ACCOUNT=		quickwit-oss

--- a/textproc/quickwit/files/patch-quickwit_quickwit-storage_src_object__storage_policy.rs
+++ b/textproc/quickwit/files/patch-quickwit_quickwit-storage_src_object__storage_policy.rs
@@ -1,0 +1,21 @@
+--- quickwit/quickwit-storage/src/object_storage/policy.rs.orig	2024-03-26 12:28:22 UTC
++++ quickwit/quickwit-storage/src/object_storage/policy.rs
+@@ -72,13 +72,16 @@ impl MultiPartPolicy {
+ impl Default for MultiPartPolicy {
+     fn default() -> Self {
+         MultiPartPolicy {
+-            // S3 limits part size from 5M to 5GB, we want to end up with as few parts as possible
+-            // since each part is charged as a put request.
+-            target_part_num_bytes: 5_000_000_000, // 5GB
++            // S3 limits part size from 5M to 5GB. On 32-bit platforms, use the
++            // largest practical default that fits in usize.
++            #[cfg(target_pointer_width = "64")]
++            target_part_num_bytes: 5_000_000_000, // 5GB
++            #[cfg(target_pointer_width = "32")]
++            target_part_num_bytes: 4_000_000_000,
+             multipart_threshold_num_bytes: 128 * 1_024 * 1_024, // 128 MiB
+             max_num_parts: 10_000,
+             max_object_num_bytes: 5_000_000_000_000u64, // S3 allows up to 5TB objects
+             max_concurrent_uploads: 100,
+         }
+     }


### PR DESCRIPTION
## Summary
- fix the quickwit i386 build by avoiding a 5GB `usize` literal on 32-bit targets
- remove the stale `BROKEN_i386` marker

## Testing
- `bmake clean patch`
- `bmake build`
- `bmake fake`
- `bmake package`
- `git diff --check`
- `bmake test` attempted, but release LTO test compilation was killed by SIGKILL during test binary builds

## Summary by Sourcery

Fix Quickwit port to build on 32-bit i386 by adjusting multipart size defaults and re-enabling the port.

Bug Fixes:
- Ensure multipart upload policy uses a usize-compatible default part size on 32-bit targets to prevent i386 build failures.

Enhancements:
- Re-enable Quickwit on i386 by removing the stale BROKEN_i386 marker in the port Makefile.