### PR TITLE
graphics/colord-gtk: update to 0.3.1

### DIFF
--- a/graphics/colord-gtk/Makefile
+++ b/graphics/colord-gtk/Makefile
@@ -1,8 +1,7 @@
 # Created by: Koop Mast <kwm@FreeBSD.org>
 
 PORTNAME=	colord-gtk
-PORTVERSION=	0.3.0
-PORTREVISION=	1
+PORTVERSION=	0.3.1
 CATEGORIES=	graphics
 MASTER_SITES=	https://www.freedesktop.org/software/colord/releases/
 

--- a/graphics/colord-gtk/distinfo
+++ b/graphics/colord-gtk/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1648009838
-SHA256 (colord-gtk-0.3.0.tar.xz) = b9466656d66d9a6ffbc2dd04fa91c8f6af516bf9efaacb69744eec0f56f3c1d0
-SIZE (colord-gtk-0.3.0.tar.xz) = 21768
+TIMESTAMP = 1779059926
+SHA256 (colord-gtk-0.3.1.tar.xz) = c176b889b75630a17f4e3d7ef24c09a3e12368e633496087459c8b53ac3a122d
+SIZE (colord-gtk-0.3.1.tar.xz) = 22132


### PR DESCRIPTION
Update graphics/colord-gtk to version 0.3.1.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Remove the obsolete PORTREVISION and bump PORTVERSION from 0.3.0 to 0.3.1 in the port Makefile.