### PR TITLE
magus: fix latest API blessed run query

### DIFF
--- a/Tools/magus/www/data/magus/index.cgi
+++ b/Tools/magus/www/data/magus/index.cgi
@@ -189,7 +189,7 @@ sub api_latest {
     SELECT DISTINCT ON (arch) id, created
       FROM runs
      WHERE status = 'complete'
-       AND blessed = 1
+       AND blessed
      ORDER BY arch, created DESC, osversion DESC
   });
   $runs_sth->execute;


### PR DESCRIPTION
## Summary
- fix /api/latest PostgreSQL query to use a boolean predicate for runs.blessed
- resolves the runtime error from comparing boolean blessed to integer 1

## Testing
- perl -c Tools/magus/www/data/magus/index.cgi
- git diff --check -- Tools/magus/www/data/magus/index.cgi

## Summary by Sourcery

Bug Fixes:
- Resolve a runtime error caused by comparing the boolean blessed column to an integer in the /api/latest PostgreSQL query.