### PR TITLE
textproc/scim-openvanilla: Fix build with modern C++ standard libraries

### DIFF
--- a/textproc/scim-openvanilla/Makefile
+++ b/textproc/scim-openvanilla/Makefile
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	SCIM OpenVanilla input method (IM)/output filter (OF) framework
 WWW=		https://openvanilla.org/
 
-LICENSE=	NONE
+LICENSE=	mit
 
 BUILD_DEPENDS=	scim:textproc/scim	\
 		${LOCALBASE}/include/OpenVanilla/OpenVanilla.h:textproc/openvanilla-framework
@@ -21,7 +21,7 @@ WRKSRC=		${WRKDIR}/${DISTNAME}/Loaders/SCIM
 USES=		pkgconfig gettext iconv gmake libtool:keepla
 GNU_CONFIGURE=	yes
 CONFIGURE_ENV+=	OV_MODULEDIR=${PREFIX}/lib/openvanilla/
-CPPFLAGS+=	-I${LOCALBASE}/include
+CPPFLAGS+=	-I${LOCALBASE}/include -D__STDC_ISO_10646__
 INSTALL_TARGET=	install-strip
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Resolves the compilation failure on Magus (port ID 2189886) where standard C++ library implicit instantiation of undefined template `std::char_traits<unsigned int>` was triggered. Specifying `-D__STDC_ISO_10646__` ensures SCIM's `WideString` is defined as `std::wstring` (`std::basic_string<wchar_t>`), for which `std::char_traits` is fully defined. Additionally, this updates the `LICENSE` field from `NONE` to `mit`.

## Summary by Sourcery

Update scim-openvanilla port to declare the correct license and adjust compiler flags for compatibility with modern C++ standard libraries.

Build:
- Add __STDC_ISO_10646__ to CPPFLAGS to ensure successful builds with modern C++ standard libraries.

Chores:
- Set the port LICENSE metadata to mit instead of NONE.