### PR TITLE
benchmarks/vkpeak: update vendored ncnn to 20260113

### DIFF
--- a/benchmarks/vkpeak/Makefile
+++ b/benchmarks/vkpeak/Makefile
@@ -15,8 +15,8 @@ LIB_DEPENDS=	libvulkan.so:graphics/vulkan-loader
 USES=		cmake compiler:c++11-lib
 USE_GITHUB=	yes
 GH_ACCOUNT=	nihui
-GH_TUPLE=	KhronosGroup:glslang:11.1.0-44-g4afd6917:nglslang/ncnn/glslang \
-		Tencent:ncnn:20220419:ncnn/ncnn
+GH_TUPLE=	nihui:glslang:fe88f421038e1bb0a25cd5c1b2dfe505db82d08f:nglslang/ncnn/glslang \
+		Tencent:ncnn:20260113:ncnn/ncnn
 PLIST_FILES=	bin/${PORTNAME}
 
 do-install:

--- a/benchmarks/vkpeak/distinfo
+++ b/benchmarks/vkpeak/distinfo
@@ -1,7 +1,7 @@
-TIMESTAMP = 1779060904
+TIMESTAMP = 1779563417
 SHA256 (nihui-vkpeak-20260112_GH0.tar.gz) = bb931a63c8abffe8f766763d18d7bfc26a69d732569bf7fd949b2e46a2e30564
 SIZE (nihui-vkpeak-20260112_GH0.tar.gz) = 12315
-SHA256 (KhronosGroup-glslang-11.1.0-44-g4afd6917_GH0.tar.gz) = 5ec414384bafcac14d096ca20205f811b61caf287ea1f7c30745735e7f483ae6
-SIZE (KhronosGroup-glslang-11.1.0-44-g4afd6917_GH0.tar.gz) = 3296291
-SHA256 (Tencent-ncnn-20220419_GH0.tar.gz) = d3d0568654555625f1093a4ea7cd9a4edab0808b45a4ec00dd4efdfbd57df90e
-SIZE (Tencent-ncnn-20220419_GH0.tar.gz) = 12158924
+SHA256 (nihui-glslang-fe88f421038e1bb0a25cd5c1b2dfe505db82d08f_GH0.tar.gz) = dc78c7f2c479779db66c60582bf8c4173b75b89f689b7edaff3a97d8820dbecd
+SIZE (nihui-glslang-fe88f421038e1bb0a25cd5c1b2dfe505db82d08f_GH0.tar.gz) = 4293800
+SHA256 (Tencent-ncnn-20260113_GH0.tar.gz) = 2fdc5c6e37f8552921a9daad498a1be54a6fa6edd32c1a9e3030b27fab253b47
+SIZE (Tencent-ncnn-20260113_GH0.tar.gz) = 13233848


### PR DESCRIPTION
## Summary
- Updated `Tencent:ncnn` GH_TUPLE tag from `20220419` to `20260113`
- Updated `glslang` GH_TUPLE to the matching commit (`fe88f421`) from nihui's fork pinned by ncnn 20260113
- Regenerated `distinfo`

## Root cause
vkpeak 20260112 uses ncnn `GpuInfo` API members that were not present in the previously vendored ncnn 20220419:
- `physicalDevicefeatures`, `physicalDeviceProperties`
- `queryShaderBfloat16Features`, `queryShaderFloat8Features`
- `queryShaderIntegerDotProductFeatures`
- `support_VK_KHR_cooperative_matrix`, `queryCooperativeMatrixSubProperties`, `queryCooperativeMatrixSubPropertiesNV`

## Test plan
- [x] `bmake makesum` — new distfiles fetched and checksummed
- [x] `bmake` — compiles cleanly against ncnn 20260113
- [x] `bmake fake` — installs correctly, fake-qa passes
- [x] `bmake package` — package created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update vkpeak port to a newer upstream snapshot and align its bundled ncnn and glslang dependencies with the versions required by that release.

Bug Fixes:
- Ensure vkpeak builds correctly by vendoring an ncnn version that provides the newer GpuInfo API used by the port.

Enhancements:
- Refresh GitHub tuple sources for ncnn and glslang to current commits and regenerate distinfo to match the new distfiles.