### PR TITLE
net/miniupnpc: update to 2.3.3

### DIFF
--- a/net/miniupnpc/Makefile
+++ b/net/miniupnpc/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	miniupnpc
-PORTVERSION=	2.2.8
-PORTREVISION=	0
+PORTVERSION=	2.3.3
 CATEGORIES?=	net
 MASTER_SITES=	http://miniupnp.free.fr/files/ \
 		https://miniupnp.tuxfamily.org/files/

--- a/net/miniupnpc/distinfo
+++ b/net/miniupnpc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1721042565
-SHA256 (miniupnpc-2.2.8.tar.gz) = 05b929679091b9921b6b6c1f25e39e4c8d1f4d46c8feb55a412aa697aee03a93
-SIZE (miniupnpc-2.2.8.tar.gz) = 104603
+TIMESTAMP = 1779060766
+SHA256 (miniupnpc-2.3.3.tar.gz) = d52a0afa614ad6c088cc9ddff1ae7d29c8c595ac5fdd321170a05f41e634bd1a
+SIZE (miniupnpc-2.3.3.tar.gz) = 141281


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump miniupnpc PORTVERSION from 2.2.8 to 2.3.3 and drop PORTREVISION in the port Makefile.