### PR TITLE
textproc/libexttextcat: update to 3.4.6

### DIFF
--- a/textproc/libexttextcat/Makefile
+++ b/textproc/libexttextcat/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libexttextcat
-PORTVERSION=	3.4.5
+PORTVERSION=	3.4.6
 CATEGORIES=	textproc
 MASTER_SITES=	https://dev-www.libreoffice.org/src/libexttextcat/
 

--- a/textproc/libexttextcat/distinfo
+++ b/textproc/libexttextcat/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1507061257
-SHA256 (libexttextcat-3.4.5.tar.xz) = 13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8
-SIZE (libexttextcat-3.4.5.tar.xz) = 1041268
+TIMESTAMP = 1779061836
+SHA256 (libexttextcat-3.4.6.tar.xz) = 6d77eace20e9ea106c1330e268ede70c9a4a89744ddc25715682754eca3368df
+SIZE (libexttextcat-3.4.6.tar.xz) = 1111320


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump the libexttextcat port version from 3.4.5 to 3.4.6, refreshing associated distinfo.