### PR TITLE
textproc/opensearch-dashboards219: Fix fake-qa plist path check

### DIFF
--- a/textproc/opensearch-dashboards219/Makefile
+++ b/textproc/opensearch-dashboards219/Makefile
@@ -60,8 +60,8 @@ do-install:
 
 post-install:
 	${ECHO} "@sample ${ETCDIR_REL}/opensearch_dashboards.yml.sample" >> ${TMPPLIST}
-	${FIND} -s ${WWWDIR} -not -type d | ${SORT} | \
-		${SED} -e 's#^${PREFIX}/##' >> ${TMPPLIST}
+	${FIND} -s ${FAKE_DESTDIR}${WWWDIR} -not -type d | ${SORT} | \
+		${SED} -e 's#^${FAKE_DESTDIR}${PREFIX}/##' >> ${TMPPLIST}
 	${ECHO} "@dir(www,www) ${WWWDIR}/data" >> ${TMPPLIST}
 	${ECHO} "@dir ${WWWDIR}/plugins/reportsDashboards/node_modules/set-interval-async/test/resources/legacy" >> ${TMPPLIST}
 	${ECHO} "@dir ${WWWDIR}/plugins/reportsDashboards/node_modules/set-interval-async/test/resources/fixed" >> ${TMPPLIST}


### PR DESCRIPTION
Fixes the fake-qa build failure for port ID 2189540 (textproc/opensearch-dashboards219). During post-install, it now correctly uses FAKE_DESTDIR prefix for both finding files and stripping the prefix, ensuring absolute staging paths do not end up in the generated temporary packaging list.

## Summary by Sourcery

Bug Fixes:
- Use FAKE_DESTDIR when scanning installed files and stripping path prefixes so that absolute staging paths do not leak into the temporary packaging list.