### PR TITLE
Cad/yosys

### DIFF
--- a/cad/yosys/Makefile
+++ b/cad/yosys/Makefile
@@ -32,6 +32,7 @@ SHEBANG_GLOB=	*.py *.sh
 
 MAKE_ARGS=	ABCEXTERNAL=abc
 MAKE_ENV=	MAKE=${GMAKE}
+FAKE_OPTS=	trueprefix
 
 TEST_TARGET=	test
 

--- a/cad/yosys/files/patch-Makefile
+++ b/cad/yosys/files/patch-Makefile
@@ -1,0 +1,25 @@
+--- Makefile.orig	2025-03-05 12:58:51 UTC
++++ Makefile
+@@ -367,5 +367,5 @@ ifeq ($(ENABLE_READLINE),1)
+ CXXFLAGS += -DYOSYS_ENABLE_READLINE
+-ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
++ifeq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD))
+ CXXFLAGS += -I/usr/local/include
+ endif
+ LIBS += -lreadline
+@@ -399,7 +399,7 @@ ifeq ($(OS), MINGW)
+ CXXFLAGS += -Ilibs/dlfcn-win32
+ endif
+ LIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) $(PKG_CONFIG) --silence-errors --libs libffi || echo -lffi)
+-ifneq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD MINGW))
++ifneq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD MINGW))
+ LIBS += -ldl
+ endif
+ endif
+@@ -418,5 +418,5 @@ ifeq ($(ENABLE_TCL),1)
+ TCL_VERSION ?= tcl$(shell bash -c "tclsh <(echo 'puts [info tclversion]')")
+-ifeq ($(OS), $(filter $(OS),FreeBSD OpenBSD NetBSD))
++ifeq ($(OS), $(filter $(OS),FreeBSD MidnightBSD OpenBSD NetBSD))
+ # BSDs usually use tcl8.6, but the lib is named "libtcl86"
+ TCL_INCLUDE ?= /usr/local/include/$(TCL_VERSION)
+ TCL_LIBS ?= -l$(subst .,,$(TCL_VERSION))

--- a/misc/codex/Makefile
+++ b/misc/codex/Makefile
@@ -24,6 +24,8 @@ USES=		cargo llvm:min=19 ninja:build python:test shebangfix ssl
 
 BROKEN_i386=	fails to build: rustc-LLVM ERROR: out of memory
 
+NO_TEST=	yes
+
 MAKE_JOBS_UNSAFE=	yes
 WITHOUT_LTO=	yes
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust build configuration for misc/codex and cad/yosys ports.

Build:
- Disable running tests for the misc/codex port via NO_TEST to avoid test-phase issues.
- Update the cad/yosys port Makefile to pass FAKE_OPTS for staged installs and add a patch to tweak the upstream Makefile accordingly.