### PR TITLE
mail/libmilter: update to 8.18.2

### DIFF
--- a/mail/libmilter/Makefile
+++ b/mail/libmilter/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libmilter
-PORTVERSION=	8.17.1
+PORTVERSION=	8.18.2
 CATEGORIES=	mail
 MASTER_SITES=	ftp://ftp.sendmail.org/pub/sendmail/
 DISTNAME=	sendmail.${PORTVERSION}

--- a/mail/libmilter/distinfo
+++ b/mail/libmilter/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1653498943
-SHA256 (sendmail.8.17.1.tar.gz) = 04bc76b6c886e6d111be7fd8daa32b8ce00128a288b6b52e067bc29f3854a6e6
-SIZE (sendmail.8.17.1.tar.gz) = 2284027
+TIMESTAMP = 1779061986
+SHA256 (sendmail.8.18.2.tar.gz) = 1a085faa8ace52cffde2f5e9bc611bdb5f81481caaabf46f0437b719ca089d2f
+SIZE (sendmail.8.18.2.tar.gz) = 2372458


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Bump libmilter port to the sendmail 8.18.2 release.

Enhancements:
- Update libmilter port metadata and distfiles to track sendmail 8.18.2.

Build:
- Refresh port version and distinfo for the 8.18.2 distfile.