### PR TITLE
audio/csound: Fix build failure with math/gmm++ >= 5.4.3

### DIFF
--- a/audio/csound/Makefile
+++ b/audio/csound/Makefile
@@ -99,7 +99,6 @@ JACK_CMAKE_BOOL=	BUILD_JACK_OPCODES USE_JACK
 
 LINALG_DESC=		Build the linear algebra opcodes
 LINALG_CMAKE_BOOL=	BUILD_LINEAR_ALGEBRA_OPCODES
-LINALG_CXXFLAGS=	-DGMM_VERSION=x # workaround based on https://github.com/csound/csound/issues/1069#issuecomment-439648756
 
 LUA_DESC=		Build Lua Interface and module
 LUA_LIB_DEPENDS=	libluajit-5.1.so:lang/luajit


### PR DESCRIPTION
Fixes the build failure for audio/csound on MidnightBSD due to a compatibility issue with newer versions of math/gmm++.

In math/gmm++ >= 5.4.3, gmm::lapack_ipvt is defined as a std::vector, which does not have a .get() member. The previous workaround flag LINALG_CXXFLAGS=-DGMM_VERSION=x forced gmm++ to use deprecated code paths that called .get(), leading to compilation errors in Opcodes/linear_algebra.cpp:
```
no member named 'get' in 'std::vector<unsigned long>'
```

Removing this workaround flag allows gmm++ to use the correct code paths and compiles successfully.

AI-Assisted-by: Antigravity <antigravity-cli@google.com>