### PR TITLE
Tools/magus: Fix MCP SSE transport handshake

### DIFF
--- a/Tools/magus/www/data/magus/auth/mcp.cgi
+++ b/Tools/magus/www/data/magus/auth/mcp.cgi
@@ -2158,6 +2158,11 @@ sub handle_sse_get() {
         -pragma        => 'no-cache',
     );
 
+    # Send the required MCP SSE endpoint event
+    my $endpoint = $cgi->url(-absolute => 1);
+    print "event: endpoint\n";
+    print "data: $endpoint\n\n";
+
     my $keepalives = $ENV{MCP_SSE_KEEPALIVES} // 6;
     $keepalives = 6 unless is_number($keepalives);
     $keepalives = int($keepalives);


### PR DESCRIPTION
Properly implements the required 'event: endpoint' handshake event in mcp.cgi, allowing standard Model Context Protocol (MCP) clients using the Server-Sent Events (SSE) transport protocol to successfully establish a connection.

## Summary by Sourcery

Bug Fixes:
- Add the missing MCP SSE endpoint event to the SSE response so standard MCP clients can complete the transport handshake.