### PR TITLE
x11-wm/enlightenment: update to 0.27.1

### DIFF
--- a/x11-wm/enlightenment/Makefile
+++ b/x11-wm/enlightenment/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	enlightenment
-PORTVERSION=	0.26.0
+PORTVERSION=	0.27.1
 PORTEPOCH=	2
 CATEGORIES=	x11-wm
 MASTER_SITES=	http://download.enlightenment.org/rel/apps/${PORTNAME}/

--- a/x11-wm/enlightenment/distinfo
+++ b/x11-wm/enlightenment/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1703971954
-SHA256 (enlightenment/enlightenment-0.26.0.tar.xz) = 11b6ef0671be5fead688bf554c30a2a1c683493ad10c5fe3115ffb4655424e84
-SIZE (enlightenment/enlightenment-0.26.0.tar.xz) = 409678784
+TIMESTAMP = 1779129859
+SHA256 (enlightenment/enlightenment-0.27.1.tar.xz) = b41df8771f60e3b96a1973ae566d7425c53a8339f18e54e31230218781da2fa9
+SIZE (enlightenment/enlightenment-0.27.1.tar.xz) = 409707272


### PR DESCRIPTION
Update x11-wm/enlightenment to version 0.27.1.

Generated by automated port update scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the enlightenment window manager port and extend Magus outcome rules for license and fake QA warnings.

New Features:
- Add centralized helper routines to detect missing, empty, and invalid LICENSE conditions across build phases.
- Introduce a FakeQA warning that aggregates and reports messages from fake-qa quality assurance runs.

Enhancements:
- Refactor fetch and patch outcome rules to reuse shared license warning helpers for consistent messaging.

Chores:
- Bump x11-wm/enlightenment port version from 0.26.0 to 0.27.1.