### PR TITLE
devel/p5-POSIX-strftime-Compiler: update to 0.46

### DIFF
--- a/devel/p5-POSIX-strftime-Compiler/Makefile
+++ b/devel/p5-POSIX-strftime-Compiler/Makefile
@@ -1,7 +1,7 @@
 
 
 PORTNAME=	POSIX-strftime-Compiler
-PORTVERSION=	0.41
+PORTVERSION=	0.46
 CATEGORIES=	devel perl5
 MASTER_SITES=	CPAN
 PKGNAMEPREFIX=	p5-
@@ -15,6 +15,5 @@ LICENSE_COMB=	dual
 USES=		perl5
 USE_PERL5=	modbuild
 NO_ARCH=	YES
-PERL_MODBUILD=	yes
 
 .include <bsd.port.mk>

--- a/devel/p5-POSIX-strftime-Compiler/distinfo
+++ b/devel/p5-POSIX-strftime-Compiler/distinfo
@@ -1,2 +1,3 @@
-SHA256 (POSIX-strftime-Compiler-0.41.tar.gz) = 670b89e11500f3808c9e21b1c300089622f68906ff12b1cbfba8e30d3a1c3739
-SIZE (POSIX-strftime-Compiler-0.41.tar.gz) = 17187
+TIMESTAMP = 1779127456
+SHA256 (POSIX-strftime-Compiler-0.46.tar.gz) = bf88873248ef88cc5e68ed074493496be684ec334e11273d4654306dd9dae485
+SIZE (POSIX-strftime-Compiler-0.46.tar.gz) = 17189


### PR DESCRIPTION
AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Bump PORTVERSION of p5-POSIX-strftime-Compiler from 0.41 to 0.46 and drop the explicit PERL_MODBUILD setting.