### PR TITLE
print/qt6-pdf: Fix build error with ft2build.h not found

### DIFF
--- a/www/qt6-webengine/Makefile
+++ b/www/qt6-webengine/Makefile
@@ -47,6 +47,7 @@ CMAKE_ON+=	QT_FEATURE_qtpdf_build
 CMAKE_OFF+=	QT_FEATURE_qtwebengine_build
 
 SYS_LIBS=	freetype
+CXXFLAGS+=	-I${LOCALBASE}/include/freetype2
 .else
 BUILD_DEPENDS+=	${LOCALBASE}/include/linux/videodev2.h:multimedia/v4l_compat \
 		${PYTHON_PKGNAMEPREFIX}html5lib>0:www/py-html5lib@${PY_FLAVOR}


### PR DESCRIPTION
Fixes the build failure for print/qt6-pdf on MidnightBSD due to a missing FreeType include path in CXXFLAGS.

When BUILD_QTPDF is defined, the parent port Makefile (www/qt6-webengine) unbundles freetype. However, the FreeType include directory (-I${LOCALBASE}/include/freetype2) was not being added to CXXFLAGS, resulting in a compilation error:
```
fx_freetype.h:10:10: fatal error: 'ft2build.h' file not found
```

Adding this path to CXXFLAGS solves the problem without affecting the master port build.

AI-Assisted-by: Antigravity <antigravity-cli@google.com>

## Summary by Sourcery

Bug Fixes:
- Ensure ft2build.h is found by adding the FreeType include directory to CXXFLAGS when BUILD_QTPDF is enabled.