### PR TITLE
ports-mgmt/portsearch: update to 1.3.5

### DIFF
--- a/ports-mgmt/portsearch/Makefile
+++ b/ports-mgmt/portsearch/Makefile
@@ -1,7 +1,7 @@
 
 
 PORTNAME=	portsearch
-PORTVERSION=	1.3.4
+PORTVERSION=	1.3.5
 CATEGORIES=	ports-mgmt
 MASTER_SITES=	${MASTER_SITE_FREEBSD_LOCAL} \
 		http://people.freebsd.org/~vd/portsearch/

--- a/ports-mgmt/portsearch/distinfo
+++ b/ports-mgmt/portsearch/distinfo
@@ -1,2 +1,3 @@
-SHA256 (portsearch-1.3.4.tar.gz) = e1e9742558e61b1d586bbd6cd4d7a2a1904c3ed0bee793e8f07aba3b7a72d203
-SIZE (portsearch-1.3.4.tar.gz) = 21063
+TIMESTAMP = 1779062044
+SHA256 (portsearch-1.3.5.tar.gz) = 7d37461e4a44db9e66d81928a9eaaf9bec7af2b0433b1a56fc7e3d201f3e8091
+SIZE (portsearch-1.3.5.tar.gz) = 21040


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump the portsearch distfile version from 1.3.4 to 1.3.5 in the port Makefile.