### PR TITLE
japanese/scim-anthy: fix libc++ WideString build

### DIFF
--- a/japanese/scim-anthy/Makefile
+++ b/japanese/scim-anthy/Makefile
@@ -22,4 +22,6 @@ USES=		gettext-runtime gmake gnome iconv libtool:keepla pkgconfig
 USE_GNOME=	atk cairo gdkpixbuf glib20 gtk20 pango
 GNU_CONFIGURE=	yes
 
+CPPFLAGS+=	-D__STDC_ISO_10646__
+
 .include <bsd.port.mk>


### PR DESCRIPTION
## Summary
- build scim-anthy with __STDC_ISO_10646__ so SCIM WideString uses wchar_t
- match textproc/scim and other SCIM module ports
- fix the libc++ std::basic_string<unsigned int> build failure reported by Magus 2186606

## Validation
- bmake build
- bmake fake
- bmake package
- bmake check-license
- bmake test
- portlint -C (0 fatal errors, 3 warnings)
- git diff --check -- japanese/scim-anthy

## Summary by Sourcery

Define the __STDC_ISO_10646__ macro for the japanese/scim-anthy port to align SCIM WideString usage with wchar_t and resolve libc++ build issues.