### PR TITLE
math/asl: update to 2.1.0

### DIFF
--- a/math/asl/Makefile
+++ b/math/asl/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	asl
 DISTVERSIONPREFIX=	releases/
-DISTVERSION=	2.0.0
+DISTVERSION=	2.1.0
 CATEGORIES=	math
 MASTER_SITES=	https://coin-or-tools.github.io/ThirdParty-ASL/:solvers
 PKGNAMEPREFIX=	coin-or-

--- a/math/asl/distinfo
+++ b/math/asl/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1645600598
+TIMESTAMP = 1779061995
 SHA256 (solvers-64919f75f.tgz) = e212926d1d797701adc901ef18eaab6b15edd13f9281dd8c9266e3cdaf8c2dd3
 SIZE (solvers-64919f75f.tgz) = 360043
-SHA256 (coin-or-tools-ThirdParty-ASL-releases-2.0.0_GH0.tar.gz) = b617b6d46a2722189dedef7c8013f7e21ebe677fe34cc6b62fabb1639fd3a96d
-SIZE (coin-or-tools-ThirdParty-ASL-releases-2.0.0_GH0.tar.gz) = 247662
+SHA256 (coin-or-tools-ThirdParty-ASL-releases-2.1.0_GH0.tar.gz) = 633e9d42b015a5a6a9ae324cac5736af1605fb74eb18299a54912b67d1a69be7
+SIZE (coin-or-tools-ThirdParty-ASL-releases-2.1.0_GH0.tar.gz) = 260750


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump the asl distversion from 2.0.0 to 2.1.0 in the port Makefile.