### PR TITLE
lang/rust-bootstrap: update to 1.94.0

### DIFF
--- a/lang/rust-bootstrap/Makefile
+++ b/lang/rust-bootstrap/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	rust
-PORTVERSION=	1.89.0
+PORTVERSION=	1.94.0
 CATEGORIES=	lang
 MASTER_SITES=	https://static.rust-lang.org/dist/
 PKGNAMEPREFIX=	${FLAVOR:S/_/-/g}-
@@ -82,6 +82,11 @@ do-configure:
 	@${ECHO_CMD} 'cargo-native-static=true' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'cargo="${LOCALBASE}/bin/cargo"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'rustc="${LOCALBASE}/bin/rustc"' >> ${WRKSRC}/config.toml
+.if defined(WITH_CCACHE_BUILD) && !defined(NO_CCACHE)
+	@${ECHO_CMD} 'ccache="${CCACHE_BIN}"' >> ${WRKSRC}/config.toml
+.else
+	@${ECHO_CMD} 'ccache=false' >> ${WRKSRC}/config.toml
+.endif
 #.if ${_RUST_HOST} != ${_RUST_TARGET}
 #	@${ECHO_CMD} 'host=["${_RUST_HOST}","${_RUST_TARGET}"]' >> ${WRKSRC}/config.toml
 #	@${ECHO_CMD} 'target=["${_RUST_TARGET}"]' >> ${WRKSRC}/config.toml
@@ -93,20 +98,21 @@ do-configure:
 	@${ECHO_CMD} '[llvm]' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'download-ci-llvm=false' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'link-shared=false' >> ${WRKSRC}/config.toml
-.if defined(WITH_CCACHE_BUILD) && !defined(NO_CCACHE)
-	@${ECHO_CMD} 'ccache="${CCACHE_BIN}"' >> ${WRKSRC}/config.toml
-.else
-	@${ECHO_CMD} 'ccache=false' >> ${WRKSRC}/config.toml
-.endif
 # https://github.com/rust-lang/rust/pull/72696#issuecomment-641517185
 	@${ECHO_CMD} 'ldflags="-lz"' >> ${WRKSRC}/config.toml
 # we need to make sure to always build llvm with host arch support to get a
 # host compiler that can build the host->target compiler
 	@${ECHO_CMD} 'targets="${_RUST_LLVM_TARGET};${_RUST_LLVM_TARGET_${ARCH}}"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} '[target.${_RUST_TARGET}]' >> ${WRKSRC}/config.toml
+.if ${_RUST_HOST} == ${_RUST_TARGET}
+	@${ECHO_CMD} 'cc="${CC}"' >> ${WRKSRC}/config.toml
+	@${ECHO_CMD} 'cxx="${CXX}"' >> ${WRKSRC}/config.toml
+	@${ECHO_CMD} 'linker="${CC}"' >> ${WRKSRC}/config.toml
+.else
 	@${ECHO_CMD} 'cc="${LOCALBASE}/freebsd-sysroot/${FLAVOR:S/_/-/g}/bin/cc"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'cxx="${LOCALBASE}/freebsd-sysroot/${FLAVOR:S/_/-/g}/bin/c++"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'linker="${LOCALBASE}/freebsd-sysroot/${FLAVOR:S/_/-/g}/bin/cc"' >> ${WRKSRC}/config.toml
+.endif
 .for _key _util in ar ${AR} ranlib ${RANLIB}
 	@bin="$$(which ${_util})"; \
 		${ECHO_CMD} "${_key}=\"$$bin\"" >> ${WRKSRC}/config.toml

--- a/lang/rust-bootstrap/distinfo
+++ b/lang/rust-bootstrap/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1776983349
-SHA256 (rust/rustc-1.89.0-src.tar.xz) = 0b9d55610d8270e06c44f459d1e2b7918a5e673809c592abed9b9c600e33d95a
-SIZE (rust/rustc-1.89.0-src.tar.xz) = 267487572
+TIMESTAMP = 1779561990
+SHA256 (rust/rustc-1.94.0-src.tar.xz) = 0b53ae34f5c0c3612cfe1de139f9167a018cd5737bc2205664fd69ba9b25f600
+SIZE (rust/rustc-1.94.0-src.tar.xz) = 273916448

