### PR TITLE
print/ttfautohint: update to 1.8.4

### DIFF
--- a/print/ttfautohint/Makefile
+++ b/print/ttfautohint/Makefile
@@ -1,7 +1,7 @@
 # Created by: Po-Chuan Hsieh <sunpoet@FreeBSD.org>
 
 PORTNAME=	ttfautohint
-PORTVERSION=	1.8.3
+PORTVERSION=	1.8.4
 CATEGORIES=	print
 MASTER_SITES=	SAVANNAH/freetype \
 		SF/freetype/ttfautohint/${PORTVERSION}

--- a/print/ttfautohint/distinfo
+++ b/print/ttfautohint/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1575793781
-SHA256 (ttfautohint-1.8.3.tar.gz) = 87bb4932571ad57536a7cc20b31fd15bc68cb5429977eb43d903fa61617cf87e
-SIZE (ttfautohint-1.8.3.tar.gz) = 3458637
+TIMESTAMP = 1779059871
+SHA256 (ttfautohint-1.8.4.tar.gz) = 8a876117fa6ebfd2ffe1b3682a9a98c802c0f47189f57d3db4b99774206832e1
+SIZE (ttfautohint-1.8.4.tar.gz) = 3539332


### PR DESCRIPTION
Update print/ttfautohint to version 1.8.4.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Track the upstream ttfautohint 1.8.4 release in the print/ttfautohint port.