### PR TITLE
www/mediawiki145: update to 1.45.3

### DIFF
--- a/www/mediawiki145/Makefile
+++ b/www/mediawiki145/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	mediawiki
-PORTVERSION=	1.45.1
+PORTVERSION=	1.45.3
 CATEGORIES=	www
 MASTER_SITES=	https://releases.wikimedia.org/mediawiki/${PORTVERSION:R}/ \
 		FREEBSD_LOCAL/wen

--- a/www/mediawiki145/distinfo
+++ b/www/mediawiki145/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1765498516
-SHA256 (mediawiki-1.45.1.tar.gz) = e2f126b19aec422051a0a50e0c6ab7e904f33b3988a47b9da8afbfd0c0a252cc
-SIZE (mediawiki-1.45.1.tar.gz) = 82078953
+TIMESTAMP = 1779062353
+SHA256 (mediawiki-1.45.3.tar.gz) = 5ea8c1f321c9f8dba4d1ac1e4eca1827fb13519d4a2190e239f51432058a4269
+SIZE (mediawiki-1.45.3.tar.gz) = 82457003


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Update the mediawiki145 port to the 1.45.3 upstream release.

New Features:
- Track the MediaWiki 1.45.3 upstream release in the mediawiki145 port.

Enhancements:
- Refresh port metadata (version and distinfo) to match the new MediaWiki 1.45.3 distribution.