### PR TITLE
x11-fonts/terminus-ttf: update to 4.49.3

### DIFF
--- a/x11-fonts/terminus-ttf/Makefile
+++ b/x11-fonts/terminus-ttf/Makefile
@@ -1,7 +1,7 @@
 # Created by: Tobias Kortkamp <t@tobik.me>
 
 PORTNAME=	terminus-ttf
-PORTVERSION=	4.47.0
+PORTVERSION=	4.49.3
 CATEGORIES=	x11-fonts
 MASTER_SITES=	http://files.ax86.net/terminus-ttf/files/${PORTVERSION}/
 

--- a/x11-fonts/terminus-ttf/distinfo
+++ b/x11-fonts/terminus-ttf/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1546786117
-SHA256 (terminus-ttf-4.47.0.zip) = 3b98bde7e54827fb042686cdc7e902ac17289092e1dd2ccfeaea7ac3cedff606
-SIZE (terminus-ttf-4.47.0.zip) = 540322
+TIMESTAMP = 1779061352
+SHA256 (terminus-ttf-4.49.3.zip) = 0ead921d98d99a4590ffe6cd66dc037fc0a2ceea1c735d866ba73fe058257577
+SIZE (terminus-ttf-4.49.3.zip) = 558303


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump the terminus-ttf port version and distfile reference from 4.47.0 to 4.49.3.