### PR TITLE
sysutils/libcdio-paranoia: update to 10.2+2.0.2

### DIFF
--- a/sysutils/libcdio-paranoia/Makefile
+++ b/sysutils/libcdio-paranoia/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libcdio-paranoia
-PORTVERSION=	10.2+2.0.1
+PORTVERSION=	10.2+2.0.2
 CATEGORIES=	sysutils
 MASTER_SITES=	GNU/libcdio
 

--- a/sysutils/libcdio-paranoia/distinfo
+++ b/sysutils/libcdio-paranoia/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1575762071
-SHA256 (libcdio-paranoia-10.2+2.0.1.tar.bz2) = 33b1cf305ccfbfd03b43936975615000ce538b119989c4bec469577570b60e8a
-SIZE (libcdio-paranoia-10.2+2.0.1.tar.bz2) = 589075
+TIMESTAMP = 1779061733
+SHA256 (libcdio-paranoia-10.2+2.0.2.tar.bz2) = 186892539dedd661276014d71318c8c8f97ecb1250a86625256abd4defbf0d0c
+SIZE (libcdio-paranoia-10.2+2.0.2.tar.bz2) = 2450370


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump libcdio-paranoia PORTVERSION to 10.2+2.0.2.