### PR TITLE
textproc/iso8879: Fix build failure by using USES=zip

### DIFF
--- a/textproc/iso8879/Makefile
+++ b/textproc/iso8879/Makefile
@@ -5,7 +5,6 @@ CATEGORIES=	textproc
 MASTER_SITES=	${MASTER_SITE_FREEBSD_LOCAL}
 MASTER_SITE_SUBDIR=	kuriyama
 DISTNAME=	isoENTS
-EXTRACT_SUFX=	.zip
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Character entity sets from ISO 8879:1986 (SGML)
@@ -15,26 +14,21 @@ LICENSE_NAME=	ISO 8879 character entity sets
 LICENSE_TEXT=	Permission to copy in any form is granted for use with conforming SGML systems and applications as defined in ISO 8879, provided this notice is included in all copies.
 LICENSE_PERMS=	auto-accept dist-mirror pkg-mirror
 
-BUILD_DEPENDS=	unzip:${PORTSDIR}/archivers/unzip
-RUN_DEPENDS=	${XMLCATMGR}:${PORTSDIR}/textproc/xmlcatmgr
+RUN_DEPENDS=	${XMLCATMGR}:textproc/xmlcatmgr
 
-EXTRACT_ONLY=	# empty
+USES=		zip
 NO_BUILD=	yes
 NO_WRKSUBDIR=	yes
-PLIST_SUB=	DTD_NAME=${PORTNAME} XMLCATMGR=${XMLCATMGR}
-PLIST_SUB+=	CATALOG_PORTS_SGML=${CATALOG_PORTS_SGML}
+PLIST_SUB=	DTD_NAME=${PORTNAME} XMLCATMGR=${XMLCATMGR} \
+		CATALOG_PORTS_SGML=${CATALOG_PORTS_SGML}
 
 INSTDIR=	${PREFIX}/share/sgml/iso8879
 XMLCATMGR=	${LOCALBASE}/bin/xmlcatmgr
 CATALOG_PORTS_SGML=	${PREFIX}/share/sgml/catalog.ports
 
-pre-install:
-	@[ -d ${INSTDIR} ] || ${MKDIR} ${INSTDIR}
-
 do-install:
-	${UNZIP_CMD} -a -q -o ${DISTDIR}/${DISTFILES} -d ${INSTDIR}
+	${MKDIR} ${INSTDIR}
+	${INSTALL_DATA} ${WRKSRC}/ISO* ${INSTDIR}
 	${INSTALL_DATA} ${FILESDIR}/catalog ${INSTDIR}/catalog
-	${CHMOD} ${SHAREMODE} ${INSTDIR}/*
-	${CHOWN} -R ${SHAREOWN}:${SHAREGRP} ${INSTDIR}
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Modernize the port by using USES=zip which utilizes the native unzip command. This fixes a build failure where /usr/local/bin/unzip was missing during the fake stage because it was only listed in BUILD_DEPENDS and the port used NO_BUILD=yes.

Also simplify the do-install target by using standard INSTALL_DATA and removing redundant pre-install target.

AI-Assisted-by: Gemini CLI <gemini-cli@google.com>

## Summary by Sourcery

Modernize the iso8879 port to use the standard zip framework and simplify installation while fixing a missing unzip build-time dependency.

Bug Fixes:
- Resolve build failures by switching from an explicit unzip BUILD_DEPENDS to USES=zip, relying on the base system unzip.

Enhancements:
- Simplify the iso8879 port Makefile by using standard INSTALL_DATA, consolidating PLIST substitutions, and removing the custom pre-install logic.