### PR TITLE
Fix key name for Claude Code Review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: anthropics/claude-code-action@beta
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: |
             You are reviewing a pull request for the MidnightBSD mports ports tree.
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Correct the input parameter name for the Claude code review GitHub Action to use the claude_code_oauth_token secret.