### PR TITLE
devel/libthai: update to 0.1.30

### DIFF
--- a/devel/libthai/Makefile
+++ b/devel/libthai/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libthai
-DISTVERSION=	0.1.29
+DISTVERSION=	0.1.30
 CATEGORIES=	devel
 MASTER_SITES=	http://linux.thai.net/pub/thailinux/software/libthai/ \
 		https://github.com/tlwg/${PORTNAME}/releases/download/v${DISTVERSION}/

--- a/devel/libthai/distinfo
+++ b/devel/libthai/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1641322573
-SHA256 (libthai-0.1.29.tar.xz) = fc80cc7dcb50e11302b417cebd24f2d30a8b987292e77e003267b9100d0f4bcd
-SIZE (libthai-0.1.29.tar.xz) = 417728
+TIMESTAMP = 1779060783
+SHA256 (libthai-0.1.30.tar.xz) = ddba8b53dfe584c3253766030218a88825488a51a7deef041d096e715af64bdd
+SIZE (libthai-0.1.30.tar.xz) = 436044


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump libthai distversion to 0.1.30 and refresh distinfo metadata.