### PR TITLE
textproc/libsass: update to 3.6.6

### DIFF
--- a/textproc/libsass/Makefile
+++ b/textproc/libsass/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libsass
-DISTVERSION=	3.6.4
+DISTVERSION=	3.6.6
 CATEGORIES=	textproc
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/textproc/libsass/distinfo
+++ b/textproc/libsass/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1619114590
-SHA256 (sass-libsass-3.6.4_GH0.tar.gz) = f9484d9a6df60576e791566eab2f757a97fd414fce01dd41fc0a693ea5db2889
-SIZE (sass-libsass-3.6.4_GH0.tar.gz) = 338519
+TIMESTAMP = 1779060788
+SHA256 (sass-libsass-3.6.6_GH0.tar.gz) = 11f0bb3709a4f20285507419d7618f3877a425c0131ea8df40fe6196129df15d
+SIZE (sass-libsass-3.6.6_GH0.tar.gz) = 342625


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Refresh dist version metadata for libsass to match upstream 3.6.6 release.