### PR TITLE
mail/claws-mail: fix plugin fake install path

### DIFF
--- a/mail/claws-mail/Makefile.claws
+++ b/mail/claws-mail/Makefile.claws
@@ -43,11 +43,11 @@ do-build:
 .  endfor
 
 do-install:
-	@${MKDIR} ${STAGEDIR}${PREFIX}/lib/claws-mail/plugins
+	@${MKDIR} ${PREFIX}/lib/claws-mail/plugins
 .  for p in ${CLAWS_PLUGINS_BUILD}
 	(cd ${WRKSRC}/src/plugins/${p} && \
 		${INSTALL_LIB} .libs/${p:S|spam_|spam|}.so \
-		${STAGEDIR}${PREFIX}/lib/claws-mail/plugins)
+		${PREFIX}/lib/claws-mail/plugins)
 .  endfor
 
 .endif


### PR DESCRIPTION
Install plugin shared libraries using the fake-time PREFIX instead of prepending STAGEDIR, which prevents doubled fake roots in slave plugin ports.

AI-Assisted-by: OpenAI Codex <noreply@openai.com>

## Summary by Sourcery

Build:
- Update claws-mail plugin install path configuration to rely on fake-time PREFIX rather than STAGEDIR to ensure correct staging roots.