--- a/lang/rust-bootstrap/files/patch-Path.inc
+++ b/lang/rust-bootstrap/files/patch-Path.inc
@@ -1,6 +1,6 @@
 --- ./src/llvm-project/llvm/lib/Support/Unix/Path.inc.orig	2025-11-28 16:49:15.298802000 -0500
 +++ ./src/llvm-project/llvm/lib/Support/Unix/Path.inc	2025-11-28 16:49:35.347530000 -0500
-@@ -35,27 +35,8 @@
+@@ -35,27 +35,11 @@
  #include <pwd.h>
  #include <sys/file.h>
  
@@ -19,6 +19,9 @@
 -#include <machine/elf.h>
 -extern char **environ;
 -#endif
++#if __FreeBSD_version < 1300057
++extern char **environ;
++#endif
 -#elif defined(__DragonFly__)
 -#include <sys/mount.h>
 -#elif defined(__MVS__)

--- a/lang/rust-bootstrap/files/patch-src_bootstrap_src_core_build__steps_install.rs
+++ b/lang/rust-bootstrap/files/patch-src_bootstrap_src_core_build__steps_install.rs
@@ -4,14 +4,14 @@ It otherwise wastes significant time (there are a lot of individual
 files) and stages host docs, wasm docs, which unstages the host
 docs first.
 
---- src/bootstrap/src/core/build_steps/install.rs.orig	2022-05-01 20:28:31 UTC
+--- src/bootstrap/src/core/build_steps/install.rs.orig	2025-09-18 00:00:00 UTC
 +++ src/bootstrap/src/core/build_steps/install.rs
