### PR TITLE
games/gnuchess: update to 6.3.0

### DIFF
--- a/games/gnuchess/Makefile
+++ b/games/gnuchess/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnuchess
-DISTVERSION=	6.2.11
+DISTVERSION=	6.3.0
 CATEGORIES=	games
 MASTER_SITES=	GNU/chess
 # The DISTFILES here is explicitly needed because it can be extended later.

--- a/games/gnuchess/distinfo
+++ b/games/gnuchess/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1745142430
-SHA256 (gnuchess-6.2.11.tar.gz) = d81140eea5c69d14b0cfb63816d4b4c9e18fba51f5267de5b1539f468939e9bd
-SIZE (gnuchess-6.2.11.tar.gz) = 811399
+TIMESTAMP = 1779061652
+SHA256 (gnuchess-6.3.0.tar.gz) = 0b37bec2098c2ad695b7443e5d7944dc6dc8284f8d01fcc30bdb94dd033ca23a
+SIZE (gnuchess-6.3.0.tar.gz) = 835620
 SHA256 (book_1.02.pgn.gz) = deac77edb061a59249a19deb03da349cae051e52527a6cb5af808d9398d32d44
 SIZE (book_1.02.pgn.gz) = 26265281


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Bump gnuchess DISTVERSION from 6.2.11 to 6.3.0, updating associated distinfo metadata.