### PR TITLE
sysutils/vpnc-scripts: update to 20220510

### DIFF
--- a/sysutils/vpnc-scripts/Makefile
+++ b/sysutils/vpnc-scripts/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	vpnc-scripts
-PORTVERSION=	20210402
+PORTVERSION=	20220510
 CATEGORIES=	sysutils net-vpn
 MASTER_SITES=	ftp://ftp.infradead.org/pub/${PORTNAME}/ \
 		ZI

--- a/sysutils/vpnc-scripts/distinfo
+++ b/sysutils/vpnc-scripts/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1649436670
-SHA256 (vpnc-scripts-20210402.tar.gz) = cd00e831904554c7acbc9cd20e6457c6e787fe52dc2f75d39263a65faccc19f0
-SIZE (vpnc-scripts-20210402.tar.gz) = 39925
+TIMESTAMP = 1779060834
+SHA256 (vpnc-scripts-20220510.tar.gz) = e2240f6c13d00da4cbcdadce238b4cdc43dc3fd74284024430cb35cff25563ac
+SIZE (vpnc-scripts-20220510.tar.gz) = 44155


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump vpnc-scripts PORTVERSION to 20220510 and refresh distinfo for the new distfile.