### PR TITLE
textproc/scim-kmfl-imengine: Fix build with modern C++ standard libraries

### DIFF
--- a/textproc/scim-kmfl-imengine/Makefile
+++ b/textproc/scim-kmfl-imengine/Makefile
@@ -10,6 +10,8 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	SCIM KMFL IMEngine platform for Keyman (KMN) language keyboards
 WWW=		https://kmfl.sourceforge.net/
 
+LICENSE=	gpl2
+
 BUILD_DEPENDS=	scim:textproc/scim
 LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
 		libfreetype.so:print/freetype2 \
@@ -24,7 +26,7 @@ USE_XORG=	x11 xkbfile xorgproto
 USE_GNOME=	glib20 gtk20 intlhack
 GNU_CONFIGURE=	yes
 USE_LDCONFIG=	yes
-CPPFLAGS+=	-I${LOCALBASE}/include
+CPPFLAGS+=	-I${LOCALBASE}/include -D__STDC_ISO_10646__
 LDFLAGS+=	-L${LOCALBASE}/lib
 INSTALL_TARGET=	install-strip
 


### PR DESCRIPTION
Resolves the compilation failure on Magus (port ID 2189884) where standard C++ library implicit instantiation of undefined template `std::char_traits<unsigned int>` was triggered. Specifying `-D__STDC_ISO_10646__` ensures SCIM's `WideString` is defined as `std::wstring` (`std::basic_string<wchar_t>`), for which `std::char_traits` is fully defined. Additionally, this sets the `LICENSE` field to `gpl2` to match `textproc/kmflcomp` and `textproc/libkmfl`.

## Summary by Sourcery

Update scim-kmfl-imengine port metadata and build flags to fix compilation with modern C++ standard libraries.

Bug Fixes:
- Define __STDC_ISO_10646__ in CPPFLAGS so WideString maps to a supported wide string type and avoids template instantiation errors with modern C++ standard libraries.

Build:
- Add GPLv2 license declaration to the port Makefile to align licensing with related KMFL components.