### PR TITLE
audio/speex: update to 1.2.1

### DIFF
--- a/audio/speex/Makefile
+++ b/audio/speex/Makefile
@@ -1,7 +1,7 @@
 
 
 PORTNAME=	speex
-DISTVERSION=	1.2.0
+DISTVERSION=	1.2.1
 PORTEPOCH=	1
 CATEGORIES=	audio
 MASTER_SITES=	http://downloads.us.xiph.org/releases/speex/

--- a/audio/speex/distinfo
+++ b/audio/speex/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1481458226
-SHA256 (speex-1.2.0.tar.gz) = eaae8af0ac742dc7d542c9439ac72f1f385ce838392dc849cae4536af9210094
-SIZE (speex-1.2.0.tar.gz) = 1047080
+TIMESTAMP = 1779060523
+SHA256 (speex-1.2.1.tar.gz) = 4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea
+SIZE (speex-1.2.1.tar.gz) = 1043278


### PR DESCRIPTION
Update audio/speex to version 1.2.1.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the speex distversion from 1.2.0 to 1.2.1 in the port Makefile and refresh distinfo accordingly.