### PR TITLE
devel/gnustep-make: update to 2.9.3

### DIFF
--- a/devel/gnustep-make/Makefile
+++ b/devel/gnustep-make/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnustep-make
-PORTVERSION=	2.9.2
+PORTVERSION=	2.9.3
 CATEGORIES=	devel gnustep
 MASTER_SITES=	GNUSTEP/core \
 		https://github.com/gnustep/tools-make/releases/download/make-2_9_1/

--- a/devel/gnustep-make/Makefile
+++ b/devel/gnustep-make/Makefile
@@ -2,7 +2,7 @@ PORTNAME=	gnustep-make
 PORTVERSION=	2.9.3
 CATEGORIES=	devel gnustep
 MASTER_SITES=	GNUSTEP/core \
-		https://github.com/gnustep/tools-make/releases/download/make-2_9_1/
+		https://github.com/gnustep/tools-make/releases/download/make-2_9_3/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GNUstep makefile package

--- a/devel/gnustep-make/distinfo
+++ b/devel/gnustep-make/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1717137269
-SHA256 (gnustep-make-2.9.2.tar.gz) = f540df9f0e1daeb3d23b08e14b204b2a46f1d0a4005cb171c95323413806e4e1
-SIZE (gnustep-make-2.9.2.tar.gz) = 611483
+TIMESTAMP = 1779061505
+SHA256 (gnustep-make-2.9.3.tar.gz) = 93ca320b706279ebca53760da89d4c3f2bbc547f4723967140a34346d9f04c24
+SIZE (gnustep-make-2.9.3.tar.gz) = 613252


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump gnustep-make PORTVERSION from 2.9.2 to 2.9.3 and refresh distinfo accordingly.