### PR TITLE
deskutils/gworkspace-gwmetadata: update to 1.1.0

### DIFF
--- a/deskutils/gworkspace-gwmetadata/Makefile
+++ b/deskutils/gworkspace-gwmetadata/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gworkspace
-PORTVERSION=	1.0.0
-PORTREVISION=	1
+PORTVERSION=	1.1.0
 CATEGORIES=	deskutils gnustep
 MASTER_SITES=	GNUSTEP/usr-apps
 PKGNAMESUFFIX=	-gwmetadata${PKGNAMESUFFIX2}
@@ -18,7 +17,6 @@ LIB_DEPENDS=	libDBKit.so:deskutils/gworkspace \
 		libPreferencePanes.so:deskutils/systempreferences
 USE_LDCONFIG=	${GNUSTEP_SYSTEM_LIBRARIES}
 
-USE_SQLITE=	yes
 LDFLAGS+=	-lpthread
 
 WRKSRC=		${WRKDIR}/gworkspace-${PORTVERSION}/GWMetadata

--- a/deskutils/gworkspace-gwmetadata/distinfo
+++ b/deskutils/gworkspace-gwmetadata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1656263295
-SHA256 (gworkspace-1.0.0.tar.gz) = 33b755ed155ab70f207581d09518b9c0d05de8c193f46a96d3847f0e828dbba2
-SIZE (gworkspace-1.0.0.tar.gz) = 2319707
+TIMESTAMP = 1779127414
+SHA256 (gworkspace-1.1.0.tar.gz) = ce304eb558100082c8e44a334f3c8ee692a0946d8106bc1a66a5490b14ff3f3c
+SIZE (gworkspace-1.1.0.tar.gz) = 2345439


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump gworkspace-gwmetadata PORTVERSION from 1.0.0 to 1.1.0 and drop the now-unneeded USE_SQLITE setting.