### PR TITLE
misc/timezonemap: update to 0.4.5.3

### DIFF
--- a/misc/timezonemap/Makefile
+++ b/misc/timezonemap/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	timezonemap
-DISTVERSION=	0.4.5.1
-PORTREVISION=	1
+DISTVERSION=	0.4.5.3
 CATEGORIES=	misc gnome
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/misc/timezonemap/distinfo
+++ b/misc/timezonemap/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1579519579
-SHA256 (dashea-timezonemap-0.4.5.1_GH0.tar.gz) = 4e46ef325c488bed73fd758275866f467f2e2d0c375fb3fbd7b149a7869b74be
-SIZE (dashea-timezonemap-0.4.5.1_GH0.tar.gz) = 2535764
+TIMESTAMP = 1779059923
+SHA256 (dashea-timezonemap-0.4.5.3_GH0.tar.gz) = 9efddf1c70b9a8a6dcddc10f28a0e78e12a95ef072f8a16a5dbecbb87b862b3d
+SIZE (dashea-timezonemap-0.4.5.3_GH0.tar.gz) = 3004134


### PR DESCRIPTION
Update misc/timezonemap to version 0.4.5.3.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump misc/timezonemap DISTVERSION to 0.4.5.3 and reset PORTREVISION.