### PR TITLE
devel/valgrind: Fix build failure with invalid shebangs and bump PORTREVISION

### DIFF
--- a/devel/valgrind/Makefile
+++ b/devel/valgrind/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	valgrind
 PORTVERSION=	3.22.0
 PORTEPOCH=	1
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	devel
 MASTER_SITES=	SOURCEWARE/valgrind
 
@@ -12,9 +12,12 @@ WWW=		https://www.valgrind.org/
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-USES=		autoreconf cpe gmake pathfix perl5 pkgconfig shebangfix tar:bz2
+USES=		autoreconf cpe gmake pathfix perl5 pkgconfig shebangfix \
+		python:run tar:bz2
 USE_PERL5=	build
-SHEBANG_FILES=	callgrind/callgrind_annotate.in callgrind/callgrind_control.in
+SHEBANG_FILES=	callgrind/callgrind_annotate.in callgrind/callgrind_control.in \
+		cachegrind/cg_annotate.in cachegrind/cg_diff.in \
+		cachegrind/cg_merge.in
 GNU_CONFIGURE=	yes
 CONFIGURE_ENV+=	ac_cv_path_PERL=${PERL}
 


### PR DESCRIPTION
Fixes the build failure for devel/valgrind on MidnightBSD due to invalid python3 shebangs in cachegrind helper scripts.

During package staging verification (fake-qa), the build was flagged as a failure because `cg_annotate`, `cg_diff`, and `cg_merge` were installed with an uncorrected `/usr/bin/env python3` shebang:
```
fake-qa reported: '/usr/bin/env python3' is an invalid shebang you need USES=shebangfix for 'bin/cg_annotate'...
```

Adding `python:run` to `USES` and adding the three cachegrind python scripts to `SHEBANG_FILES` so that `shebangfix` processes them resolves the issue. Also bumps PORTREVISION to 2.

AI-Assisted-by: Antigravity <antigravity-cli@google.com>

## Summary by Sourcery

Fix valgrind port installation on MidnightBSD by correcting python shebang handling in cachegrind helper scripts and bumping the port revision.

Bug Fixes:
- Resolve package staging failures caused by invalid python3 shebangs in cachegrind helper scripts.

Build:
- Add python runtime to USES and include cachegrind helper scripts in SHEBANG_FILES so they are processed by shebangfix.
- Increment PORTREVISION to 2 to reflect the packaging change.