### PR TITLE
www/chromium: Fix build by disabling Linux sysroot

### DIFF
--- a/www/chromium/files/patch-build_config_sysroot.gni
+++ b/www/chromium/files/patch-build_config_sysroot.gni
@@ -1,0 +1,10 @@
+--- build/config/sysroot.gni.orig	2022-09-13 19:38:09 UTC
++++ build/config/sysroot.gni
+@@ -21,7 +21,7 @@ declare_args() {
+   # The absolute path to the sysroot that target_sysroot_dir is relative to.
+   # This can be set if you want to use a custom sysroot.
+   target_sysroot = ""
+ 
+-  use_sysroot = true
++  use_sysroot = false
+ }


### PR DESCRIPTION
Resolves the build/configure failure on Magus (port ID 2189955) where the build system asserted on a missing Linux sysroot (debian_bullseye_amd64-sysroot). Although Chromium uses sysroots on Linux, on MidnightBSD we build natively against the host system libraries. Adding patch-build_config_sysroot.gni to set use_sysroot = false ensures that the GN build system and related tools (like rust_autocxx) do not assert on or require a Linux sysroot.

## Summary by Sourcery

Build:
- Add a GN build patch to set use_sysroot = false so the Chromium build no longer requires a Linux sysroot on MidnightBSD.