### PR TITLE
misc/gnome-getting-started-docs: update to 3.38.1

### DIFF
--- a/misc/gnome-getting-started-docs/Makefile
+++ b/misc/gnome-getting-started-docs/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnome-getting-started-docs
-PORTVERSION=	3.28.2
+PORTVERSION=	3.38.1
 CATEGORIES=	misc gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome3

--- a/misc/gnome-getting-started-docs/distinfo
+++ b/misc/gnome-getting-started-docs/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1525956116
-SHA256 (gnome3/gnome-getting-started-docs-3.28.2.tar.xz) = 2eda72c5e399736dee86e8c56f5f42d87058943ff0b4cbca35f2ab932d59e06d
-SIZE (gnome3/gnome-getting-started-docs-3.28.2.tar.xz) = 110245016
+TIMESTAMP = 1779061417
+SHA256 (gnome3/gnome-getting-started-docs-3.38.1.tar.xz) = 10fbe23f2c3ce427539a4e307a461694d3870b23200464f705b7d81af993c859
+SIZE (gnome3/gnome-getting-started-docs-3.38.1.tar.xz) = 81798220


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump PORTVERSION of gnome-getting-started-docs to 3.38.1 and refresh distinfo accordingly.