### PR TITLE
X11 fonts/comic neue

### DIFF
--- a/Tools/lib/Magus/OutcomeRules.pm
+++ b/Tools/lib/Magus/OutcomeRules.pm
@@ -29,6 +29,21 @@ package Magus::OutcomeRules;
 # MAINTAINER=   ctriv@MidnightBSD.org
 #
 
+sub missing_license_warning {
+  m/LICENSE not set/i
+    || m/has not defined LICENSE/i
+    || m/no licenses present in LICENSE/i
+    and return "LICENSE is not set.";
+}
+
+sub empty_license_warning {
+  m/empty license/i && return "LICENSE is empty.";
+}
+
+sub invalid_license_warning {
+  m/Invalid LICENSE: (\S+)/ && return "Invalid license set: $1";
+}
+
 
 =head1 fetch rules
 
@@ -37,6 +52,18 @@ package Magus::OutcomeRules;
 package Magus::OutcomeRules::fetch;
 
 use base qw(Magus::OutcomeRules::Base);
+
+sub NoLicense :warning {
+  Magus::OutcomeRules::missing_license_warning();
+}
+
+sub EmptyLicense :warning {
+  Magus::OutcomeRules::empty_license_warning();
+}
+
+sub InvalidLicense :warning {
+  Magus::OutcomeRules::invalid_license_warning();
+}
 
 sub FetchFailed :error {
   m/Couldn't fetch it/ && return "Fetch failed.";
@@ -62,15 +89,15 @@ package Magus::OutcomeRules::patch;
 use base qw(Magus::OutcomeRules::Base);
 
 sub NoLicense :warning {
-  m/LICENSE not set/ && return "LICENSE is not set.";
+  Magus::OutcomeRules::missing_license_warning();
 }
 
 sub EmptyLicense :warning {
-  m/empty license/ && return "LICENSE is empty.";
+  Magus::OutcomeRules::empty_license_warning();
 }
 
 sub InvalidLicense :warning {
-  m/Invalid LICENSE: (\S+)/ && return "Invalid license set: $1";
+  Magus::OutcomeRules::invalid_license_warning();
 }
 
 =head1 configure rules
@@ -170,4 +197,3 @@ use base qw(Magus::OutcomeRules::Base);
 
 1;
 __END__
-

--- a/Tools/lib/Magus/OutcomeRules.pm
+++ b/Tools/lib/Magus/OutcomeRules.pm
@@ -44,6 +44,15 @@ sub invalid_license_warning {
   m/Invalid LICENSE: (\S+)/ && return "Invalid license set: $1";
 }
 
+sub fake_qa_warning {
+  return unless m/^====>\s+Running Q\/A tests \(fake-qa\)$/m;
+
+  my @messages = m/^(?:Error|Warning):\s*(.+)$/mg;
+  return unless @messages;
+
+  return "fake-qa reported: " . join("; ", @messages);
+}
+
 
 =head1 fetch rules
 
@@ -140,6 +149,10 @@ sub FakeDestdirInFile :error {
 sub FakedOutsideDestdir :error {
   m:^    .* installed in /:m
     && return "A file was installed in the final dir instead of the fake dir.";
+}
+
+sub FakeQA :warning {
+  Magus::OutcomeRules::fake_qa_warning();
 }
 
 

--- a/Tools/lib/Magus/PortTest.pm
+++ b/Tools/lib/Magus/PortTest.pm
@@ -115,6 +115,7 @@ sub run {
   my %results = (summary => 'pass');
   
   $self->check_for_skip(\%results) && return \%results;
+  $self->check_master_sites(\%results);
 
   
   foreach my $target (qw(fetch extract patch configure build fake package install deinstall reinstall test)) {
@@ -193,6 +194,27 @@ sub check_for_skip {
   return;
 }    
 
+sub check_master_sites {
+  my ($self, $results) = @_;
+  my %seen;
+  my @insecure = grep { !$seen{$_}++ }
+                 grep { m{^(?:http|ftp)://}i }
+                 map  { $_->url } $self->{port}->master_sites;
+
+  return unless @insecure;
+
+  my @shown = @insecure > 5 ? @insecure[0..4] : @insecure;
+  my $extra = @insecure > @shown ? sprintf(" and %d more", scalar(@insecure) - scalar(@shown)) : "";
+
+  push(@{$results->{warnings}}, {
+    phase => 'prerun',
+    msg   => "MASTER_SITES contains non-HTTPS URLs: " . join(", ", @shown) . $extra,
+    name  => 'InsecureMasterSites',
+  });
+
+  $results->{summary} = 'warn' if $results->{summary} eq 'pass';
+}
+
 
 sub _run_make {
   my ($self, $target) = @_;
@@ -228,5 +250,4 @@ sub _set_env {
 
 1;
 __END__
-
 

--- a/x11-fonts/comic-neue/Makefile
+++ b/x11-fonts/comic-neue/Makefile
@@ -1,26 +1,23 @@
 PORTNAME=	comic-neue
-PORTVERSION=	2.4
-DISTVERSIONPREFIX=	v
-PORTREVISION=	1
+PORTVERSION=	2.51
 CATEGORIES=	x11-fonts
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Free Comic Sans alternative
+WWW=		http://comicneue.com/
 
 LICENSE=	OFL11
-LICENSE_FILE=	${WRKDIR}/comicneue-${PORTVERSION}/SIL-License.txt
+LICENSE_FILE=	${WRKSRC}/OFL.txt
 
-USES=		fonts
+USES=		fonts zip
 
-USE_GITHUB=	yes
-GH_ACCOUNT=	crozynski
-GH_PROJECT=	comicneue
+MASTER_SITES=	http://comicneue.com/
 
+NO_ARCH=	yes
 NO_BUILD=	yes
-WRKSRC_SUBDIR=		OTF
 
 do-install:
-	${MKDIR} ${FONTSDIR}
-	${INSTALL_DATA} ${WRKSRC}/*.otf ${FONTSDIR}
+	@${MKDIR} ${STAGEDIR}${FONTSDIR}
+	cd ${WRKSRC}/OTF && ${INSTALL_DATA} ComicNeue-Angular/*.otf ComicNeue/*.otf ${STAGEDIR}${FONTSDIR}
 
 .include <bsd.port.mk>

--- a/x11-fonts/comic-neue/distinfo
+++ b/x11-fonts/comic-neue/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1600782732
-SHA256 (crozynski-comicneue-v2.4_GH0.tar.gz) = 9e1153e1bc08d76e7d5418ac707278b687204b2eb6c59f387f1c310edb165be6
-SIZE (crozynski-comicneue-v2.4_GH0.tar.gz) = 2896409
+TIMESTAMP = 1779128725
+SHA256 (comic-neue-2.51.zip) = 54dd998c93b8d6658b1c2d6ade9f790d10ffaa3632868dd2cfac84b405290321
+SIZE (comic-neue-2.51.zip) = 2579880


### PR DESCRIPTION
## Summary by Sourcery

Refactor Magus outcome rules, extend port test pre-run checks, and update the comic-neue font port to a newer upstream version and packaging layout.

New Features:
- Add a pre-run port test check that warns when MASTER_SITES uses non-HTTPS URLs.
- Introduce an outcome rule warning that aggregates fake-qa error and warning messages.

Enhancements:
- Centralize LICENSE-related warning matching logic in shared helper functions for reuse across fetch and patch outcome rules.

Chores:
- Update the x11-fonts/comic-neue port to a newer upstream release with adjusted distfile source, license file path, staging-aware install, and metadata such as WWW and NO_ARCH.