### PR TITLE
lang/dotnet: fix MidnightBSD native build detection gates

### DIFF
--- a/lang/dotnet/Makefile
+++ b/lang/dotnet/Makefile
@@ -43,6 +43,18 @@ SHEBANG_FILES+=	src/diagnostics/src/Tools/dotnet-trace/*.sh
 
 BINARY_ALIAS=	grep=${LOCALBASE}/bin/ggrep
 DOTNET_ENV+=	PYTHON=${PYTHON_CMD}
+# Steer the runtime's native compiler discovery (eng/common/native/init-compiler.sh)
+# to the LLVM we depend on.  Otherwise it searches /usr/local/bin for the highest
+# clangNN and picks up a broken clang->bugpoint symlink, failing with
+# "clangNN -dumpversion didn't provide a version".  CLR_CC/CLR_CXX bypass the search.
+DOTNET_ENV+=	CLR_CC=${LLVM_PREFIX}/bin/clang \
+		CLR_CXX=${LLVM_PREFIX}/bin/clang++
+# The CoreCLR native build (configuretools.cmake) locates the toolchain binaries
+# (llvm-ar, llvm-nm, llvm-ranlib, llvm-strings, llvm-link, llvm-objdump,
+# llvm-readelf, llvm-objcopy) and lld via PATH.  They live in ${LLVM_PREFIX}/bin,
+# which is not on the default PATH; the versioned copies in ${LOCALBASE}/bin are
+# broken symlinks to bugpoint.  Prepend the LLVM bindir so the real tools win.
+DOTNET_ENV+=	PATH=${LLVM_PREFIX}/bin:${PATH}
 
 BOOTSTRAP_DOTNETVERSION?=			9.0
 BOOTSTRAP_SDKVERSION?=				${BOOTSTRAP_DOTNETVERSION}.110
@@ -103,6 +115,31 @@ PLIST_SUB+=	VXSORT="@comment "
 post-patch:
 	${CP} ${PATCHDIR}/0002-Fix-assembly-version-calculation-in-2026.patch \
 		${WRKSRC}/src/source-build-externals/patches/azure-activedirectory-identitymodel-extensions-for-dotnet/
+# The VMR vendors a per-repo copy of eng/common/native/init-os-and-arch.sh and
+# init-distro-rid.sh in every src/<repo>.  Our patches only fix the top-level
+# copy, so native-building repos (runtime, aspnetcore) still fail with
+# "Unsupported OS midnightbsd detected!" and cannot locate freebsd-version.
+# Apply the same MidnightBSD handling to every vendored copy (skip the
+# already-patched top-level ones, which contain "midnightbsd").
+	@${FIND} ${WRKSRC} -name init-os-and-arch.sh | while read f; do \
+		${GREP} -q midnightbsd "$$f" || \
+		${REINPLACE_CMD} -e '/^OSName=$$(uname -s/s/$$/; [ "$$OSName" = midnightbsd ] \&\& OSName=freebsd/' "$$f"; \
+	done
+	@${FIND} ${WRKSRC} -name init-distro-rid.sh | while read f; do \
+		${GREP} -q midnightbsd "$$f" || \
+		${REINPLACE_CMD} -e 's#/bin/freebsd-version#/bin/midnightbsd-version#g' "$$f"; \
+	done
+# The CoreCLR native build derives the OS from CMAKE_SYSTEM_NAME, which is
+# "MidnightBSD" (uname -s).  configureplatform.cmake does not recognize it, so
+# host arch detection never runs and the build dies with
+# "'amd64' is an unsupported architecture".  Normalize CLR_CMAKE_HOST_OS
+# midnightbsd -> freebsd right after it is lowercased (clang defines
+# __FreeBSD__, so the C/C++ sources build unchanged).
+	@${FIND} ${WRKSRC} -name configureplatform.cmake | while read f; do \
+		${GREP} -q 'REPLACE midnightbsd freebsd' "$$f" || { \
+			${AWK} '/string\(TOLOWER .* CLR_CMAKE_HOST_OS\)/ { print; print "string(REPLACE midnightbsd freebsd CLR_CMAKE_HOST_OS \"$${CLR_CMAKE_HOST_OS}\")"; next } { print }' "$$f" > "$$f.tmp" && ${MV} "$$f.tmp" "$$f"; \
+		}; \
+	done
 .endif
 
 post-extract:


### PR DESCRIPTION
## Summary

Fixes the MidnightBSD-specific gates that prevented `lang/dotnet`'s .NET
source build (`runtime` repo / CoreCLR native build) from configuring and
compiling. With these applied, the build clears every previously-blocking
gate and proceeds into the native CoreCLR compile (hostfxr/hostpolicy and
the managed libraries build successfully).

The common cause: the .NET VMR vendors a per-repo copy of the native build
scripts that only recognize FreeBSD, and the LLVM toolchain the port depends
on is not discovered on MidnightBSD.

## Changes (all in `lang/dotnet/Makefile`)

**post-patch**
- Apply the MidnightBSD handling the top-level patches already add to *every*
  vendored `eng/common/native/init-os-and-arch.sh` (`OSName midnightbsd -> freebsd`)
  and `init-distro-rid.sh` (`freebsd-version -> midnightbsd-version`) copy.
  Without this, `runtime` aborts with `Unsupported OS midnightbsd detected!`
  and cannot read the OS version (`/bin/freebsd-version` does not exist here;
  `/bin/midnightbsd-version` does).
- Normalize `CLR_CMAKE_HOST_OS midnightbsd -> freebsd` in the vendored
  `configureplatform.cmake` copies. `CMAKE_SYSTEM_NAME` is `MidnightBSD`
  (`uname -s`), so host-arch detection was skipped and cmake died with
  `'amd64' is an unsupported architecture`. clang defines `__FreeBSD__`, so the
  C/C++ sources build unchanged once the OS is recognized.

**DOTNET_ENV**
- `CLR_CC`/`CLR_CXX` -> `${LLVM_PREFIX}/bin/clang[++]` so the runtime's compiler
  search does not pick up the broken `/usr/local/bin/clangNN -> bugpointNN`
  symlinks (`clangNN -dumpversion` runs `bugpoint` and fails).
- Prepend `${LLVM_PREFIX}/bin` to `PATH` so `configuretools.cmake` finds
  `llvm-ar/nm/ranlib/strings/link/objdump/readelf/objcopy` and `lld`; the
  versioned copies in `${LOCALBASE}/bin` are broken bugpoint symlinks.

## Verification

- `bmake -n post-patch` expands to the intended sed/awk commands; the recipe
  was tested on pristine files (correct transform, idempotent).
- A full incremental build cleared OS-detect -> compiler discovery -> arch
  detection -> toolchain discovery and was actively compiling native
  (hostfxr/hostpolicy to ~98%) and managed (`System.*.dll`) code.

## Not done / follow-ups

- **A full end-to-end build+package was not completed.** The parallel CoreCLR
  compile at `-maxcpucount:${MAKE_JOBS_NUMBER}` (16 on the test box) exhausts
  memory on a 32 GB machine and hard-resets it. Capping the native build's job
  count is a likely follow-up before this can build unattended.
- Separately: `devel/llvm19` and `devel/llvm21` ship broken
  `/usr/local/bin/clangNN` and `llvm-*NN -> bugpointNN` symlinks. That is an
  LLVM-port packaging bug (worked around here) worth fixing on its own.

AI-assisted; see commit trailer.

## Summary by Sourcery

Fix native CoreCLR build configuration for MidnightBSD in the lang/dotnet port so the runtime source build can progress past OS and toolchain detection.

Bug Fixes:
- Ensure the .NET native build scripts in all vendored repos recognize MidnightBSD as FreeBSD and use the correct OS version helper binary.
- Normalize the CoreCLR CMake host OS value from MidnightBSD to FreeBSD so architecture detection no longer fails.
- Direct the runtime’s compiler and toolchain discovery to the LLVM binaries shipped with the port and avoid broken clang/llvm symlinks in the default PATH.