### PR TITLE
net/htpdate: update to 2.0.0

### DIFF
--- a/net/htpdate/Makefile
+++ b/net/htpdate/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	htpdate
-PORTVERSION=	1.3.7
-PORTREVISION=	1
+PORTVERSION=	2.0.0
 CATEGORIES=	net
 MASTER_SITES=	http://www.vervest.org/htp/archive/c/ \
 		http://twekkel.home.xs4all.nl/htp/

--- a/net/htpdate/distinfo
+++ b/net/htpdate/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1676573180
-SHA256 (htpdate-1.3.7.tar.gz) = 88c52fe475308ee95f560fd7cf68c75bc6e9a6abf56be7fed203a7f762fe7ab2
-SIZE (htpdate-1.3.7.tar.gz) = 16897
+TIMESTAMP = 1779062030
+SHA256 (htpdate-2.0.0.tar.gz) = 52f25811f00dfe714e0bcf122358ee0ad74e25db3ad230d5a4196e7a62633f27
+SIZE (htpdate-2.0.0.tar.gz) = 17443


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Update the htpdate port to the 2.0.0 upstream release and reset the port revision.

New Features:
- Track the new upstream htpdate 2.0.0 release in the ports tree.

Build:
- Adjust port metadata to reflect the new distfile version and reset PORTREVISION.