### PR TITLE
textproc/scim-m17n: Fix build with modern C++ standard libraries

### DIFF
--- a/textproc/scim-m17n/Makefile
+++ b/textproc/scim-m17n/Makefile
@@ -9,6 +9,8 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	SCIM IMEngine module which uses m17n library as the backend
 WWW=		https://github.com/scim-im/scim
 
+LICENSE=	gpl2
+
 BUILD_DEPENDS=	scim:textproc/scim \
 		gsed:textproc/gsed
 LIB_DEPENDS=	libm17n.so:devel/m17n-lib
@@ -16,6 +18,8 @@ RUN_DEPENDS=	scim:textproc/scim
 
 USES=		gmake pkgconfig libtool:keepla
 GNU_CONFIGURE=	yes
+CPPFLAGS+=	-I${LOCALBASE}/include -D__STDC_ISO_10646__
+LDFLAGS+=	-L${LOCALBASE}/lib
 INSTALL_TARGET=	install-strip
 
 USE_CXXSTD=	c++11


### PR DESCRIPTION
Resolves the compilation failure on Magus (port ID 2189885) where standard C++ library implicit instantiation of undefined template `std::char_traits<unsigned int>` was triggered. Specifying `-D__STDC_ISO_10646__` ensures SCIM's `WideString` is defined as `std::wstring` (`std::basic_string<wchar_t>`), for which `std::char_traits` is fully defined. Additionally, this sets the `LICENSE` field to `gpl2` to match related SCIM ports.

## Summary by Sourcery

Fix build issues for scim-m17n with modern C++ standard libraries and align licensing metadata with related SCIM ports.

Bug Fixes:
- Resolve compilation failures caused by incompatible wide character handling in modern standard C++ libraries.

Build:
- Add compiler and linker flags to locate dependencies and define __STDC_ISO_10646__ for successful C++11 builds.

Chores:
- Set the port LICENSE field to gpl2 to match related SCIM ports.