### PR TITLE
graphics/nvidia-texture-tools: update to 2.1.2

### DIFF
--- a/graphics/nvidia-texture-tools/Makefile
+++ b/graphics/nvidia-texture-tools/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	nvidia-texture-tools
-PORTVERSION=	2.0.8.1 # needed to not bump PORTEPOCH; remove on next update
-PORTREVISION=	3
+PORTVERSION=	2.1.2
+
 CATEGORIES=	graphics
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -19,7 +19,6 @@ LIB_DEPENDS=	libpng.so:graphics/png \
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	castano
-GH_TAGNAME=	${PORTVERSION:R}
 
 USES=		cmake compiler:c++11-lang jpeg
 CMAKE_ARGS=	-DNVTT_SHARED=TRUE

--- a/graphics/nvidia-texture-tools/distinfo
+++ b/graphics/nvidia-texture-tools/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1491085339
-SHA256 (castano-nvidia-texture-tools-2.0.8.1-2.0.8_GH0.tar.gz) = d188d0b28d61985c06dbc151278f8daa3edd680e910977d1261ba9fa4a151629
-SIZE (castano-nvidia-texture-tools-2.0.8.1-2.0.8_GH0.tar.gz) = 939218
+TIMESTAMP = 1779127462
+SHA256 (castano-nvidia-texture-tools-2.1.2_GH0.tar.gz) = 0187336b0285038fab4f4a6b7654f51beaebab040b6aad53c147c917c5ab519b
+SIZE (castano-nvidia-texture-tools-2.1.2_GH0.tar.gz) = 45172897


### PR DESCRIPTION
Update graphics/nvidia-texture-tools to version 2.1.2.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump PORTVERSION to 2.1.2 and drop the now-unnecessary PORTREVISION and GH_TAGNAME override for the GitHub fetch configuration.