### PR TITLE
graphics/drm-515-kmod: depend on linuxkpi_hdmi on MidnightBSD

### DIFF
--- a/graphics/drm-515-kmod/Makefile
+++ b/graphics/drm-515-kmod/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	drm-515-kmod
 PORTVERSION=	${DRM_KMOD_DISTVERSION}
-PORTREVISION=	9
+PORTREVISION=	10
 CATEGORIES=	graphics
 
 .include "Makefile.version"

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_amd_amdgpu_amdgpu__freebsd.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_amd_amdgpu_amdgpu__freebsd.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/amd/amdgpu/amdgpu_freebsd.c.orig	2026-06-24 20:44:00.000000000 -0400
++++ drivers/gpu/drm/amd/amdgpu/amdgpu_freebsd.c	2026-06-24 20:44:00.000000000 -0400
+@@ -7,7 +7,7 @@
+ MODULE_DEPEND(amdgpu, drmn, 2, 2, 2);
+ MODULE_DEPEND(amdgpu, ttm, 1, 1, 1);
+ MODULE_DEPEND(amdgpu, linuxkpi, 1, 1, 1);
+-#if __FreeBSD_version >= 1400085
++#if __FreeBSD_version >= 1400085 || defined(__MidnightBSD_version)
+ MODULE_DEPEND(amdgpu, linuxkpi_hdmi, 1, 1, 1);
+ #endif
+ MODULE_DEPEND(amdgpu, dmabuf, 1, 1, 1);

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_drm__os__freebsd.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_drm__os__freebsd.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/drm_os_freebsd.c.orig	2026-06-24 20:44:00.000000000 -0400
++++ drivers/gpu/drm/drm_os_freebsd.c	2026-06-24 20:44:00.000000000 -0400
+@@ -211,7 +211,7 @@
+ MODULE_DEPEND(drmn, pci, 1, 1, 1);
+ MODULE_DEPEND(drmn, mem, 1, 1, 1);
+ MODULE_DEPEND(drmn, linuxkpi, 1, 1, 1);
+-#if __FreeBSD_version >= 1400085
++#if __FreeBSD_version >= 1400085 || defined(__MidnightBSD_version)
+ MODULE_DEPEND(drmn, linuxkpi_hdmi, 1, 1, 1);
+ #endif
+ MODULE_DEPEND(drmn, dmabuf, 1, 1, 1);

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_i915_i915__module.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_i915_i915__module.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/i915/i915_module.c.orig	2026-06-24 20:44:00.000000000 -0400
++++ drivers/gpu/drm/i915/i915_module.c	2026-06-24 20:44:00.000000000 -0400
+@@ -134,7 +134,7 @@
+ MODULE_DEPEND(i915kms, ttm, 1, 1, 1);
+ MODULE_DEPEND(i915kms, agp, 1, 1, 1);
+ MODULE_DEPEND(i915kms, linuxkpi, 1, 1, 1);
+-#if __FreeBSD_version >= 1400085
++#if __FreeBSD_version >= 1400085 || defined(__MidnightBSD_version)
+ MODULE_DEPEND(i915kms, linuxkpi_hdmi, 1, 1, 1);
+ #endif
+ MODULE_DEPEND(i915kms, dmabuf, 1, 1, 1);

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_radeon_radeon__freebsd.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_radeon_radeon__freebsd.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/radeon/radeon_freebsd.c.orig	2026-06-24 20:44:00.000000000 -0400
++++ drivers/gpu/drm/radeon/radeon_freebsd.c	2026-06-24 20:44:00.000000000 -0400
+@@ -7,7 +7,7 @@
+ MODULE_DEPEND(radeonkms, drmn, 2, 2, 2);
+ MODULE_DEPEND(radeonkms, ttm, 1, 1, 1);
+ MODULE_DEPEND(radeonkms, linuxkpi, 1, 1, 1);
+-#if __FreeBSD_version >= 1400085
++#if __FreeBSD_version >= 1400085 || defined(__MidnightBSD_version)
+ MODULE_DEPEND(radeonkms, linuxkpi_hdmi, 1, 1, 1);
+ #endif
+ MODULE_DEPEND(radeonkms, dmabuf, 1, 1, 1);

--- a/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_ttm_ttm__module.c
+++ b/graphics/drm-515-kmod/files/patch-drivers_gpu_drm_ttm_ttm__module.c
@@ -1,0 +1,11 @@
+--- drivers/gpu/drm/ttm/ttm_module.c.orig	2026-06-24 20:44:00.000000000 -0400
++++ drivers/gpu/drm/ttm/ttm_module.c	2026-06-24 20:44:00.000000000 -0400
+@@ -94,7 +94,7 @@
+ #ifdef CONFIG_AGP
+ MODULE_DEPEND(ttm, drmn, 2, 2, 2);
+ MODULE_DEPEND(ttm, linuxkpi, 1, 1, 1);
+-#if __FreeBSD_version >= 1400085
++#if __FreeBSD_version >= 1400085 || defined(__MidnightBSD_version)
+ MODULE_DEPEND(ttm, linuxkpi_hdmi, 1, 1, 1);
+ #endif
+ MODULE_DEPEND(ttm, dmabuf, 1, 1, 1);


### PR DESCRIPTION
## Summary
- include MidnightBSD in the linuxkpi_hdmi dependency guard
- add module dependency patches for drm, amdgpu, i915, radeon, and ttm

## Reason
The DRM modules reference HDMI infoframe symbols from linuxkpi_hdmi, but the dependency was only guarded for FreeBSD. On MidnightBSD, loading drm.ko and dependent GPU modules can otherwise fail to resolve those symbols.

## Validation
- git status -sb
- git diff --stat origin/master...HEAD
- git push -u origin graphics/drm-515-kmod

Fresh bmake port validation was not run in this publish-only turn.

## Summary by Sourcery

New Features:
- Add linuxkpi_hdmi as an explicit module dependency for drm, amdgpu, i915, radeon, and ttm on MidnightBSD to ensure HDMI symbols are resolved.