### PR TITLE
devel/libayatana-appindicator: update to 0.5.94

### DIFF
--- a/devel/libayatana-appindicator/Makefile
+++ b/devel/libayatana-appindicator/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	libayatana-appindicator
-PORTVERSION=	0.5.91
-PORTREVISION=	1
+PORTVERSION=	0.5.94
 CATEGORIES=	devel
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/devel/libayatana-appindicator/distinfo
+++ b/devel/libayatana-appindicator/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1652970199
-SHA256 (AyatanaIndicators-libayatana-appindicator-0.5.91_GH0.tar.gz) = 52eb5d0c0de07177833e50fbaee592dcb3939e96c6b789921e2a8caf40a1ed26
-SIZE (AyatanaIndicators-libayatana-appindicator-0.5.91_GH0.tar.gz) = 158269
+TIMESTAMP = 1779060875
+SHA256 (AyatanaIndicators-libayatana-appindicator-0.5.94_GH0.tar.gz) = 884a6bc77994c0b58c961613ca4c4b974dc91aa0f804e70e92f38a542d0d0f90
+SIZE (AyatanaIndicators-libayatana-appindicator-0.5.94_GH0.tar.gz) = 164282


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Update libayatana-appindicator port to the 0.5.94 release.

New Features:
- Track the upstream libayatana-appindicator 0.5.94 distribution in the port framework.

Build:
- Adjust port metadata to reflect the new distfile version and remove the now-unnecessary port revision.