### PR TITLE
mail/roundcube: update to 1.6.16

### DIFF
--- a/mail/roundcube/Makefile
+++ b/mail/roundcube/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	roundcube
-DISTVERSION=	1.6.13
+DISTVERSION=	1.6.16
 PORTEPOCH=	1
 CATEGORIES?=	mail www
 MASTER_SITES=	https://github.com/roundcube/roundcubemail/releases/download/${DISTVERSION}/

--- a/mail/roundcube/distinfo
+++ b/mail/roundcube/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1771866156
-SHA256 (roundcubemail-1.6.13-complete.tar.gz) = bdd1bafe79149a6b63f699fa94e7626189ec60e2c37954de7e84ee685dbbf5bb
-SIZE (roundcubemail-1.6.13-complete.tar.gz) = 5841171
+TIMESTAMP = 1780514948
+SHA256 (roundcubemail-1.6.16-complete.tar.gz) = 554f88f642d2d709916e9fd674239a83189a956e7258ce72a1d927c84ecd7e1a
+SIZE (roundcubemail-1.6.16-complete.tar.gz) = 5879804


### PR DESCRIPTION
Updates `mail/roundcube` from 1.6.13 to 1.6.16 on the current 1.6 LTS branch and refreshes `distinfo`.

Roundcube 1.6.16 is the latest 1.6.x security release and includes fixes for recently reported vulnerabilities.

Validation run:
- `bmake makesum`
- `bmake patch`
- `bmake fake`
- `bmake package`
- `bmake test`
- `portlint -C` (0 fatal errors; existing style warnings remain)

## Summary by Sourcery

Update the Roundcube mail port to the latest 1.6.x security release.

New Features:
- Provide the Roundcube 1.6.16 release in place of 1.6.13.

Bug Fixes:
- Pull in upstream security and bug fixes included in Roundcube 1.6.16.

Build:
- Refresh distinfo to match the new Roundcube 1.6.16 distribution archive.