### PR TITLE
security/libssh2: update to 1.11.1

### DIFF
--- a/security/libssh2/Makefile
+++ b/security/libssh2/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libssh2
-PORTVERSION=	1.11.0
+PORTVERSION=	1.11.1
 PORTEPOCH=	3
 CATEGORIES=	security devel
 MASTER_SITES=	https://www.libssh2.org/download/ \

--- a/security/libssh2/distinfo
+++ b/security/libssh2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1697058384
-SHA256 (libssh2-1.11.0.tar.gz) = 3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461
-SIZE (libssh2-1.11.0.tar.gz) = 1053562
+TIMESTAMP = 1779061709
+SHA256 (libssh2-1.11.1.tar.gz) = d9ec76cbe34db98eec3539fe2c899d26b0c837cb3eb466a56b0f109cabf658f7
+SIZE (libssh2-1.11.1.tar.gz) = 1093012


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump libssh2 PORTVERSION from 1.11.0 to 1.11.1 and refresh distinfo.