### PR TITLE
devel/spice-protocol: update to 0.14.5

### DIFF
--- a/devel/spice-protocol/Makefile
+++ b/devel/spice-protocol/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	spice-protocol
-PORTVERSION=	0.14.4
+PORTVERSION=	0.14.5
 CATEGORIES=	devel
 MASTER_SITES=	http://www.spice-space.org/download/releases/
 

--- a/devel/spice-protocol/distinfo
+++ b/devel/spice-protocol/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1644652583
-SHA256 (spice-protocol-0.14.4.tar.xz) = 04ffba610d9fd441cfc47dfaa135d70096e60b1046d2119d8db2f8ea0d17d912
-SIZE (spice-protocol-0.14.4.tar.xz) = 23540
+TIMESTAMP = 1779060201
+SHA256 (spice-protocol-0.14.5.tar.xz) = baf58449f6e89d19f475899ad5fb9196fdc46c03cc53233f4e39cf2978f9cff7
+SIZE (spice-protocol-0.14.5.tar.xz) = 23592


### PR DESCRIPTION
Update devel/spice-protocol to version 0.14.5.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)