-@@ -138,7 +138,7 @@ macro_rules! install {
+@@ -204,7 +204,7 @@ macro_rules! install {
  }
- 
+
  install!((self, builder, _config),
--    Docs, path = "src/doc", _config.docs, only_hosts: false, {
-+    Docs, path = "src/doc", _config.docs, only_hosts: true, {
+-    Docs, path = "src/doc", _config.docs, IS_HOST: false, {
++    Docs, path = "src/doc", _config.docs, IS_HOST: true, {
          let tarball = builder.ensure(dist::Docs { host: self.target }).expect("missing docs");
-         install_sh(builder, "docs", self.compiler.stage, Some(self.target), &tarball);
+         install_sh(builder, "docs", self.build_compiler, Some(self.target), &tarball);
      };

--- a/lang/rust-bootstrap/files/patch-src_tools_rust-analyzer_crates_proc-macro-srv_proc-macro-test_build.rs
+++ b/lang/rust-bootstrap/files/patch-src_tools_rust-analyzer_crates_proc-macro-srv_proc-macro-test_build.rs
@@ -1,0 +1,29 @@
+--- src/tools/rust-analyzer/crates/proc-macro-srv/proc-macro-test/build.rs.orig	2026-03-02 00:00:00 UTC
++++ src/tools/rust-analyzer/crates/proc-macro-srv/proc-macro-test/build.rs
+@@ -110,12 +110,22 @@ fn main() {
+     let mut artifact_path = None;
++    let mut fallback_artifact_path = None;
+     for message in Message::parse_stream(output.stdout.as_slice()) {
+         if let Message::CompilerArtifact(artifact) = message.unwrap()
+             && artifact.target.kind.contains(&cargo_metadata::TargetKind::ProcMacro)
+-            && (artifact.package_id.repr.starts_with(&repr) || artifact.package_id.repr == pkgid)
+         {
+-            artifact_path = Some(PathBuf::from(&artifact.filenames[0]));
++            let Some(filename) = artifact.filenames.first() else {
++                continue;
++            };
++            let filename = PathBuf::from(filename);
++            if artifact.package_id.repr.starts_with(&repr) || artifact.package_id.repr == pkgid {
++                artifact_path = Some(filename);
++            } else {
++                fallback_artifact_path = Some(filename);
++            }
+         }
+     }
+-
++
+     // This file is under `target_dir` and is already under `OUT_DIR`.
+-    let artifact_path = artifact_path.expect("no dylib for proc-macro-test-impl found");
++    let artifact_path = artifact_path
++        .or(fallback_artifact_path)
++        .expect("no dylib for proc-macro-test-impl found");

--- a/lang/rust-bootstrap/files/patch-vendor_cc.rs
+++ b/lang/rust-bootstrap/files/patch-vendor_cc.rs
@@ -86,8 +86,8 @@ https://reviews.llvm.org/D77776
                  (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                  (false, false, false, false, false) => {
                      cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
---- vendor/cc-1.2.23/src/tool.rs.orig	2025-04-01 18:22:03 UTC
-+++ vendor/cc-1.2.23/src/tool.rs
+--- vendor/cc-1.2.28/src/tool.rs.orig	2025-10-28 12:34:00 UTC
++++ vendor/cc-1.2.28/src/tool.rs
 @@ -141,9 +141,7 @@ impl Tool {
 
              match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
@@ -99,9 +99,9 @@ https://reviews.llvm.org/D77776
                  (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                  (false, false, false, false, false) => {
                      cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
---- vendor/cc-1.2.25/src/tool.rs.orig	2025-08-04 08:20:29 UTC
-+++ vendor/cc-1.2.25/src/tool.rs
-@@ -141,9 +141,7 @@ impl Tool {
+--- vendor/cc-1.2.38/src/tool.rs.orig	2025-11-05 21:59:07 UTC
++++ vendor/cc-1.2.38/src/tool.rs
+@@ -158,9 +158,7 @@ impl Tool {
 
              match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
                  (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),
@@ -112,9 +112,9 @@ https://reviews.llvm.org/D77776
                  (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                  (false, false, false, false, false) => {
                      cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
---- vendor/cc-1.2.26/src/tool.rs.orig	2025-04-01 18:22:03 UTC
-+++ vendor/cc-1.2.26/src/tool.rs
-@@ -141,9 +141,7 @@ impl Tool {
+--- vendor/cc-1.2.45/src/tool.rs.orig	2026-03-17 17:56:14 UTC
++++ vendor/cc-1.2.45/src/tool.rs
+@@ -159,9 +159,7 @@ impl Tool {
 
              match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
                  (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),
@@ -125,9 +125,9 @@ https://reviews.llvm.org/D77776
                  (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                  (false, false, false, false, false) => {
                      cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
---- vendor/cc-1.2.27/src/tool.rs.orig	2025-04-01 18:22:03 UTC
-+++ vendor/cc-1.2.27/src/tool.rs
-@@ -141,9 +141,7 @@ impl Tool {
+--- vendor/cc-1.2.50/src/tool.rs.orig	2026-04-22 17:39:24 UTC
++++ vendor/cc-1.2.50/src/tool.rs
+@@ -158,9 +158,7 @@ impl Tool {
 
              match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
                  (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),


### PR DESCRIPTION
## Summary

- update `lang/rust-bootstrap` to Rust 1.94.0
- refresh bootstrap patches against the Rust 1.94 source layout
- adjust generated `config.toml` so same-host amd64 builds use native cc/c++, while cross targets keep the freebsd-sysroot wrappers

## Validation

- `bmake patch`
- `bmake configure`
- `bmake build`
- `bmake fake`
- `bmake package`
- `bmake describe`
- `bmake check-license`
- `bmake patch FLAVOR=i386`
- `bmake configure FLAVOR=i386`
- `portlint -C` (0 fatal, 17 existing-style warnings)
- `git diff --check`

## Summary by Sourcery

Update the rust-bootstrap port to Rust 1.94.0 and refresh local patches and build configuration to match the new upstream layout and tooling.

Bug Fixes:
- Ensure rust-analyzer proc-macro tests can fall back to an alternative compiled artifact when the expected package ID does not match.
- Fix Bootstrap LLVM Path.inc handling of environ on older FreeBSD versions to avoid symbol issues.

Enhancements:
- Refresh vendor cc crate patches to track newer upstream versions used by Rust 1.94.0.
- Adjust rust-bootstrap config generation so same-host builds use the native compiler toolchain while cross builds continue to use freebsd-sysroot wrappers.
- Move ccache configuration to the general Rust build config section to better align with the updated Rust build system.
- Restrict installation of Rust documentation to host targets only to avoid unnecessary staging of non-host docs.

Build:
- Update rust-bootstrap Makefile version and distinfo to fetch Rust 1.94.0 sources.