### PR TITLE
devel/py-pathlib2: update to 2.3.7

### DIFF
--- a/devel/py-pathlib2/Makefile
+++ b/devel/py-pathlib2/Makefile
@@ -1,7 +1,7 @@
 # Created by: Yuri Victorovich <yuri@rawbw.com>
 
 PORTNAME=	pathlib2
-PORTVERSION=	2.3.5
+PORTVERSION=	2.3.7
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}

--- a/devel/py-pathlib2/distinfo
+++ b/devel/py-pathlib2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1572327470
-SHA256 (pathlib2-2.3.5.tar.gz) = 6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868
-SIZE (pathlib2-2.3.5.tar.gz) = 34393
+TIMESTAMP = 1779061624
+SHA256 (pathlib2-2.3.7.tar.gz) = 7a4329d67beff9a712e1d3ae147e4e3e108b0bfd284ffdea03a635126c76b3c0
+SIZE (pathlib2-2.3.7.tar.gz) = 38804


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump py-pathlib2 PORTVERSION from 2.3.5 to 2.3.7 and refresh associated distinfo.