### PR TITLE
Fix rust proc macro test dylib lookup

### DIFF
--- a/lang/rust/Makefile
+++ b/lang/rust/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	rust
 PORTVERSION?=	1.94.0
-PORTREVISION?=	0
+PORTREVISION?=	1
 CATEGORIES=	lang
 MASTER_SITES=	https://static.rust-lang.org/dist/:src \
 		https://dev-static.rust-lang.org/dist/:src \

--- a/lang/rust/files/patch-src_tools_rust-analyzer_crates_proc-macro-srv_proc-macro-test_build.rs
+++ b/lang/rust/files/patch-src_tools_rust-analyzer_crates_proc-macro-srv_proc-macro-test_build.rs
@@ -1,0 +1,29 @@
+--- src/tools/rust-analyzer/crates/proc-macro-srv/proc-macro-test/build.rs.orig	2026-03-02 00:00:00 UTC
++++ src/tools/rust-analyzer/crates/proc-macro-srv/proc-macro-test/build.rs
+@@ -110,12 +110,22 @@ fn main() {
+     let mut artifact_path = None;
++    let mut fallback_artifact_path = None;
+     for message in Message::parse_stream(output.stdout.as_slice()) {
+         if let Message::CompilerArtifact(artifact) = message.unwrap()
+             && artifact.target.kind.contains(&cargo_metadata::TargetKind::ProcMacro)
+-            && (artifact.package_id.repr.starts_with(&repr) || artifact.package_id.repr == pkgid)
+         {
+-            artifact_path = Some(PathBuf::from(&artifact.filenames[0]));
++            let Some(filename) = artifact.filenames.first() else {
++                continue;
++            };
++            let filename = PathBuf::from(filename);
++            if artifact.package_id.repr.starts_with(&repr) || artifact.package_id.repr == pkgid {
++                artifact_path = Some(filename);
++            } else {
++                fallback_artifact_path = Some(filename);
++            }
+         }
+     }
+-
++
+     // This file is under `target_dir` and is already under `OUT_DIR`.
+-    let artifact_path = artifact_path.expect("no dylib for proc-macro-test-impl found");
++    let artifact_path = artifact_path
++        .or(fallback_artifact_path)
++        .expect("no dylib for proc-macro-test-impl found");


### PR DESCRIPTION
AI-Assisted-by: OpenAI Codex <noreply@openai.com>

## Summary by Sourcery

Adjust Rust port to more reliably locate the proc-macro-test dynamic library used by rust-analyzer.

Bug Fixes:
- Ensure proc-macro-test falls back to an alternative compiled proc-macro artifact when the preferred package ID is not found, preventing dylib lookup failures.

Enhancements:
- Track both primary and fallback proc-macro artifact paths when parsing cargo build output in proc-macro-test.

Build:
- Bump the Rust port revision and add a patch to the rust-analyzer proc-macro-test build script.