### PR TITLE
graphics/libgeotiff: update to 1.7.4

### DIFF
--- a/graphics/libgeotiff/Makefile
+++ b/graphics/libgeotiff/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	libgeotiff
-PORTVERSION=	1.7.1
-PORTREVISION=	1
+PORTVERSION=	1.7.4
 CATEGORIES=	graphics
 MASTER_SITES=	https://download.osgeo.org/geotiff/libgeotiff/ \
 		FREEBSD_LOCAL/sunpoet

--- a/graphics/libgeotiff/distinfo
+++ b/graphics/libgeotiff/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1647264432
-SHA256 (libgeotiff-1.7.1.tar.gz) = 05ab1347aaa471fc97347d8d4269ff0c00f30fa666d956baba37948ec87e55d6
-SIZE (libgeotiff-1.7.1.tar.gz) = 542779
+TIMESTAMP = 1779061906
+SHA256 (libgeotiff-1.7.4.tar.gz) = c598d04fdf2ba25c4352844dafa81dde3f7fd968daa7ad131228cd91e9d3dc47
+SIZE (libgeotiff-1.7.4.tar.gz) = 549848


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump libgeotiff port version from 1.7.1_1 to 1.7.4 and refresh distinfo.