### PR TITLE
Fix ruby33 package and test build

### DIFF
--- a/lang/ruby33/Makefile
+++ b/lang/ruby33/Makefile
@@ -31,6 +31,7 @@ USE_LDCONFIG=	yes
 
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS=	${RUBY_CONFIGURE_ARGS} \
+		--disable-dtrace \
 		--disable-rpath \
 		--enable-install-static-library \
 		--enable-pthread \
@@ -219,7 +220,6 @@ post-install-DOCS-on:
 .endfor
 	@(cd ${WRKSRC}/doc/ && ${COPYTREE_SHARE} \* ${FAKE_DESTDIR}${RUBY_DOCDIR}/)
 	${INSTALL_DATA} ${WRKSRC}/COPYING*	\
-			${WRKSRC}/ChangeLog	\
 			${WRKSRC}/LEGAL		\
 			${WRKSRC}/README*	\
 			${FAKE_DESTDIR}${RUBY_DOCDIR}/


### PR DESCRIPTION
## Summary
- disable Ruby DTrace probes so the upstream leaked-symbol test passes on MidnightBSD
- stop installing Ruby 3.3's ChangeLog directory as a plain DOCS file

## Validation
- bmake -C lang/ruby33 package
- bmake -C lang/ruby33 test
- bmake -C lang/ruby33 check-license
- portlint -C lang/ruby33: 0 fatal errors, 9 warnings

## Summary by Sourcery

Disable Ruby 3.3 DTrace support and adjust installed documentation to fix the MidnightBSD ruby33 package and test builds.

Bug Fixes:
- Disable Ruby DTrace probes in the ruby33 port to resolve upstream leaked-symbol test failures on MidnightBSD.
- Stop installing Ruby 3.3's ChangeLog file as a DOCS entry to correct the packaging of documentation.