### PR TITLE
cad/yosys: fix MidnightBSD build paths

### DIFF
--- a/cad/yosys/Makefile
+++ b/cad/yosys/Makefile
@@ -32,6 +32,7 @@ SHEBANG_GLOB=	*.py *.sh
 
 MAKE_ARGS=	ABCEXTERNAL=abc
 MAKE_ENV=	MAKE=${GMAKE}
+FAKE_OPTS=	trueprefix
 
 TEST_TARGET=	test
 

--- a/cad/yosys/files/patch-Makefile
+++ b/cad/yosys/files/patch-Makefile
@@ -1,0 +1,25 @@
+--- Makefile.orig	2025-03-05 12:58:51 UTC
++++ Makefile
+@@ -367,5 +367,5 @@ ifeq ($(ENABLE_READLINE),1)
+ CXXFLAGS += -DYOSYS_ENABLE_READLINE
+-ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
++ifeq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD))
+ CXXFLAGS += -I/usr/local/include
+ endif
+ LIBS += -lreadline
+@@ -399,7 +399,7 @@ ifeq ($(OS), MINGW)
+ CXXFLAGS += -Ilibs/dlfcn-win32
+ endif
+ LIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi)
+-ifneq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD MINGW))
++ifneq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD MINGW))
+ LIBS += -ldl
+ endif
+ endif
+@@ -418,5 +418,5 @@ ifeq ($(ENABLE_TCL),1)
+ TCL_VERSION ?= tcl$(shell bash -c "tclsh <(echo 'puts [info tclversion]')")
+-ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
++ifeq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD))
+ # BSDs usually use tcl8.6, but the lib is named "libtcl86"
+ TCL_INCLUDE ?= /usr/local/include/$(TCL_VERSION)
+ TCL_LIBS ?= -l$(subst .,,$(TCL_VERSION))


### PR DESCRIPTION
## Summary
- treat MidnightBSD like the other BSDs in Yosys' Makefile for Tcl/readline include paths and libdl handling
- use trueprefix fake install handling to avoid doubled fake-root install paths

## Validation
- bmake package
- portlint -C (0 fatal errors; warnings: USES ordering, MPORT_MAINTAINER_MODE)
- git diff --check

## Summary by Sourcery

Adjust yosys port build configuration to better support MidnightBSD and correct fake install paths.

Enhancements:
- Align yosys Makefile handling for MidnightBSD with other BSDs for include paths and libdl usage.

Build:
- Enable trueprefix fake install handling for the yosys port to prevent doubled fake-root paths.