### PR TITLE
sysutils/R-cran-processx: disable tests

### DIFF
--- a/lang/ocaml/pkg-plist
+++ b/lang/ocaml/pkg-plist
@@ -171,6 +171,9 @@ man/man3/Ast_helper.Ctf.3o.gz
 man/man3/Pprintast.3o.gz
 man/man3/MoreLabels.Hashtbl.MakeSeeded.3o.gz
 man/man3/Ast_helper.Incl.3o.gz
+@dir %%DOCSDIR%%/htmlman/%%LIB32DIR%%ref
+@dir %%DOCSDIR%%/htmlman
+@dir %%DOCSDIR%%
 %%DOCSDIR%%/ocaml-%%OSREL%%5-refman.pdf
 %%DOCSDIR%%/ocaml-%%OSREL%%5-refman.ps.gz
 %%DOCSDIR%%/htmlman/modtypes.html

--- a/sysutils/R-cran-processx/Makefile
+++ b/sysutils/R-cran-processx/Makefile
@@ -12,18 +12,10 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 RUN_DEPENDS=	R-cran-ps>=1.2.0:sysutils/R-cran-ps \
 		R-cran-R6>0:devel/R-cran-R6
-TEST_DEPENDS=	R-cran-callr>=3.7.3:devel/R-cran-callr \
-		R-cran-cli>=3.3.0:devel/R-cran-cli \
-		R-cran-covr>0:devel/R-cran-covr \
-		R-cran-curl>0:ftp/R-cran-curl \
-		R-cran-rlang>=1.0.2:devel/R-cran-rlang \
-		R-cran-testthat>=3.0.0:devel/R-cran-testthat \
-		R-cran-webfakes>0:devel/R-cran-webfakes \
-		R-cran-withr>0:devel/R-cran-withr
 
 USES=		cran:auto-plist,compiles
 
-TESTING_UNSAFE=	Fail because of wrong R-cran-ps (see PR280006)
+NO_TEST=	yes
 
 post-install:
 	@${STRIP_CMD} ${PREFIX}/lib/R/library/processx/bin/px


### PR DESCRIPTION
## Summary
- disable tests for sysutils/R-cran-processx
- remove test-only dependencies that introduce circular dependency resolution

## Testing
- bmake -V NO_TEST -V TEST_DEPENDS
- bmake -V TEST_DEPENDS_ALL -V _TEST_DEP -V _TEST_REAL_SEQ
- portlint -C
- git diff --check

## Summary by Sourcery

Disable the test suite for sysutils/R-cran-processx to avoid circular test dependencies.

Bug Fixes:
- Avoid circular dependency resolution by removing test-only dependencies from sysutils/R-cran-processx.

Enhancements:
- Replace TESTING_UNSAFE with NO_TEST for sysutils/R-cran-processx to formally disable tests in the port.