### PR TITLE
www/node24: use sqlite:port to get session and metadata extensions

### DIFF
--- a/www/node24/Makefile
+++ b/www/node24/Makefile
@@ -30,7 +30,7 @@ LIB_DEPENDS=	libbrotlidec.so:archivers/brotli \
 		libzstd.so:archivers/zstd
 RUN_DEPENDS=	corepack>=0:www/corepack
 
-USES=		compiler:c++11-lang gmake localbase pkgconfig python:build shebangfix sqlite tar:xz
+USES=		compiler:c++11-lang gmake localbase pkgconfig python:build shebangfix sqlite:port tar:xz
 
 CONFIGURE_ARGS=	--prefix=${PREFIX:S|^${DESTDIR}||} \
 		--shared-brotli \


### PR DESCRIPTION
Node.js 24 uses sqlite3session_* and sqlite3_column_*_name APIs from the SQLite session and column metadata extensions, which are not compiled into the base system sqlite3. Force use of the ports sqlite3 which has SESSION and METADATA enabled by default.

AI-Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>

## Summary by Sourcery

Build:
- Switch the www/node24 port to use sqlite:port in the USES framework so it links against the ports SQLite with SESSION and METADATA enabled.