### PR TITLE
devel/libgit2-glib: update to 1.2.1

### DIFF
--- a/devel/libgit2-glib/Makefile
+++ b/devel/libgit2-glib/Makefile
@@ -1,7 +1,7 @@
 # Also update devel/libgit2, devel/rubygem-rugged, devel/py-pygit2
 
 PORTNAME=	libgit2-glib
-PORTVERSION=	1.2.0
+PORTVERSION=	1.2.1
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome

--- a/devel/libgit2-glib/distinfo
+++ b/devel/libgit2-glib/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1693730808
-SHA256 (gnome/libgit2-glib-1.2.0.tar.xz) = 1331dada838f4e1f591b26459d44126a325de762dc3cd26153a31afbdfe18190
-SIZE (gnome/libgit2-glib-1.2.0.tar.xz) = 140576
+TIMESTAMP = 1779061871
+SHA256 (gnome/libgit2-glib-1.2.1.tar.xz) = 97423a779002b3be8751c75f9d79049dfccca3616a26159fc162486772ba785f
+SIZE (gnome/libgit2-glib-1.2.1.tar.xz) = 141252


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump libgit2-glib PORTVERSION from 1.2.0 to 1.2.1.