### PR TITLE
x11/libgnomekbd: switch to meson build

### DIFF
--- a/x11/libgnomekbd/Makefile
+++ b/x11/libgnomekbd/Makefile
@@ -6,20 +6,21 @@ DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GNOME keyboard shared library
+WWW=		https://gitlab.gnome.org/GNOME/libgnomekbd
 
-LICENSE=	gpl2
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 LIB_DEPENDS=	libxklavier.so:x11/libxklavier
 
-USES=		gettext gmake gnome libtool localbase pathfix pkgconfig \
+USES=		gettext gnome localbase meson pkgconfig \
 		tar:xz xorg
-USE_GNOME=	cairo gtk30 introspection:build
-GNU_CONFIGURE=	yes
+USE_GNOME=	cairo gdkpixbuf glib20 gtk30 introspection:build
 USE_XORG=	x11
-INSTALLS_ICONS=	yes
 USE_LDCONFIG=	yes
-INSTALL_TARGET=	install-strip
+
+MESON_ARGS=	-Dtests=false \
+		-Dvapi=false
 
 GLIB_SCHEMAS=	org.gnome.libgnomekbd.desktop.gschema.xml \
 		org.gnome.libgnomekbd.gschema.xml \

--- a/x11/libgnomekbd/pkg-plist
+++ b/x11/libgnomekbd/pkg-plist
@@ -8,11 +8,9 @@ include/libgnomekbd/gkbd-keyboard-drawing.h
 include/libgnomekbd/gkbd-status.h
 include/libgnomekbd/gkbd-util.h
 lib/girepository-1.0/Gkbd-3.0.typelib
-lib/libgnomekbd.a
 lib/libgnomekbd.so
 lib/libgnomekbd.so.8
 lib/libgnomekbd.so.8.0.0
-lib/libgnomekbdui.a
 lib/libgnomekbdui.so
 lib/libgnomekbdui.so.8
 lib/libgnomekbdui.so.8.0.0
@@ -56,6 +54,7 @@ share/locale/gl/LC_MESSAGES/libgnomekbd.mo
 share/locale/gu/LC_MESSAGES/libgnomekbd.mo
 share/locale/he/LC_MESSAGES/libgnomekbd.mo
 share/locale/hi/LC_MESSAGES/libgnomekbd.mo
+share/locale/hr/LC_MESSAGES/libgnomekbd.mo
 share/locale/hu/LC_MESSAGES/libgnomekbd.mo
 share/locale/id/LC_MESSAGES/libgnomekbd.mo
 share/locale/it/LC_MESSAGES/libgnomekbd.mo


### PR DESCRIPTION
## Summary
- switch libgnomekbd to its in-tree Meson build so configure no longer looks for a missing generated ./configure script
- update plist for Meson output and installed hr locale
- correct LICENSE to lgpl2.1+ and add WWW

## Validation
- bmake configure
- bmake fake
- bmake package
- bmake check-license
- portlint -C (0 fatal errors; warnings only)
- git diff --check -- x11/libgnomekbd

## Notes
- bmake test was not run; upstream tests are disabled with -Dtests=false, matching the port configuration.
- The existing x11/libgnomekbd branch was stale and had no open PR, so this PR uses x11/libgnomekbd-fix.

## Summary by Sourcery

Switch x11/libgnomekbd to the upstream Meson-based build and update port metadata accordingly.

Bug Fixes:
- Fix build configuration by using the in-tree Meson build instead of relying on a missing generated configure script.

Enhancements:
- Expand GNOME-related dependencies configuration and disable tests and Vala bindings in the Meson build to match the port configuration.

Build:
- Migrate the port from GNU configure/gmake to Meson, adjusting USES, USE_GNOME, and build arguments.
- Update the packing list to reflect Meson-installed files, including the hr locale.

Chores:
- Correct the declared license to LGPL 2.1+ and add the project homepage URL to the port metadata.