### PR TITLE
textproc/sassc: update to 3.6.2

### DIFF
--- a/textproc/sassc/Makefile
+++ b/textproc/sassc/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	sassc
-PORTVERSION=	3.6.1
+PORTVERSION=	3.6.2
 CATEGORIES=	textproc
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/textproc/sassc/distinfo
+++ b/textproc/sassc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1600778191
-SHA256 (sass-sassc-3.6.1_GH0.tar.gz) = 8cee391c49a102b4464f86fc40c4ceac3a2ada52a89c4c933d8348e3e4542a60
-SIZE (sass-sassc-3.6.1_GH0.tar.gz) = 26137
+TIMESTAMP = 1779060459
+SHA256 (sass-sassc-3.6.2_GH0.tar.gz) = 608dc9002b45a91d11ed59e352469ecc05e4f58fc1259fc9a9f5b8f0f8348a03
+SIZE (sass-sassc-3.6.2_GH0.tar.gz) = 26637


### PR DESCRIPTION
Update textproc/sassc to version 3.6.2.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump sassc port version from 3.6.1 to 3.6.2.