### PR TITLE
math/xtensor: update to 0.27.1

### DIFF
--- a/math/xtensor/Makefile
+++ b/math/xtensor/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xtensor
-DISTVERSION=	0.24.2
+DISTVERSION=	0.27.1
 CATEGORIES=	math
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/math/xtensor/distinfo
+++ b/math/xtensor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1654022980
-SHA256 (xtensor-stack-xtensor-0.24.2_GH0.tar.gz) = 790d9e449add817154177157a850b9afd0260dc0f9df857d8b3a38886a10ef8b
-SIZE (xtensor-stack-xtensor-0.24.2_GH0.tar.gz) = 1194041
+TIMESTAMP = 1779061550
+SHA256 (xtensor-stack-xtensor-0.27.1_GH0.tar.gz) = 117c192ae3b7c37c0156dedaa88038e0599a6b264666c3c6c2553154b500fe23
+SIZE (xtensor-stack-xtensor-0.27.1_GH0.tar.gz) = 1224405


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Update the xtensor math port to version 0.27.1.