### PR TITLE
x11-clocks/xfce4-datetime-plugin: update to 0.8.3

### DIFF
--- a/x11-clocks/xfce4-datetime-plugin/Makefile
+++ b/x11-clocks/xfce4-datetime-plugin/Makefile
@@ -1,8 +1,7 @@
 # Created by: Martin Wilke (miwi@FreeBSD.org)
 
 PORTNAME=	xfce4-datetime-plugin
-PORTVERSION=	0.8.1
-PORTREVISION=	1
+PORTVERSION=	0.8.3
 CATEGORIES=	x11-clocks xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4

--- a/x11-clocks/xfce4-datetime-plugin/distinfo
+++ b/x11-clocks/xfce4-datetime-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1608833048
-SHA256 (xfce4/xfce4-datetime-plugin-0.8.1.tar.bz2) = e9f6f15be29ceb5c45718006b46dbd19b89981617d0768b2ef942b5a70af2540
-SIZE (xfce4/xfce4-datetime-plugin-0.8.1.tar.bz2) = 330734
+TIMESTAMP = 1779061021
+SHA256 (xfce4/xfce4-datetime-plugin-0.8.3.tar.bz2) = 6b2eeb79fb586868737426cbd2a4cd43c7f8c58507d8a2f578e0150187cc00b0
+SIZE (xfce4/xfce4-datetime-plugin-0.8.3.tar.bz2) = 329081


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump xfce4-datetime-plugin PORTVERSION to 0.8.3 and drop obsolete PORTREVISION.