### PR TITLE
net/uhttpmock: update to 0.11.0

### DIFF
--- a/net/uhttpmock/Makefile
+++ b/net/uhttpmock/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	uhttpmock
-PORTVERSION=	0.5.3
-PORTREVISION=	1
+PORTVERSION=	0.11.0
 CATEGORIES=	net gnome
 MASTER_SITES=	http://tecnocode.co.uk/downloads/uhttpmock/
 DIST_SUBDIR=	gnome3

--- a/net/uhttpmock/distinfo
+++ b/net/uhttpmock/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1697220064
-SHA256 (gnome3/uhttpmock-0.5.3.tar.xz) = 90843223c3a30bdb7f1eb3442373a03fee425af85a9df289cd687698ccff112f
-SIZE (gnome3/uhttpmock-0.5.3.tar.xz) = 318708
+TIMESTAMP = 1779061449
+SHA256 (gnome3/uhttpmock-0.11.0.tar.xz) = feedc01a2ade9f0dcd61e73838ad53733d3cf68b7d51379acc00c894ea7884bf
+SIZE (gnome3/uhttpmock-0.11.0.tar.xz) = 48192


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump uhttpmock PORTVERSION from 0.5.3_1 to 0.11.0 and refresh distinfo as needed.