### PR TITLE
x11-fonts/terminus-font: update to 4.49.1

### DIFF
--- a/x11-fonts/terminus-font/Makefile
+++ b/x11-fonts/terminus-font/Makefile
@@ -1,7 +1,7 @@
 # Created by: Michael Hsin <mhsin@mhsin.org>
 
 PORTNAME=	terminus-font
-PORTVERSION=	4.48
+PORTVERSION=	4.49.1
 CATEGORIES=	x11-fonts
 MASTER_SITES=	SF/${PORTNAME:tl}/${PORTNAME}-${PORTVERSION}
 

--- a/x11-fonts/terminus-font/distinfo
+++ b/x11-fonts/terminus-font/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1566058197
-SHA256 (terminus-font-4.48.tar.gz) = 34799c8dd5cec7db8016b4a615820dfb43b395575afbb24fc17ee19c869c94af
-SIZE (terminus-font-4.48.tar.gz) = 620561
+TIMESTAMP = 1779060454
+SHA256 (terminus-font-4.49.1.tar.gz) = d961c1b781627bf417f9b340693d64fc219e0113ad3a3af1a3424c7aa373ef79
+SIZE (terminus-font-4.49.1.tar.gz) = 648345


### PR DESCRIPTION
Update x11-fonts/terminus-font to version 4.49.1.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Bump PORTVERSION and distinfo for x11-fonts/terminus-font to 4.49.1.