### PR TITLE
graphics/drm-515-kmod: new port (Linux 5.15 DRM drivers)

### DIFF
--- a/graphics/drm-515-kmod/Makefile
+++ b/graphics/drm-515-kmod/Makefile
@@ -1,0 +1,55 @@
+PORTNAME=	drm-515-kmod
+PORTVERSION=	${DRM_KMOD_DISTVERSION}
+PORTREVISION=	9
+CATEGORIES=	graphics
+
+.include "Makefile.version"
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	DRM drivers modules
+WWW=		https://github.com/freebsd/drm-kmod/
+
+LICENSE=	bsd2 mit gpl
+LICENSE_COMB=	multi
+
+ONLY_FOR_ARCHS=	aarch64 amd64 i386 powerpc64 powerpc64le
+ONLY_FOR_ARCHS_REASON=	the new KMS components are only supported on amd64, i386, aarch64, and powerpc64
+
+FAKE_OPTS=	trueprefix
+
+CONFLICTS_INSTALL=	drm-510-kmod \
+			drm-61-kmod
+
+USES=		kmod uidfix compiler:c++11-lang
+
+USE_GITHUB=	yes
+GH_ACCOUNT=	freebsd
+GH_PROJECT=	drm-kmod
+GH_TAGNAME=	${DRM_KMOD_GH_TAGNAME}
+
+.include <bsd.mport.options.mk>
+
+IGNORE_MidnightBSD_3.2=	Needs 4.x or higher
+IGNORE_MidnightBSD_3.1=	Needs 4.x or higher
+
+.if ${ARCH} == "amd64"
+PLIST_SUB+=	AMDGPU=""
+PLIST_SUB+=	I915=""
+.elif ${ARCH} == "i386"
+PLIST_SUB+=	AMDGPU="@comment "
+PLIST_SUB+=	I915=""
+.elif ${ARCH} == "aarch64" || ${ARCH:Mpowerpc*}
+PLIST_SUB+=	AMDGPU=""
+PLIST_SUB+=	I915="@comment "
+.else
+PLIST_SUB+=	AMDGPU="@comment "
+PLIST_SUB+=	I915="@comment "
+.endif
+
+MAKE_ENV+=	MAKEOBJDIRPREFIX=${WRKSRC}/obj
+
+pre-build:
+		${MKDIR} ${WRKSRC}/obj
+		(cd ${WRKSRC} ; ${SETENV} ${MAKE_ENV} ${MAKE_CMD} obj)
+
+.include <bsd.port.mk>

--- a/graphics/drm-515-kmod/Makefile.version
+++ b/graphics/drm-515-kmod/Makefile.version
@@ -1,0 +1,5 @@
+# drm-kmod common version definition
+#
+# This will be included from consumers such as nvidia-drm
+DRM_KMOD_DISTVERSION=	5.15.160
+DRM_KMOD_GH_TAGNAME=	drm_v5.15.160_6

--- a/graphics/drm-515-kmod/distinfo
+++ b/graphics/drm-515-kmod/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1760982913
+SHA256 (freebsd-drm-kmod-5.15.160-drm_v5.15.160_6_GH0.tar.gz) = e21962b06c5c4740a165fbb36a1c15107a4c6ccba50ca08df4fb1c9368645ce6
+SIZE (freebsd-drm-kmod-5.15.160-drm_v5.15.160_6_GH0.tar.gz) = 26099109

