### PR TITLE
x11-fonts/libXfont2: update to 2.0.8 (security)

### DIFF
--- a/x11-fonts/libXfont2/Makefile
+++ b/x11-fonts/libXfont2/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libXfont2
-PORTVERSION=	2.0.5
+PORTVERSION=	2.0.8
 CATEGORIES=	x11-fonts
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -9,7 +9,7 @@ LICENSE=	mit
 
 LIB_DEPENDS=	libfreetype.so:print/freetype2
 
-USES=		xorg xorg-cat:lib
+USES=		tar:xz xorg xorg-cat:lib
 USE_XORG=	xorgproto xtrans fontenc
 INSTALL_TARGET=	install-strip
 #USES+=	cpe

--- a/x11-fonts/libXfont2/distinfo
+++ b/x11-fonts/libXfont2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1651245137
-SHA256 (xorg/lib/libXfont2-2.0.5.tar.bz2) = aa7c6f211cf7215c0ab4819ed893dc98034363d7b930b844bb43603c2e10b53e
-SIZE (xorg/lib/libXfont2-2.0.5.tar.bz2) = 524868
+TIMESTAMP = 1783521974
+SHA256 (xorg/lib/libXfont2-2.0.8.tar.xz) = f556c0e1093a4e6911cc90bc4b106d201902ee187fd74af206ff162f7e6a24d5
+SIZE (xorg/lib/libXfont2-2.0.8.tar.xz) = 474560


### PR DESCRIPTION
Updates `x11-fonts/libXfont2` from 2.0.5 to 2.0.8 to address the X.Org security advisory of 2026-07-08 (issues in libXfont2 prior to 2.0.8).

## CVEs fixed
- **CVE-2026-56001** — `BitmapScaleBitmaps()` integer overflow heap buffer overflow
- **CVE-2026-56002** — `pcfReadFont()` PCF font parsing heap buffer overflow
- **CVE-2026-56003** — `ComputeScaledProperties()` property buffer heap overflow

All three fixes verified present in the 2.0.8 source.

## Changes
- `PORTVERSION` 2.0.5 → 2.0.8
- Added `tar:xz` to `USES` (2.0.8 ships as `.tar.xz`)
- Regenerated `distinfo`

## Notes
- Shared library soname is unchanged (`libXfont2.so.2`), so no dependent `PORTREVISION` bumps are required.
- Validated with `bmake` build / `fake` (clean plist) / `package` on amd64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update libXfont2 port to the 2.0.8 release and adjust packaging to match the new upstream distribution format.

Bug Fixes:
- Pull in upstream libXfont2 fixes for multiple security vulnerabilities present before 2.0.8.

Build:
- Update PORTVERSION to 2.0.8 and regenerate distinfo for the new distfile.
- Add tar:xz to USES to handle the new .tar.xz distfile format.