### PR TITLE
devel/npth: fix plist for 1.8

### DIFF
--- a/devel/npth/Makefile
+++ b/devel/npth/Makefile
@@ -5,6 +5,7 @@ MASTER_SITES=	GNUPG
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	New GNU Portable Threads
+WWW=		https://www.gnupg.org/software/npth/index.html
 
 LICENSE=	lgpl3 gpl3
 LICENSE_COMB=	dual

--- a/devel/npth/pkg-descr
+++ b/devel/npth/pkg-descr
@@ -7,5 +7,3 @@ In contrast to GNU Pth, it is based on the system's standard threads
 implementation.  This allows the use of libraries which are not compatible to
 GNU Pth.  Experience with a Windows Pth emulation showed that this is a solid
 way to provide a co-routine based framework.
-
-WWW: https://www.gnupg.org/software/npth/index.html

--- a/devel/npth/pkg-plist
+++ b/devel/npth/pkg-plist
@@ -1,6 +1,6 @@
-bin/npth-config
 include/npth.h
 lib/libnpth.so
 lib/libnpth.so.0
-lib/libnpth.so.0.1.2
+lib/libnpth.so.0.3.0
+libdata/pkgconfig/npth.pc
 share/aclocal/npth.m4


### PR DESCRIPTION
Update the plist for the current npth install layout and move WWW from pkg-descr to the Makefile.

AI-Assisted-by: OpenAI Codex <noreply@openai.com>

## Summary by Sourcery

Update npth port metadata and packaging list for the current 1.8 layout.

Documentation:
- Move the project homepage URL from pkg-descr into the Makefile WWW field.

Chores:
- Refresh the pkg-plist to match the current npth 1.8 installation layout.