### PR TITLE
Refactor Magus pipeline phases

### DIFF
--- a/Tools/lib/Magus.pm
+++ b/Tools/lib/Magus.pm
@@ -8,6 +8,7 @@ BEGIN {
 }
 
 
+use Magus::Phase ();
 use Magus::Config;
 use Magus::Port ();
 use Magus::Lock ();

--- a/Tools/lib/Magus.pm
+++ b/Tools/lib/Magus.pm
@@ -20,6 +20,8 @@ use Magus::Chroot ();
 use Magus::Index ();
 use Magus::Run ();
 use Magus::Log ();
+use Magus::PhaseLog ();
+use Magus::PhaseResult ();
 use Magus::Distfile ();
 use Magus::RestrictedDistfile ();
 use Magus::MasterSite ();

--- a/Tools/lib/Magus/App/Slave/Worker.pm
+++ b/Tools/lib/Magus/App/Slave/Worker.pm
@@ -5,6 +5,10 @@ use warnings;
 
 use File::Basename qw(dirname);
 use File::Path qw(mkpath);
+use IO::Select;
+use IPC::Open3 qw(open3);
+use Symbol qw(gensym);
+use Text::ParseWords qw(shellwords);
 
 sub run {
   my ($class, %args) = @_;
@@ -134,14 +138,14 @@ sub inject_pkgfile {
   my $run  = $port->run->id;
   my $dest = join('/', $chroot->root, $chroot->packages, 'All');
   
-  my $cmd = "/usr/bin/scp $Magus::Config{'PkgfilesRoot'}/$run/$file $dest";
+  my $src = "$Magus::Config{'PkgfilesRoot'}/$run/$file";
   
   $self->log->debug("downloading: $run/$file");
   
-  my $out = `$cmd 2>&1`;
+  my ($exit, $out) = $self->run_command('/usr/bin/scp', $src, $dest);
   
-  if ($? != 0) {
-    die "$cmd returned non-zero: $out\n";
+  if ($exit != 0) {
+    die "scp returned non-zero: $out\n";
   }
 }
 
@@ -157,13 +161,13 @@ sub inject_distfiles {
     my $dest = join('/', $chroot->root, $chroot->distfiles, $file);
     mkpath(dirname($dest));
 
-    my $cmd = "/usr/bin/scp $Magus::Config{'DistfilesRoot'}/$run/$file $dest";
+    my $src = "$Magus::Config{'DistfilesRoot'}/$run/$file";
 
     $self->log->debug("downloading: $run/$file");
 
-    my $out = `$cmd 2>&1`;
+    my ($exit, $out) = $self->run_command('/usr/bin/scp', $src, $dest);
 
-    if ($? != 0) {
+    if ($exit != 0) {
       $self->log->debug("download failed: $run/$file $out");
     }
   }
@@ -283,10 +287,8 @@ sub run_scan_phase {
   }
 
   my $scanner = $Magus::Config{ClamAVScanner} || 'clamscan';
-  my $options = $Magus::Config{ClamAVOptions} || '';
-  my $cmd = join(' ', grep { length } ($scanner, $options, _shell_quote($pkgfile))) . ' 2>&1';
-  my $out = `$cmd`;
-  my $exit = $? >> 8;
+  my @options = $self->scanner_options;
+  my ($exit, $out) = $self->run_command($scanner, @options, $pkgfile);
 
   $self->replace_phase_log(scan => $out);
 
@@ -310,14 +312,14 @@ sub upload_pkgfile {
   my $file = sprintf("%s-%s.%s", $port->pkgname, $port->version, $Magus::Config{'PkgExtension'});
   my $from = join('/', $chroot->root, $chroot->packages, 'All', $file);
   
-  my $cmd = "/usr/bin/scp $from $Magus::Config{'PkgfilesRoot'}/$run/$file";
+  my $dest = "$Magus::Config{'PkgfilesRoot'}/$run/$file";
 
   $self->log->debug("uploading: $run/$file");
   
-  my $out = `$cmd 2>&1`;
+  my ($exit, $out) = $self->run_command('/usr/bin/scp', $from, $dest);
 
-  if ($? != 0 ) {
-     die "$cmd returned non-zero: $out\n";
+  if ($exit != 0 ) {
+     die "scp returned non-zero: $out\n";
   }
 }
 
@@ -332,13 +334,11 @@ sub upload_distfiles {
     my $dest = "$Magus::Config{'DistfilesRoot'}/$run/$file";
     mkpath(dirname($dest));
 
-    my $cmd = "/usr/bin/scp $from $dest";
-
     $self->log->debug("uploading: $run/$file");
 
-    my $out = `$cmd 2>&1`;
+    my ($exit, $out) = $self->run_command('/usr/bin/scp', $from, $dest);
 
-    if ($? != 0 ) {
+    if ($exit != 0 ) {
       $self->log->debug("upload failed: $run/$file $out");
     }
   }
@@ -354,6 +354,8 @@ sub replace_phase_log {
 sub distfile_cache_path {
   my ($self, $file) = @_;
 
+  return unless defined $file;
+
   $file =~ s/:[A-Za-z0-9_,]+$//;
   $file =~ s/\?.*$//;
 
@@ -365,11 +367,50 @@ sub distfile_cache_path {
   return $file;
 }
 
-sub _shell_quote {
-  my ($value) = @_;
+sub scanner_options {
+  my ($self) = @_;
 
-  $value =~ s/'/'\\''/g;
-  return "'$value'";
+  my $options = $Magus::Config{ClamAVOptions};
+  return unless defined $options && length $options;
+
+  my @args = ref($options) eq 'ARRAY' ? @$options : shellwords($options);
+  foreach my $arg (@args) {
+    die "Invalid ClamAV option contains a control character.\n"
+      if !defined($arg) || $arg =~ /[[:cntrl:]]/;
+  }
+
+  return @args;
+}
+
+sub run_command {
+  my ($self, @cmd) = @_;
+
+  foreach my $arg (@cmd) {
+    die "Invalid command argument contains a control character.\n"
+      if !defined($arg) || $arg =~ /[[:cntrl:]]/;
+  }
+
+  my $err = gensym;
+  my $pid = open3(undef, my $out_fh, $err, @cmd);
+  my $selector = IO::Select->new($out_fh, $err);
+  my $out = '';
+
+  while (my @ready = $selector->can_read) {
+    foreach my $fh (@ready) {
+      my $buf = '';
+      my $read = sysread($fh, $buf, 8192);
+      if ($read) {
+        $out .= $buf;
+      } else {
+        $selector->remove($fh);
+        close($fh);
+      }
+    }
+  }
+
+  waitpid($pid, 0);
+
+  return ($? >> 8, $out);
 }
 
 sub log {

--- a/Tools/lib/Magus/App/Slave/Worker.pm
+++ b/Tools/lib/Magus/App/Slave/Worker.pm
@@ -3,6 +3,9 @@ package Magus::App::Slave::Worker;
 use strict;
 use warnings;
 
+use File::Basename qw(dirname);
+use File::Path qw(mkpath);
+
 sub run {
   my ($class, %args) = @_;
   
@@ -14,13 +17,13 @@ sub run {
   
   eval {
     $self->{port} = $self->{lock}->port;
-    $self->log->info("Starting test run for $self->{port}");
-    $self->{port}->note_event(info => "Test Started");
-    $self->prep_chroot();
-    $self->inject_depends();
-    $self->inject_distfiles();
-    $self->run_test();
-    $self->{port}->note_event($self->{port}->status => "Test complete.");
+    $self->{phase} = $self->{lock}->phase || 'build';
+    $self->log->info("Starting $self->{phase} phase for $self->{port}");
+    $self->{port}->set_phase_status($self->{phase}, 'running');
+    $self->{port}->note_event(info => ucfirst($self->{phase}) . " Started", $self->{phase}, 'PhaseStarted');
+    $self->run_phase();
+    $self->{port}->refresh;
+    $self->{port}->note_event($self->{port}->phase_status($self->{phase}) => ucfirst($self->{phase}) . " complete.", $self->{phase}, 'PhaseComplete');
   }; 
   
   if ($@) {
@@ -35,8 +38,14 @@ sub run {
 	my $error = $@;
 	eval { 
 	  my $port = $self->port;
-	  $self->log->err("Exception thrown building $port: $error");
-	  $port->set_result_internal("Exception thrown: $error");
+	  my $phase = $self->{phase} || 'build';
+	  $self->log->err("Exception thrown during $phase phase for $port: $error");
+	  if ($phase eq 'build') {
+	    $port->set_result_internal("Exception thrown: $error");
+	  } else {
+	    $port->set_phase_status($phase, 'internal');
+	    $port->note_event(internal => "Exception thrown: $error", $phase, 'Exception');
+	  }
         };
         
         if ($@ && $@ =~ m/DBI/) {
@@ -44,6 +53,51 @@ sub run {
           exit 6;
         }
   }
+}
+
+sub run_phase {
+  my ($self) = @_;
+
+  my $phase = $self->{phase};
+
+  if ($phase eq 'scan') {
+    $self->run_scan_phase();
+    return;
+  }
+
+  $self->prep_chroot();
+
+  if ($phase eq 'build') {
+    $self->inject_depends();
+    $self->inject_distfiles();
+    $self->run_make_phase('build');
+    $self->{port}->refresh;
+    if ($self->{port}->status eq 'pass' || $self->{port}->status eq 'warn') {
+      $self->upload_pkgfile();
+      $self->upload_distfiles();
+    }
+    return;
+  }
+
+  if ($phase eq 'fetch') {
+    $self->inject_distfiles();
+    $self->run_make_phase('fetch');
+    $self->{port}->refresh;
+    if ($self->{port}->phase_status('fetch') eq 'pass' || $self->{port}->phase_status('fetch') eq 'warn') {
+      $self->upload_distfiles();
+    }
+    return;
+  }
+
+  if ($phase eq 'test') {
+    $self->inject_depends();
+    $self->inject_pkgfile($self->{port});
+    $self->inject_distfiles();
+    $self->run_make_phase('test');
+    return;
+  }
+
+  die "Unknown Magus phase: $phase\n";
 }
 
 sub prep_chroot {
@@ -99,16 +153,10 @@ sub inject_distfiles {
   my $run  = $port->run->id;
 
   foreach my $distfile ($port->distfiles) {
-    my $file = $distfile->filename;
+    my $file = $self->distfile_cache_path($distfile->filename) or next;
+    my $dest = join('/', $chroot->root, $chroot->distfiles, $file);
+    mkpath(dirname($dest));
 
-    # the stored filename may carry a master site group suffix (e.g.
-    # foo.tar.gz:source2, optionally comma-separated for multiple groups)
-    # and/or a URL query string (e.g. foo.tar?a=b&c=d); strip both so we
-    # reference the real on-disk distfile name.
-    $file =~ s/:[A-Za-z0-9_,]+$//;
-    $file =~ s/\?.*$//;
-
-    my $dest = join('/', $chroot->root, $chroot->distfiles);
     my $cmd = "/usr/bin/scp $Magus::Config{'DistfilesRoot'}/$run/$file $dest";
 
     $self->log->debug("downloading: $run/$file");
@@ -122,8 +170,8 @@ sub inject_distfiles {
 }
 
 
-sub run_test {
-  my ($self) = @_;
+sub run_make_phase {
+  my ($self, $phase) = @_;
   
   my $port = $self->{port};
   my $chroot = $self->{chroot};
@@ -148,11 +196,11 @@ sub run_test {
     
       my $test = Magus::PortTest->new(port => $port, chroot => $chroot);
 
-      $self->log->info("Building $port");
+      $self->log->info("Running $phase phase for $port");
 
-      my $results = $test->run;
+      my $results = $test->run($phase);
   
-      $self->insert_results($results);
+      $self->insert_results($phase, $results);
     };
     
     if ($@) {
@@ -161,8 +209,15 @@ sub run_test {
       }
       # make sure we get to that exit() down there. 
       my $error = $@;
-      $self->log->err("Exception thrown building $port: $error");
-      eval { $port->set_result_internal("Exception thrown: $error"); };
+      $self->log->err("Exception thrown during $phase phase for $port: $error");
+      eval {
+        if ($phase eq 'build') {
+          $port->set_result_internal("Exception thrown: $error");
+        } else {
+          $port->set_phase_status($phase, 'internal');
+          $port->note_event(internal => "Exception thrown: $error", $phase, 'Exception');
+        }
+      };
     }
     
     exit(0);
@@ -175,24 +230,22 @@ sub run_test {
     # update our port object with new data from the database, as the child
     # process probably changed stuff
     $port->refresh;
-    
-    
-    if ($port->status eq 'pass' || $port->status eq 'warn') {
-        $self->upload_pkgfile();
-        $self->upload_distfiles();
-    }
   } else {
     die "Child exited unexpectedly: $?\n";
   }
 }  
 
 sub insert_results {
-  my ($self, $results) = @_;
+  my ($self, $phase, $results) = @_;
   
-  $self->log->info("Inserting results for %s; summary: $results->{summary}", $self->port);
-      
-  $self->port->status($results->{'summary'});
-  $self->port->update;  
+  $self->log->info("Inserting $phase results for %s; summary: $results->{summary}", $self->port);
+
+  if ($phase eq 'build') {
+    $self->port->status($results->{'summary'});
+    $self->port->update;
+  }
+
+  $self->port->set_phase_status($phase, $results->{'summary'});
             
   my %type_conversion = (skip => 'skip', warning => 'warn', error => 'fail');
                 
@@ -200,12 +253,52 @@ sub insert_results {
     next unless $results->{$type . 's'};
                           
     foreach my $sr (@{$results->{$type . 's'}}) {
-      $self->port->note_event($type_conversion{$type} => $sr->{msg});
+      $self->port->note_event($type_conversion{$type} => $sr->{msg}, $phase, $sr->{name});
     }
   }  
                                             
   if ($results->{log}) {
-    Magus::Log->insert({ port => $self->port, data => $results->{log}->{data}});
+    $self->replace_phase_log($phase, $results->{log}->{data});
+    if ($phase eq 'build') {
+      Magus::Log->search(port => $self->port)->delete_all;
+      Magus::Log->insert({ port => $self->port, data => $results->{log}->{data}});
+    }
+  }
+}
+
+sub run_scan_phase {
+  my ($self) = @_;
+
+  my $port = $self->{port};
+  my $run = $port->run->id;
+  my $file = sprintf("%s-%s.%s", $port->pkgname, $port->version, $Magus::Config{'PkgExtension'});
+  my $pkgfile = "$Magus::Config{'PkgfilesRoot'}/$run/$file";
+
+  if (!-f $pkgfile) {
+    my $msg = "Package file is missing: $pkgfile";
+    $port->set_phase_status(scan => 'internal');
+    $port->note_event(internal => $msg, scan => 'PackageMissing');
+    $self->replace_phase_log(scan => $msg);
+    return;
+  }
+
+  my $scanner = $Magus::Config{ClamAVScanner} || 'clamscan';
+  my $options = $Magus::Config{ClamAVOptions} || '';
+  my $cmd = join(' ', grep { length } ($scanner, $options, _shell_quote($pkgfile))) . ' 2>&1';
+  my $out = `$cmd`;
+  my $exit = $? >> 8;
+
+  $self->replace_phase_log(scan => $out);
+
+  if ($exit == 0) {
+    $port->set_phase_status(scan => 'pass');
+    $port->note_event(info => "Virus scan passed.", scan => 'VirusScanClean');
+  } elsif ($exit == 1) {
+    $port->set_phase_status(scan => 'fail');
+    $port->note_event(fail => "Virus scan found a problem.", scan => 'VirusScanFailed');
+  } else {
+    $port->set_phase_status(scan => 'internal');
+    $port->note_event(internal => "Virus scanner exited with $exit.", scan => 'VirusScanError');
   }
 }
     
@@ -234,17 +327,12 @@ sub upload_distfiles {
   my $run  = $port->run->id;
 
   foreach my $distfile ($port->distfiles) {
-    my $file = $distfile->filename;
-
-    # strip any master site group suffix and URL query string so the local
-    # path and the uploaded name match the real on-disk distfile (see
-    # inject_distfiles for details).
-    $file =~ s/:[A-Za-z0-9_,]+$//;
-    $file =~ s/\?.*$//;
-
+    my $file = $self->distfile_cache_path($distfile->filename) or next;
     my $from = join('/', $chroot->root, $chroot->distfiles, $file);
+    my $dest = "$Magus::Config{'DistfilesRoot'}/$run/$file";
+    mkpath(dirname($dest));
 
-    my $cmd = "/usr/bin/scp $from $Magus::Config{'DistfilesRoot'}/$run/$file";
+    my $cmd = "/usr/bin/scp $from $dest";
 
     $self->log->debug("uploading: $run/$file");
 
@@ -256,6 +344,33 @@ sub upload_distfiles {
   }
 }
 
+sub replace_phase_log {
+  my ($self, $phase, $data) = @_;
+
+  Magus::PhaseLog->search(port => $self->port, phase => $phase)->delete_all;
+  Magus::PhaseLog->insert({ port => $self->port, phase => $phase, data => $data });
+}
+
+sub distfile_cache_path {
+  my ($self, $file) = @_;
+
+  $file =~ s/:[A-Za-z0-9_,]+$//;
+  $file =~ s/\?.*$//;
+
+  if ($file =~ m{(?:^|/)\.\.(?:/|$)} || $file =~ m{^/}) {
+    $self->log->err("Unsafe distfile path ignored: $file");
+    return;
+  }
+
+  return $file;
+}
+
+sub _shell_quote {
+  my ($value) = @_;
+
+  $value =~ s/'/'\\''/g;
+  return "'$value'";
+}
 
 sub log {
   return $_[0]->{logger};

--- a/Tools/lib/Magus/Config.pm
+++ b/Tools/lib/Magus/Config.pm
@@ -58,6 +58,9 @@ sub load_config {
         DistfilesRoot  => '/mnt/magus/distfiles',
         PkgfilesRoot   => '/mnt/magus/packages',
         PkgExtension   => 'mport',
+        WorkerPhases   => [qw(build fetch scan test)],
+        ClamAVScanner   => 'clamscan',
+        ClamAVOptions   => '--no-summary',
         MasterDataDir  => 'ftp://stargazer.midnightbsd.org/pub/magus',
         MportsSnapDir  => 'runs',
         VcsRoot        => 'https://github.com/midnightbsd/',
@@ -81,4 +84,3 @@ BEGIN {load_config("$Magus::Root/config.yaml")};
 
 1;
 __END__
-

--- a/Tools/lib/Magus/Config.pm
+++ b/Tools/lib/Magus/Config.pm
@@ -31,6 +31,7 @@ use strict;
 use warnings;
 use YAML qw(LoadFile);
 use Sys::Hostname qw(hostname);
+use Magus::Phase ();
 
 our %Config;
 
@@ -58,7 +59,7 @@ sub load_config {
         DistfilesRoot  => '/mnt/magus/distfiles',
         PkgfilesRoot   => '/mnt/magus/packages',
         PkgExtension   => 'mport',
-        WorkerPhases   => [qw(build fetch scan test)],
+        WorkerPhases   => [Magus::Phase->default_worker_order],
         ClamAVScanner   => 'clamscan',
         ClamAVOptions   => '--no-summary',
         MasterDataDir  => 'ftp://stargazer.midnightbsd.org/pub/magus',

--- a/Tools/lib/Magus/Index.pm
+++ b/Tools/lib/Magus/Index.pm
@@ -109,6 +109,8 @@ sub sync {
       default_flavor => 1,
     });     
 
+     $class->sync_phase_results($port);
+
      for (@{$dump{'master_sites'}}) {
        Magus::MasterSite->insert({
            port => $port->id,
@@ -186,6 +188,8 @@ sub sync {
       flavor      => $dump{flavor},
       default_flavor => 0,
     });
+
+     $class->sync_phase_results($port);
 
      for (@{$dump{'master_sites'}}) {
        Magus::MasterSite->insert({
@@ -334,6 +338,12 @@ sub sync_categories {
     }
 }
 
+sub sync_phase_results {
+    my ($class, $port) = @_;
+
+    Magus::PhaseResult->ensure_for_port($port);
+}
+
 sub mark_ignored {
     my ($class, $dump, $port) = @_;
     my $ignore = $dump->{ignore} // "";
@@ -341,12 +351,15 @@ sub mark_ignored {
     if ($class->ignore_is_metaport($ignore)) {
       print "\n\tMetaport.  Marking as internal.";
       $port->set_result_internal($ignore);
+      Magus::PhaseResult->mark_nonbuild_skip($port);
     } elsif ($dump->{is_interactive}) {
       print "\n\tIGNORE set.  Marking as skipped.";
       $port->set_result_skip("Port is marked as interactive.");
+      Magus::PhaseResult->mark_nonbuild_skip($port);
     } elsif (length $ignore) {
       print "\n\tIGNORE set.  Marking as skipped.";
       $port->set_result_skip($ignore);
+      Magus::PhaseResult->mark_nonbuild_skip($port);
     }
 }
 

--- a/Tools/lib/Magus/Lock.pm
+++ b/Tools/lib/Magus/Lock.pm
@@ -35,7 +35,7 @@ use strict;
 use warnings;
 
 __PACKAGE__->table('locks');
-__PACKAGE__->columns(Essential => qw(id port machine));
+__PACKAGE__->columns(Essential => qw(id port phase machine));
 __PACKAGE__->sequence('locks_id_seq');
 
 __PACKAGE__->has_a(machine => "Magus::Machine");
@@ -45,20 +45,33 @@ __PACKAGE__->set_sql(by_run => <<'END_OF_SQL');
 SELECT locks.* FROM locks,ports WHERE port=ports.id AND ports.run=?
 END_OF_SQL
 
+__PACKAGE__->set_sql(by_run_and_phase => <<'END_OF_SQL');
+SELECT locks.* FROM locks,ports WHERE port=ports.id AND ports.run=? AND locks.phase=?
+END_OF_SQL
+
 sub get_ready_lock {
   my ($class, $run) = @_;
 
+  my @phases = $class->_worker_phases;
+
   my $lock;
-  my $port;
   
   while (!defined $lock) {
-    my $port = Magus::Port->get_ready_port($run);
+    my ($port, $phase);
+
+    foreach my $candidate_phase (@phases) {
+      $port = Magus::Port->get_ready_port($run, $candidate_phase);
+      if ($port) {
+        $phase = $candidate_phase;
+        last;
+      }
+    }
    
     if (!$port) { # we ran thru all the ports...
       return;
     }
     
-    $lock = $class->_get_lock($port);
+    $lock = $class->_get_lock($port, $phase);
   }
   
   return $lock;
@@ -66,12 +79,14 @@ sub get_ready_lock {
 
 
 sub _get_lock {
-  my ($class, $port) = @_;
+  my ($class, $port, $phase) = @_;
   my $lock;
+  $phase ||= 'build';
   
   eval {
     $lock = $class->insert({
       port    => $port,
+      phase   => $phase,
       machine => $Magus::Machine,
     });
   };
@@ -87,6 +102,25 @@ sub _get_lock {
   return $lock;
 }
 
+sub _worker_phases {
+  my ($class) = @_;
+
+  my $configured = $Magus::Config{WorkerPhases};
+  my @phases;
+
+  if (ref($configured) eq 'ARRAY') {
+    @phases = @$configured;
+  } elsif (defined $configured && length $configured) {
+    @phases = split(/\s*,\s*|\s+/, $configured);
+  } else {
+    @phases = qw(build fetch scan test);
+  }
+
+  my %valid = map { $_ => 1 } qw(fetch build test scan);
+  @phases = grep { $valid{$_} } @phases;
+  return @phases ? @phases : qw(build);
+}
+
 #
 # depreacted method
 #
@@ -99,4 +133,3 @@ sub arch {
 
 1;
 __END__
-

--- a/Tools/lib/Magus/Lock.pm
+++ b/Tools/lib/Magus/Lock.pm
@@ -33,6 +33,7 @@ package Magus::Lock;
 use base qw(Magus::DBI);
 use strict;
 use warnings;
+use Magus::Phase ();
 
 __PACKAGE__->table('locks');
 __PACKAGE__->columns(Essential => qw(id port phase machine));
@@ -113,11 +114,10 @@ sub _worker_phases {
   } elsif (defined $configured && length $configured) {
     @phases = split(/\s*,\s*|\s+/, $configured);
   } else {
-    @phases = qw(build fetch scan test);
+    @phases = Magus::Phase->default_worker_order;
   }
 
-  my %valid = map { $_ => 1 } qw(fetch build test scan);
-  @phases = grep { $valid{$_} } @phases;
+  @phases = grep { Magus::Phase->is_valid($_) } @phases;
   return @phases ? @phases : qw(build);
 }
 

--- a/Tools/lib/Magus/Phase.pm
+++ b/Tools/lib/Magus/Phase.pm
@@ -1,0 +1,31 @@
+package Magus::Phase;
+#
+# Copyright (c) 2026 Lucas Holt. All rights reserved.
+#
+
+use strict;
+use warnings;
+
+my @PHASES = qw(fetch build test scan);
+my %VALID_PHASE = map { $_ => 1 } @PHASES;
+
+sub names {
+  return @PHASES;
+}
+
+sub nonbuild_names {
+  return grep { $_ ne 'build' } @PHASES;
+}
+
+sub default_worker_order {
+  return qw(build fetch scan test);
+}
+
+sub is_valid {
+  my ($class, $phase) = @_;
+
+  return defined $phase && $VALID_PHASE{$phase};
+}
+
+1;
+__END__

--- a/Tools/lib/Magus/PhaseLog.pm
+++ b/Tools/lib/Magus/PhaseLog.pm
@@ -1,0 +1,18 @@
+package Magus::PhaseLog;
+#
+# Copyright (c) 2026 Lucas Holt. All rights reserved.
+#
+
+use strict;
+use warnings;
+
+use base qw(Magus::DBI);
+
+__PACKAGE__->table('phase_logs');
+__PACKAGE__->columns(Essential => qw/id port phase data/);
+__PACKAGE__->sequence('phase_logs_id_seq');
+
+__PACKAGE__->has_a(port => 'Magus::Port');
+
+1;
+__END__

--- a/Tools/lib/Magus/PhaseResult.pm
+++ b/Tools/lib/Magus/PhaseResult.pm
@@ -7,8 +7,7 @@ use strict;
 use warnings;
 
 use base qw(Magus::DBI);
-
-use constant PHASES => qw(fetch build test scan);
+use Magus::Phase ();
 
 __PACKAGE__->table('port_phase_results');
 __PACKAGE__->columns(Essential => qw/id port phase status/);
@@ -19,7 +18,7 @@ __PACKAGE__->has_a(port    => 'Magus::Port');
 __PACKAGE__->has_a(machine => 'Magus::Machine');
 
 sub phase_names {
-  return PHASES;
+  return Magus::Phase->names;
 }
 
 sub ensure_for_port {
@@ -59,15 +58,26 @@ sub set_status {
     q{
       UPDATE port_phase_results
          SET status = ?,
-             machine = ?,
+             machine = CASE WHEN ? = 'untested' THEN NULL ELSE ? END,
              updated = CURRENT_TIMESTAMP,
-             started = CASE WHEN ? = 'running' THEN CURRENT_TIMESTAMP ELSE started END,
-             finished = CASE WHEN ? != 'running' THEN CURRENT_TIMESTAMP ELSE finished END
+             started = CASE
+                         WHEN ? = 'running' THEN CURRENT_TIMESTAMP
+                         WHEN ? = 'untested' THEN NULL
+                         ELSE started
+                       END,
+             finished = CASE
+                          WHEN ? = 'running' THEN NULL
+                          WHEN ? = 'untested' THEN NULL
+                          ELSE CURRENT_TIMESTAMP
+                        END
        WHERE id = ?
     },
     undef,
     $status,
+    $status,
     $machine_id,
+    $status,
+    $status,
     $status,
     $status,
     $self->id,

--- a/Tools/lib/Magus/PhaseResult.pm
+++ b/Tools/lib/Magus/PhaseResult.pm
@@ -1,0 +1,80 @@
+package Magus::PhaseResult;
+#
+# Copyright (c) 2026 Lucas Holt. All rights reserved.
+#
+
+use strict;
+use warnings;
+
+use base qw(Magus::DBI);
+
+use constant PHASES => qw(fetch build test scan);
+
+__PACKAGE__->table('port_phase_results');
+__PACKAGE__->columns(Essential => qw/id port phase status/);
+__PACKAGE__->columns(All       => qw/machine started finished updated/);
+__PACKAGE__->sequence('port_phase_results_id_seq');
+
+__PACKAGE__->has_a(port    => 'Magus::Port');
+__PACKAGE__->has_a(machine => 'Magus::Machine');
+
+sub phase_names {
+  return PHASES;
+}
+
+sub ensure_for_port {
+  my ($class, $port) = @_;
+
+  foreach my $phase ($class->phase_names) {
+    $class->retrieve(port => $port, phase => $phase) || $class->insert({
+      port   => $port,
+      phase  => $phase,
+      status => 'untested',
+    });
+  }
+}
+
+sub mark_nonbuild_skip {
+  my ($class, $port) = @_;
+
+  foreach my $phase ($class->phase_names) {
+    next if $phase eq 'build';
+    my $result = $class->retrieve(port => $port, phase => $phase) || $class->insert({
+      port   => $port,
+      phase  => $phase,
+      status => 'untested',
+    });
+    $result->status('skip');
+    $result->update;
+  }
+}
+
+sub set_status {
+  my ($self, $status, $machine) = @_;
+
+  my $machine_id = $machine ? $machine->id : undef;
+  my $dbh = $self->db_Main;
+
+  $dbh->do(
+    q{
+      UPDATE port_phase_results
+         SET status = ?,
+             machine = ?,
+             updated = CURRENT_TIMESTAMP,
+             started = CASE WHEN ? = 'running' THEN CURRENT_TIMESTAMP ELSE started END,
+             finished = CASE WHEN ? != 'running' THEN CURRENT_TIMESTAMP ELSE finished END
+       WHERE id = ?
+    },
+    undef,
+    $status,
+    $machine_id,
+    $status,
+    $status,
+    $self->id,
+  );
+
+  $self->refresh;
+}
+
+1;
+__END__

--- a/Tools/lib/Magus/Port.pm
+++ b/Tools/lib/Magus/Port.pm
@@ -284,11 +284,7 @@ sub reset {
 
   $self->phase_logs->delete_all if $self->phase_logs;
   foreach my $phase_result ($self->phase_results) {
-    $phase_result->status('untested');
-    $phase_result->machine(undef);
-    $phase_result->started(undef);
-    $phase_result->finished(undef);
-    $phase_result->update;
+    $phase_result->set_status('untested');
   }
 
   $self->status('untested');
@@ -332,7 +328,10 @@ Returns the result row for a phase, creating it if needed.
 sub phase_result {
   my ($self, $phase) = @_;
 
-  return Magus::PhaseResult->retrieve(port => $self, phase => $phase) || Magus::PhaseResult->insert({
+  my ($result) = grep { $_->phase eq $phase } $self->phase_results;
+  return $result if $result;
+
+  return Magus::PhaseResult->insert({
     port   => $self,
     phase  => $phase,
     status => 'untested',

--- a/Tools/lib/Magus/Port.pm
+++ b/Tools/lib/Magus/Port.pm
@@ -46,6 +46,8 @@ __PACKAGE__->has_many(depends => [ 'Magus::Depend' => 'dependency' ] => 'port');
 __PACKAGE__->has_many(categories => [ 'Magus::PortCategory' => 'category' ]);
 __PACKAGE__->has_many(perms => [ 'Magus::PortLicensePerms' => 'perm' ]);
 __PACKAGE__->has_many(events => 'Magus::Event');
+__PACKAGE__->has_many(phase_results => 'Magus::PhaseResult');
+__PACKAGE__->has_many(phase_logs => 'Magus::PhaseLog');
 __PACKAGE__->has_many(master_sites => 'Magus::MasterSite');
 __PACKAGE__->has_many(distfiles => 'Magus::Distfile');
 __PACKAGE__->has_many(restricted_distfiles => 'Magus::RestrictedDistfile');
@@ -54,6 +56,47 @@ __PACKAGE__->has_many(critical => ['Magus::CriticalPorts' => 'pkgname' ] => 'pkg
 
 __PACKAGE__->set_sql(ready_ports => 'SELECT __ESSENTIAL__ FROM ready_ports WHERE run=?');
 __PACKAGE__->set_sql(single_ready_port => 'SELECT __ESSENTIAL__ FROM ready_ports WHERE run=? LIMIT 1');
+__PACKAGE__->set_sql(ready_fetch_ports => qq{
+      SELECT __ESSENTIAL__
+      FROM __TABLE__, port_phase_results
+      WHERE port_phase_results.port=__TABLE__.id
+        AND __TABLE__.run=?
+        AND port_phase_results.phase='fetch'
+        AND port_phase_results.status='untested'
+        AND NOT EXISTS (
+          SELECT 1 FROM locks
+          WHERE locks.port=__TABLE__.id AND locks.phase='fetch'
+        )
+      ORDER BY __TABLE__.name ASC
+  });
+__PACKAGE__->set_sql(ready_test_ports => qq{
+      SELECT __ESSENTIAL__
+      FROM __TABLE__, port_phase_results
+      WHERE port_phase_results.port=__TABLE__.id
+        AND __TABLE__.run=?
+        AND port_phase_results.phase='test'
+        AND port_phase_results.status='untested'
+        AND (__TABLE__.status='pass' OR __TABLE__.status='warn')
+        AND NOT EXISTS (
+          SELECT 1 FROM locks
+          WHERE locks.port=__TABLE__.id AND locks.phase='test'
+        )
+      ORDER BY __TABLE__.name ASC
+  });
+__PACKAGE__->set_sql(ready_scan_ports => qq{
+      SELECT __ESSENTIAL__
+      FROM __TABLE__, port_phase_results
+      WHERE port_phase_results.port=__TABLE__.id
+        AND __TABLE__.run=?
+        AND port_phase_results.phase='scan'
+        AND port_phase_results.status='untested'
+        AND (__TABLE__.status='pass' OR __TABLE__.status='warn')
+        AND NOT EXISTS (
+          SELECT 1 FROM locks
+          WHERE locks.port=__TABLE__.id AND locks.phase='scan'
+        )
+      ORDER BY __TABLE__.name ASC
+  });
 __PACKAGE__->set_sql(last_twenty => qq{
       SELECT __ESSENTIAL__
       FROM __TABLE__
@@ -85,8 +128,20 @@ All the port's depends are tested and unlocked.
 =cut
 
 sub get_ready_port {
-  my ($class, $run) = @_;
-  return shift->search_single_ready_port($run)->next;
+  my ($class, $run, $phase) = @_;
+  $phase ||= 'build';
+
+  return $class->search_single_ready_port($run)->next if $phase eq 'build';
+
+  my %search = (
+    fetch => 'search_ready_fetch_ports',
+    test  => 'search_ready_test_ports',
+    scan  => 'search_ready_scan_ports',
+  );
+
+  die "Unknown Magus phase: $phase\n" unless $search{$phase};
+  my $method = $search{$phase};
+  return $class->$method($run)->next;
 }
   
 
@@ -207,8 +262,9 @@ sub _set_result {
   
   $self->status($status);
   $self->update;
+  $self->set_phase_status(build => $status);
    
-  $self->note_event($type, $msg);
+  $self->note_event($type, $msg, build => 'Result');
 }
 
 =head2 $port->reset();
@@ -224,6 +280,15 @@ sub reset {
 
   if (my $log = Magus::Log->retrieve(port => $self)) {
     $log->delete;
+  }
+
+  $self->phase_logs->delete_all if $self->phase_logs;
+  foreach my $phase_result ($self->phase_results) {
+    $phase_result->status('untested');
+    $phase_result->machine(undef);
+    $phase_result->started(undef);
+    $phase_result->finished(undef);
+    $phase_result->update;
   }
 
   $self->status('untested');
@@ -258,6 +323,43 @@ sub log {
   return $self->{__log} = $log->data;
 }
 
+=head2 $port->phase_result($phase)
+
+Returns the result row for a phase, creating it if needed.
+
+=cut
+
+sub phase_result {
+  my ($self, $phase) = @_;
+
+  return Magus::PhaseResult->retrieve(port => $self, phase => $phase) || Magus::PhaseResult->insert({
+    port   => $self,
+    phase  => $phase,
+    status => 'untested',
+  });
+}
+
+sub phase_status {
+  my ($self, $phase) = @_;
+
+  my $result = $self->phase_result($phase);
+  return $result ? $result->status : 'untested';
+}
+
+sub set_phase_status {
+  my ($self, $phase, $status, $machine) = @_;
+
+  my $result = $self->phase_result($phase);
+  $result->set_status($status, $machine || $Magus::Machine);
+}
+
+sub phase_log {
+  my ($self, $phase) = @_;
+
+  my $log = Magus::PhaseLog->retrieve(port => $self, phase => $phase) or return;
+  return $log->data;
+}
+
 =head2 $port->note_event(type => $msg);
 
 Add an event to the port of the given type with the given message
@@ -265,11 +367,13 @@ Add an event to the port of the given type with the given message
 =cut
 
 sub note_event {
-  my ($self, $type, $msg) = @_;
+  my ($self, $type, $msg, $phase, $name) = @_;
   
   $self->add_to_events({
     machine => $Magus::Machine,
+    phase   => $phase,
     type    => $type,
+    name    => $name,
     msg     => $msg,
   });
 }

--- a/Tools/lib/Magus/PortTest.pm
+++ b/Tools/lib/Magus/PortTest.pm
@@ -107,7 +107,8 @@ $results = {
 =cut
 
 sub run {
-  my ($self) = @_;
+  my ($self, $phase) = @_;
+  $phase ||= 'build';
   
   $self->_set_env;
   $self->{chroot}->mark_dirty;
@@ -115,10 +116,9 @@ sub run {
   my %results = (summary => 'pass');
   
   $self->check_for_skip(\%results) && return \%results;
-  $self->check_master_sites(\%results);
+  $self->check_master_sites(\%results) if $phase eq 'build';
 
-  
-  foreach my $target (qw(fetch extract patch configure build fake package install deinstall reinstall test)) {
+  foreach my $target ($self->targets_for_phase($phase)) {
     if (!$self->_run_make($target)) {
       my $error_code = $? >> 8;
       push(@{$results{errors}}, {
@@ -167,6 +167,16 @@ sub run {
   }
   
   return \%results;
+}
+
+sub targets_for_phase {
+  my ($self, $phase) = @_;
+
+  return qw(fetch) if $phase eq 'fetch';
+  return qw(fetch extract patch configure build fake package) if $phase eq 'build';
+  return qw(test) if $phase eq 'test';
+
+  die "Unknown Magus phase: $phase\n";
 }
 
 
@@ -250,4 +260,3 @@ sub _set_env {
 
 1;
 __END__
-

--- a/Tools/lib/Magus/Run.pm
+++ b/Tools/lib/Magus/Run.pm
@@ -67,9 +67,9 @@ sub is_empty {
   my ($self) = @_;
   
   # if there is a locked port, then there may be new ports once this one is done.
-  return 0 if Magus::Lock->search_by_run($self)->count;
+  return 0 if Magus::Lock->search_by_run_and_phase($self, 'build')->count;
 
-  return Magus::Port->get_ready_port($self) ? 0 : 1;
+  return Magus::Port->get_ready_port($self, 'build') ? 0 : 1;
 }
 
 
@@ -102,4 +102,3 @@ sub tarballpath {
 
 1;
 __END__
-

--- a/Tools/magus/config.yaml.example
+++ b/Tools/magus/config.yaml.example
@@ -10,3 +10,10 @@ ChrootTarBall: /usr/magus/0.2-CURRENT-20070901.tar
 PkgfilesRoot: /usr/magus/packages
 DistfilesRoot: /usr/magus/distfiles
 PkgExtension: mport
+WorkerPhases:
+  - build
+  - fetch
+  - scan
+  - test
+ClamAVScanner: clamscan
+ClamAVOptions: --no-summary

--- a/Tools/magus/distcheck/distcheck.cxx
+++ b/Tools/magus/distcheck/distcheck.cxx
@@ -170,6 +170,9 @@ int main(int argc, char *argv[])
 				if (!fs::exists(dest))
 				{
 					try {
+						if (dest.has_parent_path()) {
+							fs::create_directories(dest.parent_path());
+						}
 						fs::copy_file(src, dest);
 						std::cout << "Copied source " << src << " to destination " << dest << std::endl;
 						copied_count++;

--- a/Tools/magus/master/delete_run.pl
+++ b/Tools/magus/master/delete_run.pl
@@ -7,6 +7,8 @@ use lib qw(/usr/mports/Tools/lib);
 use Magus;
 use Magus::Depend;
 use Magus::Log;
+use Magus::PhaseLog;
+use Magus::PhaseResult;
 
 #
 # Script to delete runs from the db with cascading deletes.
@@ -31,6 +33,8 @@ if (@run_ids) {
                     $port->events->delete_all if $port->events;
 
                     Magus::Log->search(port => $pid)->delete_all;
+                    Magus::PhaseLog->search(port => $pid)->delete_all;
+                    Magus::PhaseResult->search(port => $pid)->delete_all;
 
                     # remove depends where this port is the depender
                     Magus::Depend->search(port       => $port)->delete_all;

--- a/Tools/magus/phased-pipeline-plan.md
+++ b/Tools/magus/phased-pipeline-plan.md
@@ -1,0 +1,59 @@
+# Magus Phased Pipeline Refactor Plan
+
+## Summary
+
+Refactor Magus so package availability is driven by build/package success only,
+while fetch, test, and virus scan results are tracked independently. Keep
+`ports.status` as the build status for compatibility with `magus bless`, existing
+APIs, and current package publishing behavior.
+
+## Data Model
+
+- Add `port_phase_results` with one row per `(port, phase)` for `fetch`,
+  `build`, `test`, and `scan`.
+- Track per-phase `status`, `machine`, `started`, `finished`, and `updated`.
+- Add phase logs while keeping the existing `logs` table as the build log for
+  backward compatibility.
+- Make `locks` phase-aware with one lock per `(port, phase)`.
+- During index/import, create phase rows for each port. Ignored/internal/skipped
+  ports should have build marked accordingly and non-applicable phases marked
+  `skip`.
+
+## Pipeline Behavior
+
+- Fetch phase runs `bmake fetch` only, warms the distfile cache, preserves
+  distfile subdirectories, and does not gate builds.
+- Build phase runs `fetch extract patch configure build fake package`, writes
+  `ports.status`, and uploads packages/distfiles on `pass` or `warn`.
+- Test phase runs independently after build `pass` or `warn`, runs only
+  `bmake test`, and does not change `ports.status`.
+- Virus scan phase runs independently after build `pass` or `warn`, scans the
+  built package with configurable ClamAV tooling, and does not affect bless.
+
+## Scheduler And Completion
+
+- Add phase-aware ready selection for fetch, build, test, and scan.
+- Keep run completion based only on the build queue and build locks.
+- Add configurable worker phase selection so deployments can run dedicated
+  fetch/test/scan workers or mixed workers.
+- Default mixed-worker priority should favor package availability: `build`,
+  then `fetch`, then `scan`, then `test`.
+
+## Web And API
+
+- Keep existing `status` fields meaning build status.
+- Add separate fetch, test, and virus scan summaries on run and port pages.
+- Extend API responses with `fetch_status`, `test_status`, and `scan_status`.
+- Keep `magus bless`, latest package APIs, and package index generation
+  independent of test and virus scan phase results.
+
+## Validation
+
+- Run Perl syntax checks for modified Magus libraries, CGI scripts, and slave
+  scripts.
+- Validate schema changes where local tooling is available.
+- Build-check changed C++ helpers when touched.
+- Test distfile subdirectory preservation with staged filenames containing
+  subdirectories.
+- Verify build success makes a package blessable even if test or scan fails or
+  has not run.

--- a/Tools/magus/ready_ports.sql
+++ b/Tools/magus/ready_ports.sql
@@ -1,1 +1,30 @@
-ALTER ALGORITHM=UNDEFINED DEFINER=`ctriv`@`%` SQL SECURITY DEFINER VIEW `ready_ports` AS select `ports`.`id` AS `id`,`ports`.`run` AS `run`,`ports`.`name` AS `name`,`ports`.`pkgname` AS `pkgname`,`ports`.`version` AS `version`,`ports`.`description` AS `description`,`ports`.`license` AS `license`,`ports`.`www` AS `www`,`ports`.`status` AS `status`,`ports`.`updated` AS `updated`,(select count(0) AS `COUNT(*)` from `depends` where (`depends`.`dependency` = `ports`.`id`)) AS `priority` from `ports` where ((`ports`.`status` = _latin1'untested') and (not(`ports`.`id` in (select `locks`.`port` AS `port` from `locks` where (`locks`.`port` = `ports`.`id`)))) and ((not(`ports`.`id` in (select `depends`.`port` AS `port` from `depends` where (`depends`.`port` = `ports`.`id`)))) or (not(`ports`.`id` in (select `depends`.`port` AS `port` from `depends` where ((not(`depends`.`dependency` in (select `ports`.`id` AS `dep_id` from `ports` where ((`ports`.`id` = `depends`.`dependency`) and ((`ports`.`status` = _latin1'pass') or (`ports`.`status` = _latin1'warn')))))) or `depends`.`dependency` in (select `locks`.`port` AS `port` from `locks` where (`locks`.`port` = `ports`.`id`)))))))) order by (select count(0) AS `COUNT(*)` from `depends` where (`depends`.`dependency` = `ports`.`id`)) desc
+CREATE OR REPLACE VIEW ready_ports AS
+    SELECT ports.id AS id,
+           ports.run AS run,
+           ports.name AS name,
+           ports.pkgname AS pkgname,
+           ports.version AS version,
+           ports.description AS description,
+           ports.license AS license,
+           ports.www AS www,
+           ports.status AS status,
+           ports.updated AS updated,
+          (SELECT count(0) AS COUNT
+           FROM depends
+           WHERE depends.dependency = ports.id) AS priority
+    FROM ports
+    LEFT JOIN locks on locks.port = ports.id and locks.phase = 'build'
+    LEFT JOIN depends on depends.port = ports.id
+    WHERE ports.status = 'untested' and locks.id is null and
+          (depends.port is null or
+             not exists
+                  (SELECT depends.port AS port
+                   FROM depends WHERE ports.id = depends.port and not exists
+                     (SELECT ports.id as dep_id
+                      FROM ports
+                      WHERE ports.id = depends.dependency and (ports.status = 'pass' or ports.status = 'warn'))
+                      or exists
+                         (SELECT 1
+                          FROM locks dep_locks
+                          WHERE dep_locks.port = depends.dependency and dep_locks.phase = 'build')))
+ORDER BY priority desc, ports.name asc;

--- a/Tools/magus/ready_ports.sql
+++ b/Tools/magus/ready_ports.sql
@@ -19,12 +19,12 @@ CREATE OR REPLACE VIEW ready_ports AS
           (depends.port is null or
              not exists
                   (SELECT depends.port AS port
-                   FROM depends WHERE ports.id = depends.port and not exists
+                   FROM depends WHERE ports.id = depends.port and (not exists
                      (SELECT ports.id as dep_id
                       FROM ports
                       WHERE ports.id = depends.dependency and (ports.status = 'pass' or ports.status = 'warn'))
                       or exists
                          (SELECT 1
                           FROM locks dep_locks
-                          WHERE dep_locks.port = depends.dependency and dep_locks.phase = 'build')))
+                          WHERE dep_locks.port = depends.dependency and dep_locks.phase = 'build'))))
 ORDER BY priority desc, ports.name asc;

--- a/Tools/magus/schema.sql
+++ b/Tools/magus/schema.sql
@@ -45,9 +45,11 @@ CREATE TABLE  "events" (
    "name"   varchar(128), 
    "msg"   text, 
    "machine"   int NOT NULL, 
+   "time" timestamp NOT NULL default CURRENT_TIMESTAMP,
    primary key ("id")
 )  ;
 CREATE INDEX "events_port_idx" ON "events" USING btree ("port");
+CREATE INDEX "events_port_phase_idx" ON "events" USING btree ("port", "phase");
 
 --
 -- Table structure for table locks
@@ -61,9 +63,10 @@ CREATE SEQUENCE "locks_id_seq" ;
 CREATE TABLE  "locks" (
    "id" integer DEFAULT nextval('"locks_id_seq"') NOT NULL,
    "port"   int NOT NULL, 
+   "phase"   varchar(16) NOT NULL default 'build',
    "machine"   int NOT NULL, 
    primary key ("id"),
- unique ("port") 
+ unique ("port", "phase")
 )  ;
 
 --
@@ -82,6 +85,25 @@ CREATE TABLE  "logs" (
    primary key ("id"),
    "unique"   KEY (port) 
 )  ;
+
+--
+-- Table structure for table phase_logs
+--
+
+DROP TABLE "phase_logs" CASCADE\g
+DROP SEQUENCE "phase_logs_id_seq" CASCADE ;
+
+CREATE SEQUENCE "phase_logs_id_seq" ;
+
+CREATE TABLE  "phase_logs" (
+   "id" integer DEFAULT nextval('"phase_logs_id_seq"') NOT NULL,
+   "port"   int NOT NULL,
+   "phase"   varchar(16) NOT NULL,
+   "data"   text,
+   primary key ("id"),
+ unique ("port", "phase")
+)  ;
+CREATE INDEX "phase_logs_port_phase_idx" ON "phase_logs" USING btree ("port", "phase");
 
 --
 -- Table structure for table machines
@@ -166,6 +188,31 @@ update_ports();
 CREATE INDEX "ports_run_idx" ON "ports" USING btree ("run");
 CREATE INDEX "ports_name_idx" ON "ports" USING btree ("name");
 CREATE INDEX ports_run_status_pkgname_version_idx ON ports (run, status, pkgname, version);
+
+--
+-- Table structure for table port_phase_results
+--
+
+DROP TABLE "port_phase_results" CASCADE\g
+DROP SEQUENCE "port_phase_results_id_seq" CASCADE ;
+
+CREATE SEQUENCE "port_phase_results_id_seq" ;
+
+CREATE TABLE "port_phase_results"
+(
+    "id"       integer DEFAULT nextval('"port_phase_results_id_seq"') NOT NULL,
+    "port"     int                                                   NOT NULL,
+    "phase"    varchar(16)                                           NOT NULL,
+    "status"   varchar(32)                                           NOT NULL default 'untested',
+    "machine"  int,
+    "started"  timestamp,
+    "finished" timestamp,
+    "updated"  timestamp NOT NULL default CURRENT_TIMESTAMP,
+    primary key ("id"),
+ unique ("port", "phase")
+);
+CREATE INDEX "phase_results_phase_status_idx" ON "port_phase_results" USING btree ("phase", "status");
+CREATE INDEX "phase_results_port_phase_idx" ON "port_phase_results" USING btree ("port", "phase");
 
 --
 -- Temporary table structure for view ready_ports
@@ -298,7 +345,7 @@ create VIEW ready_ports AS
            FROM depends
            WHERE depends.dependency = ports.id) AS priority
     FROM ports
-    LEFT JOIN locks on locks.port = ports.id
+    LEFT JOIN locks on locks.port = ports.id and locks.phase = 'build'
     LEFT JOIN depends on depends.port = ports.id
     WHERE ports.status = 'untested' and locks.id is null and
           (depends.port is null or
@@ -309,7 +356,7 @@ create VIEW ready_ports AS
                       FROM ports
                       WHERE ports.id = depends.dependency and (ports.status = 'pass' or ports.status = 'warn'))
                       or
-    depends.dependency = locks.port))
+    exists (select 1 from locks dep_locks where dep_locks.port = depends.dependency and dep_locks.phase = 'build')))
 ORDER BY priority desc, ports.name asc;
 
 DROP TABLE "critical_ports" CASCADE\g
@@ -327,6 +374,7 @@ CREATE TABLE  "critical_ports" (
 alter table ports add foreign key (run) references runs(id);
 alter table port_categories add foreign key (category) references categories(id);
 alter table locks add foreign key (port) references ports(id);
+alter table locks add foreign key ("machine") references machines("id");
 alter table distfiles add foreign key (port) references ports(id);
 alter table restricted_distfiles add foreign key (port) references ports(id);
 alter table master_sites add foreign key (port) references ports(id);
@@ -337,6 +385,9 @@ ALTER TABLE "depends" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");
 ALTER TABLE "depends" ADD FOREIGN KEY ("dependency") REFERENCES "ports"("id");
 ALTER TABLE "port_license_perms" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");
 ALTER TABLE "logs" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");
+ALTER TABLE "phase_logs" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");
+ALTER TABLE "port_phase_results" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");
+ALTER TABLE "port_phase_results" ADD FOREIGN KEY ("machine") REFERENCES machines("id");
 
 create table mirrors
 (

--- a/Tools/magus/schema.sql
+++ b/Tools/magus/schema.sql
@@ -351,12 +351,13 @@ create VIEW ready_ports AS
           (depends.port is null or
              not exists
                   (SELECT depends.port AS port
-                   FROM depends WHERE ports.id = depends.port and not exists  
+                   FROM depends WHERE ports.id = depends.port and (not exists
                      (SELECT ports.id as dep_id
                       FROM ports
                       WHERE ports.id = depends.dependency and (ports.status = 'pass' or ports.status = 'warn'))
                       or
     exists (select 1 from locks dep_locks where dep_locks.port = depends.dependency and dep_locks.phase = 'build')))
+          )
 ORDER BY priority desc, ports.name asc;
 
 DROP TABLE "critical_ports" CASCADE\g

--- a/Tools/magus/slave/magus.pl
+++ b/Tools/magus/slave/magus.pl
@@ -176,7 +176,7 @@ sub main {
       if (!$run || !($lock = Magus::Lock->get_ready_lock($run))) {
         # there's no more ports to test, sleep for a while and check again.
         X();
-        $Logger->debug("No ports to build, sleeping $Magus::Config{DoneWaitPeriod} seconds.");
+        $Logger->debug("No Magus phase work available, sleeping $Magus::Config{DoneWaitPeriod} seconds.");
         sleep($Magus::Config{DoneWaitPeriod});
         next MAIN;
       }
@@ -215,7 +215,7 @@ sub start_child {
   my $pid = fork;
   
   if ($pid) {
-    $Logger->info("Forked child worker $pid");
+    $Logger->info("Forked child worker $pid for %s phase", $lock->phase);
   
     # parent return
     $Children{$pid} = { lock => $lock, worker_id => $worker_id };
@@ -273,8 +273,13 @@ sub process_dead_children {
     my $corpse = $DeadChildren[0];
 
     if ($corpse->{exitcode} == 6) {
-      $Logger->info("Child $corpse->{pid} lost database connection.  Reseting %s", $corpse->{lock}->port);
-      $corpse->{lock}->port->reset;
+      my $phase = $corpse->{lock}->phase || 'build';
+      $Logger->info("Child $corpse->{pid} lost database connection.  Reseting %s phase for %s", $phase, $corpse->{lock}->port);
+      if ($phase eq 'build') {
+        $corpse->{lock}->port->reset;
+      } else {
+        $corpse->{lock}->port->set_phase_status($phase, 'untested');
+      }
     } 
     
     $corpse->{lock}->delete;

--- a/Tools/magus/www/data/magus/auth/mcp.cgi
+++ b/Tools/magus/www/data/magus/auth/mcp.cgi
@@ -1218,6 +1218,10 @@ sub tool_get_port_details($id, $args) {
     $text .= sprintf("  pkgname:     %s\n",   $port->pkgname);
     $text .= sprintf("  version:     %s\n",   $port->version  // '');
     $text .= sprintf("  status:      %s\n",   $port->status);
+    $text .= sprintf("  fetch:       %s\n",   $port->phase_status('fetch'));
+    $text .= sprintf("  build:       %s\n",   $port->status);
+    $text .= sprintf("  test:        %s\n",   $port->phase_status('test'));
+    $text .= sprintf("  scan:        %s\n",   $port->phase_status('scan'));
     $text .= sprintf("  flavor:      %s\n",   $port->flavor   // '');
     $text .= sprintf("  arch:        %s\n",   $run->arch);
     $text .= sprintf("  osversion:   %s\n",   $run->osversion);
@@ -1230,19 +1234,19 @@ sub tool_get_port_details($id, $args) {
     my $dbh = Magus::DBI->db_Main();
 
     # Build events (failures, warnings, info messages) using direct SQL
-    my $sth_events = $dbh->prepare("SELECT time, type, msg FROM events WHERE port = ? ORDER BY time");
+    my $sth_events = $dbh->prepare("SELECT time, phase, type, msg FROM events WHERE port = ? ORDER BY time");
     $sth_events->execute($port_id);
     my $events = $sth_events->fetchall_arrayref({});
     $sth_events->finish;
 
     if (@$events) {
-        $text .= "\nBuild events:\n";
+        $text .= "\nEvents:\n";
         for my $ev (@$events) {
-            $text .= sprintf("  [%s] type=%-10s  %s\n",
-                $ev->{time} // '?', $ev->{type} // '?', $ev->{msg} // '');
+            $text .= sprintf("  [%s] phase=%-6s type=%-10s  %s\n",
+                $ev->{time} // '?', $ev->{phase} // 'build', $ev->{type} // '?', $ev->{msg} // '');
         }
     } else {
-        $text .= "\nNo build events recorded.\n";
+        $text .= "\nNo events recorded.\n";
     }
 
     # Direct dependencies using direct SQL

--- a/Tools/magus/www/data/magus/index.cgi
+++ b/Tools/magus/www/data/magus/index.cgi
@@ -656,10 +656,11 @@ sub port_page {
     $tmpl->param(log => $port->log);
   }
 
-  my @phase_logs = map {{
-    phase => $_,
-    data  => $port->phase_log($_),
-  }} grep { defined $port->phase_log($_) } qw(fetch test scan);
+  my @phase_logs;
+  for my $phase (Magus::Phase->nonbuild_names) {
+    my $data = $port->phase_log($phase);
+    push @phase_logs, { phase => $phase, data => $data } if defined $data;
+  }
 
   $tmpl->param(phase_logs => \@phase_logs) if @phase_logs;
   

--- a/Tools/magus/www/data/magus/index.cgi
+++ b/Tools/magus/www/data/magus/index.cgi
@@ -117,6 +117,15 @@ sub main {
   }
 }
 
+sub phase_status_fields($port) {
+  return (
+    fetch_status => $port->phase_status('fetch'),
+    build_status => $port->status,
+    test_status  => $port->phase_status('test'),
+    scan_status  => $port->phase_status('scan'),
+  );
+}
+
 sub is_number {
   my $num = shift;
   return looks_like_number($num) && $num !~ /inf|nan/i;
@@ -174,7 +183,8 @@ sub api_run_port_stats {
     description => $port->description,
     license => $port->license,
     www => $port->www,
-    cpe => $port->cpe
+    cpe => $port->cpe,
+    phase_status_fields($port),
      });
   }
       
@@ -407,6 +417,7 @@ sub summary_page {
   my @locks = map {{
     port       => $_->port->name,
     port_id    => $_->port->id,
+    phase      => $_->phase,
     machine    => $_->machine->name,
     machine_id => $_->machine->id,
     arch       => $_->port->run->arch,
@@ -510,6 +521,19 @@ sub run_page {
   push(@$status_stats, { status => 'ready', count => Magus::Port->search_ready_ports($run)->count });
   $tmpl->param(status_stats => $status_stats);
 
+  my $phase_sth = $dbh->prepare("
+    SELECT phase, status, COUNT(*) AS count
+    FROM port_phase_results
+    INNER JOIN ports ON port_phase_results.port = ports.id
+    WHERE ports.run=?
+    GROUP BY phase, status
+    ORDER BY phase, status
+  ");
+  $phase_sth->execute($run->id);
+  my $phase_stats = $phase_sth->fetchall_arrayref({});
+  $phase_sth->finish;
+  $tmpl->param(phase_stats => $phase_stats);
+
   my $sth2 = $dbh->prepare("WITH hourly_events AS (
     SELECT
         DATE_TRUNC('hour', events.time) AS hour,
@@ -574,6 +598,7 @@ sub port_page {
     osversion => $port->run->osversion,
     arch      => $port->run->arch,
     status    => $port->status,
+    phase_status_fields($port),
     license   => $port->license,
     restricted => $port->restricted,
     can_reset => $port->can_reset? 1 : 0,
@@ -592,6 +617,7 @@ sub port_page {
       machine_id => $machine_obj ? $machine_obj->id : undef,
           machine    => $machine_obj ? $machine_obj->name : undef,
           type       => $event_obj->type,
+          phase      => $event_obj->phase,
           msg        => $event_obj->msg,
           time       => $event_obj->time,
     }
@@ -629,6 +655,13 @@ sub port_page {
   if ($port->log) {
     $tmpl->param(log => $port->log);
   }
+
+  my @phase_logs = map {{
+    phase => $_,
+    data  => $port->phase_log($_),
+  }} grep { defined $port->phase_log($_) } qw(fetch test scan);
+
+  $tmpl->param(phase_logs => \@phase_logs) if @phase_logs;
   
   if (@depends_of) {
     $tmpl->param(depends_of => \@depends_of);
@@ -761,6 +794,7 @@ sub search {
   
   my @results = map {{
     summary   => $_->status,
+    phase_status_fields($_),
     port      => $_->name,
     flavor    => $_->flavor,
     pkgname   => $_->pkgname,
@@ -838,6 +872,7 @@ sub async_run_port_stats {
   
   my @results = map {{
     summary   => $_->status,
+    phase_status_fields($_),
     port      => $_->name,
     flavor    => $_->flavor,
     pkgname   => $_->pkgname,

--- a/Tools/magus/www/tmpls/index.tmpl
+++ b/Tools/magus/www/tmpls/index.tmpl
@@ -66,6 +66,7 @@
 <thead>
 <tr>
 	<th>Port</th>
+	<th>Phase</th>
 	<th>Machine</th>
 	<th>Arch</th>
 	<th>OSVersion</th>
@@ -78,6 +79,7 @@
 <tr>
 	<td>(<a onclick="return confirm_reset()" href="/magus/auth/delete_lock.cgi?id=<TMPL_VAR NAME=id>">X</a>)
 	     <a href="<TMPL_VAR name=port_root>/<TMPL_VAR NAME=port_id>"><TMPL_VAR NAME="port"></a></td>
+	<td><TMPL_VAR NAME="phase"></td>
 	<td><a href="<TMPL_VAR NAME="machine_root">/<TMPL_VAR NAME="machine_id">"><TMPL_VAR NAME="machine"></a></td>
 	<td><TMPL_VAR name="arch"></td>
 	<td><TMPL_VAR NAME="osversion"></td>

--- a/Tools/magus/www/tmpls/port-list.tmpl
+++ b/Tools/magus/www/tmpls/port-list.tmpl
@@ -5,7 +5,10 @@
                 <th>Flavor</th>
 		<th>Version</th>
                 <th>Package Name</th>
-		<th>Status</th>
+		<th>Build</th>
+		<th>Fetch</th>
+		<th>Test</th>
+		<th>Scan</th>
 		<th>Run</th>
 		<th>OSVersion</th>
 		<th>Arch</th>
@@ -21,6 +24,9 @@
 		<td><TMPL_VAR NAME=version></td>
 		<td><TMPL_VAR NAME=pkgname></td>
 		<td><TMPL_VAR NAME=summary></td>
+		<td><TMPL_VAR NAME=fetch_status></td>
+		<td><TMPL_VAR NAME=test_status></td>
+		<td><TMPL_VAR NAME=scan_status></td>
 		<td><a href="<TMPL_VAR NAME="run_root">/<TMPL_VAR NAME="run">"><TMPL_VAR NAME=run></a></td>
 		<td><TMPL_VAR NAME=osversion></td>
 		<td><TMPL_VAR NAME=arch></td>
@@ -33,10 +39,9 @@
         	</td>
         </tr>
         <tr class="details" id="result_<TMPL_VAR NAME=id>_row">
-        	<td colspan="6" id="result_<TMPL_VAR NAME=id>_details"></td>
+		<td colspan="12" id="result_<TMPL_VAR NAME=id>_details"></td>
         </tr>
                 
 	</TMPL_LOOP>
     </tbody>
 </table>
-

--- a/Tools/magus/www/tmpls/port.tmpl
+++ b/Tools/magus/www/tmpls/port.tmpl
@@ -16,7 +16,10 @@
         <th>Arch</th>
         <th>License</th>
         <th>Restricted</th>
-        <th>Status</th>
+        <th>Build</th>
+        <th>Fetch</th>
+        <th>Test</th>
+        <th>Scan</th>
         <th></th>
     </tr>
     </thead>
@@ -30,6 +33,9 @@
         <td><TMPL_IF NAME="license"><TMPL_VAR NAME="license"><TMPL_ELSE><em>No License</em></TMPL_IF></td>
         <td><TMPL_VAR NAME="restricted"></td>
         <td><TMPL_VAR NAME="status"></td>
+        <td><TMPL_VAR NAME="fetch_status"></td>
+        <td><TMPL_VAR NAME="test_status"></td>
+        <td><TMPL_VAR NAME="scan_status"></td>
         <td>
           <TMPL_IF NAME="can_reset">
             <a class="btn btn-danger" onclick="return confirm_reset()" href="/magus/auth/reset_port.cgi?id=<TMPL_VAR NAME=id>&tm=<TMPL_VAR NAME=tm>">Reset Port</a>
@@ -50,6 +56,7 @@
 <thead>
 <tr>
         <th>Machine</th>
+        <th>Phase</th>
         <th>Type</th>
         <th>Time</th>
         <th>Message</th>
@@ -60,6 +67,7 @@
 <TMPL_LOOP name="events">
 <tr class="<TMPL_IF NAME=fail>error</TMPL_IF> <TMPL_IF NAME=pass>success</TMPL_IF> <TMPL_IF NAME=warn>warning</TMPL_IF> <TMPL_VAR NAME=type>">
         <td><a href="<TMPL_VAR NAME="machine_root">/<TMPL_VAR NAME="machine_id">"><TMPL_VAR NAME="machine"></a></td>
+        <td><TMPL_VAR NAME="phase"></td>
         <td><TMPL_VAR NAME="type"></td>
         <td style="white-space: nowrap; font-size: smaller"><TMPL_VAR NAME="time"></td>
         <td><TMPL_VAR NAME="msg"></td>
@@ -72,8 +80,14 @@
 
     <section>
       <TMPL_IF NAME="log">
-      <h3>Log</h3>
+      <h3>Build Log</h3>
       <pre class="log"><TMPL_VAR NAME="log"></pre>
+      </TMPL_IF>
+      <TMPL_IF NAME="phase_logs">
+      <TMPL_LOOP NAME="phase_logs">
+      <h3><TMPL_VAR NAME="phase"> Log</h3>
+      <pre class="log"><TMPL_VAR NAME="data"></pre>
+      </TMPL_LOOP>
       </TMPL_IF>
     </section>
 </div>

--- a/Tools/magus/www/tmpls/run.tmpl
+++ b/Tools/magus/www/tmpls/run.tmpl
@@ -57,6 +57,21 @@
 	    </ul>
 	</td>
 </tr>
+<TMPL_IF NAME="phase_stats">
+<tr>
+	<td colspan="7">
+	    <strong>Phase Results</strong>
+	    <ul class="stats">
+	      <TMPL_LOOP NAME="phase_stats">
+		<li>
+		    <TMPL_VAR NAME="phase"> / <span class="<TMPL_VAR NAME="status">"><TMPL_VAR NAME="status"></span>:
+		    <TMPL_VAR NAME="count">
+		</li>
+              </TMPL_LOOP>
+	    </ul>
+	</td>
+</tr>
+</TMPL_IF>
 <tr>
 	<td colspan="7" id="events-display"> </td>
 </tr>
@@ -77,4 +92,3 @@
                 }
         };
 </script>
-

--- a/ports-mgmt/magus-utils/Makefile
+++ b/ports-mgmt/magus-utils/Makefile
@@ -15,6 +15,7 @@ RUN_DEPENDS=	p5-DBD-Pg>=0:databases/p5-DBD-Pg \
 		p5-Class-Accessor>=0:devel/p5-Class-Accessor \
 		p5-BSD-Resource>=0:devel/p5-BSD-Resource \
 		p5-Module-CoreList>=0:devel/p5-Module-CoreList \
+		clamscan:security/clamav \
 		git:devel/git
 
 USES=		perl5 pgsql:14


### PR DESCRIPTION
## Summary
- split Magus work into independent fetch, build, test, and virus scan phases
- keep ports.status as the build/package status so magus bless ignores test and scan results
- add phase-aware locks, phase result/log tables, slave scheduling, web/API phase display, and ClamAV scanner configuration
- add ClamAV to ports-mgmt/magus-utils for slave node installs

## Validation
- git diff --check
- targeted Perl syntax checks for modified Magus modules and CGI/slave scripts with DB/config stubs where needed
- bmake in Tools/magus/distcheck
- distfile path normalization probe for grouped/query/subdirectory/unsafe paths

## Notes
- schema/runtime database load was not verified locally because no PostgreSQL server was listening on /tmp/.s.PGSQL.5432 during development
- unrelated untracked files are present in the local worktree and were not included in this branch

## Summary by Sourcery

Refactor Magus to support phase-aware fetch, build, test, and virus scan pipelines while preserving build status semantics, with corresponding scheduler, database, web/API, and slave worker updates.

New Features:
- Introduce per-phase results and logs for fetch, build, test, and scan, including ClamAV-based virus scanning of built packages.
- Expose per-phase status and logs via the web UI, APIs, and CLI tooling while keeping overall port status as the build result.
- Allow workers to be configured to process specific phases and schedule ports per phase independently of the main build pipeline.

Bug Fixes:
- Normalize and validate distfile paths to safely handle grouped, query-string, and subdirectory filenames, creating necessary directories before copying.

Enhancements:
- Make locks phase-aware and adjust ready-port selection, dependency handling, and run-emptiness checks to operate on build vs non-build phases correctly.
- Extend schema, indices, and foreign keys to support per-phase results, logs, timestamps, and machine attribution without changing existing logs semantics.
- Refine event recording to include phase and structured names, and update log handling so build logs remain backward compatible while additional phase logs are tracked separately.
- Update distfile handling and helper tools to preserve directory structure when copying into cache locations.

Build:
- Add ClamAV as a runtime dependency to magus-utils for virus scanning support.

Documentation:
- Document the phased pipeline design and behavior in a new Magus phased pipeline refactor plan.

Tests:
- Enhance the distcheck helper to validate that distfiles with subdirectory paths are copied correctly.