--- a/graphics/drm-515-kmod/files/patch-drivers_dma-buf_dma-buf.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_dma-buf_dma-buf.c
@@ -1,0 +1,11 @@
+--- drivers/dma-buf/dma-buf.c.orig	2026-06-11 16:12:56.973401000 -0400
++++ drivers/dma-buf/dma-buf.c	2026-06-11 16:12:56.987856000 -0400
+@@ -125,7 +125,7 @@
+ 
+ static int
+ dma_buf_stat(struct file *fp, struct stat *sb,
+-	     struct ucred *active_cred __unused)
++	     struct ucred *active_cred __unused, struct thread *td __unused)
+ {
+ 
+ 	/* XXX need to define flags for st_mode */

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_i915_gem_i915__gem__shmem.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_i915_gem_i915__gem__shmem.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/i915/gem/i915_gem_shmem.c.orig	2026-06-11 16:40:32.692159000 -0400
++++ drivers/gpu/drm/i915/gem/i915_gem_shmem.c	2026-06-11 16:40:32.695544000 -0400
+@@ -14,7 +14,7 @@
+ #include "i915_scatterlist.h"
+ #include "i915_trace.h"
+ 
+-#if !defined(__FreeBSD_version) || __FreeBSD_version < 1400080
++#if (!defined(__FreeBSD_version) || __FreeBSD_version < 1400080) && !defined(__MidnightBSD_version)
+ static inline unsigned long totalram_pages(void) { return physmem; }
+ #endif
+ 

--- a/graphics/drm-515-kmod/pkg-descr
+++ b/graphics/drm-515-kmod/pkg-descr
@@ -1,0 +1,3 @@
+amdgpu, i915, and radeon DRM drivers modules.
+Currently corresponding to Linux 5.15 DRM.
+This version is for FreeBSD 14 / MidnightBSD 4 and above.

--- a/graphics/drm-515-kmod/pkg-message
+++ b/graphics/drm-515-kmod/pkg-message
@@ -1,0 +1,18 @@
+[
+{ type: install
+  message: <<EOM
+The drm-515-kmod port can be enabled for amdgpu (for AMD
+GPUs starting with the HD7000 series / Tahiti) or i915kms (for Intel
+APUs starting with HD3000 / Sandy Bridge) through kld_list in
+/etc/rc.conf. radeonkms for older AMD GPUs can be loaded and there are
+some positive reports if EFI boot is NOT enabled (similar to amdgpu).
+
+For amdgpu: kld_list="amdgpu"
+For Intel: kld_list="i915kms"
+For radeonkms: kld_list="radeonkms"
+
+Please ensure that all users requiring graphics are members of the
+"video" group.
+EOM
+}
+]

--- a/graphics/drm-515-kmod/pkg-plist
+++ b/graphics/drm-515-kmod/pkg-plist
@@ -1,0 +1,6 @@
+/%%KMODDIR%%/dmabuf.ko
+%%AMDGPU%%/%%KMODDIR%%/amdgpu.ko
+/%%KMODDIR%%/drm.ko
+%%I915%%/%%KMODDIR%%/i915kms.ko
+/%%KMODDIR%%/radeonkms.ko
+/%%KMODDIR%%/ttm.ko


### PR DESCRIPTION
## What

New `graphics/drm-515-kmod` port — the Linux 5.15 DRM stack (drm, ttm, dmabuf,
amdgpu, i915kms, radeonkms) — modelled on the existing `drm-510-kmod`.

Builds all six `.ko` on amd64 against `/usr/src`:
`make build SRC_BASE=/usr/src` (verified from a clean extract).

## Contents

- `Makefile` / `Makefile.version`: 5.15.160, GitHub tag `drm_v5.15.160_6`;
  `distinfo` refreshed.
- `pkg-plist`: drm-515 module set (drops `linuxkpi_gplv2.ko` vs drm-510).
- `files/`: two MidnightBSD source patches for FreeBSD-14 assumptions in the
  drm-kmod source vs MidnightBSD's base API:
  - `dma_buf_stat` gains the `struct thread *` arg (MidnightBSD `fo_stat_t`
    still carries it).
  - i915 `totalram_pages()` fallback gated on `__MidnightBSD_version` (our
    LinuxKPI provides it).

## Dependency

Requires the LinuxKPI uplift in **MidnightBSD/src#379** (FreeBSD 14-level
LinuxKPI). Merge that first; this port will not build against the current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new drm-515-kmod port providing Linux 5.15 DRM kernel modules for supported MidnightBSD architectures, including required compatibility adjustments for the base system.

New Features:
- Introduce the graphics/drm-515-kmod port packaging the Linux 5.15 DRM driver stack as kernel modules for amd64, i386, aarch64, and powerpc64*.

Enhancements:
- Add architecture-specific packaging logic and source patches so the new DRM 5.15 modules build against MidnightBSD's LinuxKPI and kernel interfaces.