### PR TITLE
multimedia/webcamoid: update to 9.3.0

### DIFF
--- a/multimedia/webcamoid/Makefile
+++ b/multimedia/webcamoid/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	webcamoid
-DISTVERSION=	9.1.1
-PORTREVISION=	0
+DISTVERSION=	9.3.0
 CATEGORIES=	multimedia
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/multimedia/webcamoid/distinfo
+++ b/multimedia/webcamoid/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1686979739
-SHA256 (webcamoid-webcamoid-9.1.1_GH0.tar.gz) = 70209d5ff5f3d00b71376171a73a4ce610ecee5e050edca658c484c0cb508e74
-SIZE (webcamoid-webcamoid-9.1.1_GH0.tar.gz) = 9288681
+TIMESTAMP = 1779062340
+SHA256 (webcamoid-webcamoid-9.3.0_GH0.tar.gz) = 5f9fefb305f4309283d06daae663f16ca47a67c0c640fd3031a3e88738fe6879
+SIZE (webcamoid-webcamoid-9.3.0_GH0.tar.gz) = 9666604


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Update the webcamoid port to the 9.3.0 upstream release.

Build:
- Bump webcamoid port version from 9.1.1 to 9.3.0 and refresh associated distfile metadata.

Chores:
- Remove obsolete PORTREVISION now that the port is updated to a new upstream version.