### PR TITLE
cad/stepcode: fix STAGEDIR path doubling in post-install

### DIFF
--- a/cad/stepcode/Makefile
+++ b/cad/stepcode/Makefile
@@ -20,8 +20,8 @@ CMAKE_ARGS+=	-DSC_INSTALL_PREFIX=${PREFIX} \
 MANDIRS=	${PREFIX}/man
 
 post-install:
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/bin/schema_scanner
-	@(cd ${STAGEDIR}${PREFIX} ; \
+	${STRIP_CMD} ${PREFIX}/bin/schema_scanner
+	@(cd ${PREFIX} ; \
 		${FIND} include \( -type f -or -type l \) | ${SORT} >> ${TMPPLIST})
 
 .include <bsd.port.mk>


### PR DESCRIPTION
## Summary
- Replace `${STAGEDIR}${PREFIX}` with `${PREFIX}` in `post-install` for both the `strip` call and the `cd`/`find` pipeline

## Root cause
During `bmake fake`, `${PREFIX}` already expands to `${FAKE_DESTDIR}${TRUE_PREFIX}` (i.e. it includes the staging directory). Using `${STAGEDIR}${PREFIX}` therefore doubled the staging prefix, causing `strip` to target a non-existent path and `find` to `cd` into a non-existent directory.

## Test plan
- [x] `bmake fake` — strip and find complete successfully, fake passes
- [x] `bmake package` — package created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct post-install strip and plist generation paths by using PREFIX without prepending STAGEDIR.