### PR TITLE
textproc/opensearch13: Fix fake-qa build error

### DIFF
--- a/textproc/opensearch13/Makefile
+++ b/textproc/opensearch13/Makefile
@@ -104,6 +104,6 @@ post-install:
 		${SED} -e 's#^${FAKE_DESTDIR}${TRUE_PREFIX}/##' >> ${TMPPLIST}
 	${ECHO} "@dir lib/opensearch/plugins" >> ${TMPPLIST}
 	${ECHO} "@dir libexec/opensearch" >> ${TMPPLIST}
-	${ECHO} "@dir(opensearch,opensearch,0755) ${ETCDIR}" >> ${TMPPLIST}
+	${ECHO} "@dir(opensearch,opensearch,0755) ${ETCDIR_REL}" >> ${TMPPLIST}
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Resolves the packaging/fake-qa build failure on Magus (port ID 2189541) where the generated plist temporary file (.PLIST.mktmp) was found to refer to the absolute temporary fake staging path (/magus/work/usr/mports/textproc/opensearch13/work/fake-inst-amd64). Using ${ETCDIR_REL} instead of ${ETCDIR} generates relative entries that do not embed the temporary staging path, matching the pattern used in other OpenSearch/ElasticSearch ports.

## Summary by Sourcery

Bug Fixes:
- Generate @dir entries for the opensearch configuration directory using a relative etc directory variable to prevent fake-qa failures due to absolute staging paths in the plist.