### PR TITLE
devel/tinysparql: fix fake install paths

### DIFF
--- a/devel/tinysparql/Makefile
+++ b/devel/tinysparql/Makefile
@@ -19,7 +19,7 @@ LIB_DEPENDS=	libdbus-1.so:devel/dbus \
 		libicutu.so:devel/icu \
 		libjson-glib-1.0.so:devel/json-glib
 
-USES=		gettext gnome localbase:ldflags meson pkgconfig python:build sqlite tar:xz
+USES=		gettext gnome localbase:ldflags meson pkgconfig python:build sqlite:port tar:xz
 USE_GNOME=	glib20 introspection:build libxml2 pygobject3
 USE_LDCONFIG=	yes
 
@@ -48,7 +48,10 @@ VAPI_USES=		vala:build
 VAPI_MESON_ENABLED=	vapi
 
 post-install:
-	@(cd ${STAGEDIR}${PREFIX}/lib && ${LN} -sf libtracker-sparql-3.0.so.0.1001.0 \
-		libtracker-sparql-3.0.so)
+	@(cd ${PREFIX}/lib && \
+		${LN} -sf libtinysparql-3.0.so.0.1001.0 \
+			libtracker-sparql-3.0.so.0.1001.0 && \
+		${LN} -sf libtracker-sparql-3.0.so.0.1001.0 \
+			libtracker-sparql-3.0.so)
 
 .include <bsd.port.mk>

--- a/devel/tinysparql/files/patch-src_libtinysparql_meson.build
+++ b/devel/tinysparql/files/patch-src_libtinysparql_meson.build
@@ -1,0 +1,8 @@
+--- src/libtinysparql/meson.build.orig	2025-10-13 18:52:32 UTC
++++ src/libtinysparql/meson.build
+@@ -247,5 +247,2 @@ tracker_sparql_uninstalled_dir = meson.current_build_d
+ tracker_sparql_uninstalled_dir = meson.current_build_dir()
+-
+-meson.add_install_script('symlink-libtracker-sparql.sh', get_option('libdir'), meson.current_build_dir())
+-
+ meson.override_dependency('tinysparql-3.0', tracker_sparql_dep)


### PR DESCRIPTION
## Summary
- disable upstream Meson install script that doubles the fake root during make fake
- create tracker compatibility library symlinks from the port post-install hook
- force sqlite:port so QA records the sqlite library tinysparql links against

## Validation
- bmake patch
- bmake package
- portlint -C (0 fatal errors; existing warnings about TEST option, NLS knob, and MPORT_MAINTAINER_MODE)
- git diff --check

## Summary by Sourcery

Fix tinysparql port installation paths and library compatibility handling.

Bug Fixes:
- Correct fake installation root handling by disabling the upstream Meson install step.
- Ensure tracker compatibility libraries are created as symlinks to libtinysparql after installation.
- Record sqlite as a ports-provided dependency so QA tracks the correct linked sqlite library.