### PR TITLE
sysutils/rust-coreutils: update to 0.8.0

### DIFF
--- a/sysutils/rust-coreutils/Makefile
+++ b/sysutils/rust-coreutils/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	rust-coreutils
-DISTVERSION=	0.7.0
+DISTVERSION=	0.8.0
 CATEGORIES=	sysutils
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/sysutils/rust-coreutils/distinfo
+++ b/sysutils/rust-coreutils/distinfo
@@ -1,4 +1,4 @@
-TIMESTAMP = 1773046681
+TIMESTAMP = 1779062278
 SHA256 (rust/crates/adler2-2.0.1.crate) = 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa
 SIZE (rust/crates/adler2-2.0.1.crate) = 13366
 SHA256 (rust/crates/aho-corasick-1.1.4.crate) = ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301
@@ -775,5 +775,5 @@ SHA256 (rust/crates/zmij-1.0.19.crate) = 3ff05f8caa9038894637571ae6b9e29466c1f4f
 SIZE (rust/crates/zmij-1.0.19.crate) = 23948
 SHA256 (rust/crates/zopfli-0.8.3.crate) = f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249
 SIZE (rust/crates/zopfli-0.8.3.crate) = 51589
-SHA256 (uutils-coreutils-0.7.0_GH0.tar.gz) = dc56a3c4632742357d170d60a7dcecb9693de710daeaafa3ad925750b1905522
-SIZE (uutils-coreutils-0.7.0_GH0.tar.gz) = 3137923
+SHA256 (uutils-coreutils-0.8.0_GH0.tar.gz) = 03f765fd23e9cc66f8789edc6928644d8eae5e5a7962d83795739d0a8a85eaef
+SIZE (uutils-coreutils-0.8.0_GH0.tar.gz) = 3189526


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump rust-coreutils DISTVERSION from 0.7.0 to 0.8.0 in the ports tree.