### PR TITLE
net/zsync: update to 0.6.3

### DIFF
--- a/net/zsync/Makefile
+++ b/net/zsync/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	zsync
-PORTVERSION=	0.6.2
-PORTREVISION=	1
+PORTVERSION=	0.6.3
 CATEGORIES=	net
 MASTER_SITES=	http://zsync.moria.org.uk/download/
 

--- a/net/zsync/distinfo
+++ b/net/zsync/distinfo
@@ -1,2 +1,3 @@
-SHA256 (zsync-0.6.2.tar.bz2) = 0b9d53433387aa4f04634a6c63a5efa8203070f2298af72a705f9be3dda65af2
-SIZE (zsync-0.6.2.tar.bz2) = 245592
+TIMESTAMP = 1779062205
+SHA256 (zsync-0.6.3.tar.bz2) = 293b6191821641d3ed6248206f8f9df0bf46e6ee2cf8b4dd97cfd1d5909edb9a
+SIZE (zsync-0.6.3.tar.bz2) = 272821


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Refresh the zsync port metadata to track the latest upstream version 0.6.3.