### PR TITLE
security/chkrootkit: update to 0.59

### DIFF
--- a/security/chkrootkit/Makefile
+++ b/security/chkrootkit/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	chkrootkit
-PORTVERSION=	0.58b
+PORTVERSION=	0.59
 CATEGORIES=	security
 MASTER_SITES=	ftp://ftp.chkrootkit.org/pub/seg/pac/
 

--- a/security/chkrootkit/distinfo
+++ b/security/chkrootkit/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1690489500
-SHA256 (chkrootkit-0.58b.tar.gz) = 75ed2ace81f0fa3e9c3fb64dab0e8857ed59247ea755f5898416feb2c66807b9
-SIZE (chkrootkit-0.58b.tar.gz) = 42957
+TIMESTAMP = 1779060242
+SHA256 (chkrootkit-0.59.tar.gz) = bd38f1d7f543a2aa6dd8c7ad6bb88df7c0d7dc101df57377dac24415cbc8c5ee
+SIZE (chkrootkit-0.59.tar.gz) = 45088


### PR DESCRIPTION
Update security/chkrootkit to version 0.59.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump the chkrootkit port version from 0.58b to 0.59 and refresh distinfo accordingly.