### PR TITLE
x11/xsetroot: update to 1.1.4

### DIFF
--- a/x11/xsetroot/Makefile
+++ b/x11/xsetroot/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xsetroot
-PORTVERSION=	1.1.2
+PORTVERSION=	1.1.4
 CATEGORIES=	x11
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -7,7 +7,7 @@ COMMENT=	Root window parameter setting utility for X
 
 LICENSE=	mit
 
-USES=		xorg xorg-cat:app
+USES=		tar:xz xorg xorg-cat:app
 USE_XORG=	xmuu x11 xbitmaps xcursor
 PLIST_FILES=	bin/xsetroot share/man/man1/xsetroot.1.gz
 

--- a/x11/xsetroot/distinfo
+++ b/x11/xsetroot/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1525892509
-SHA256 (xorg/app/xsetroot-1.1.2.tar.bz2) = 10c442ba23591fb5470cea477a0aa5f679371f4f879c8387a1d9d05637ae417c
-SIZE (xorg/app/xsetroot-1.1.2.tar.bz2) = 129091
+TIMESTAMP = 1783805541
+SHA256 (xorg/app/xsetroot-1.1.4.tar.xz) = 1315a3f7e9abe06357363b93461e272601f67225ce0bc075c430cce35073362b
+SIZE (xorg/app/xsetroot-1.1.4.tar.xz) = 129272


### PR DESCRIPTION
Updates `x11/xsetroot` from 1.1.2 to 1.1.4.

## Changes
- `PORTVERSION` 1.1.2 → 1.1.4.
- Add `tar:xz` to `USES` — upstream switched the release tarball to `.tar.xz` (matching FreeBSD's port and the other modern xorg app ports).
- Regenerated `distinfo`.

## Upstream changes since 1.1.2
`-help` now exits 0, `--help`/`--version` accepted as aliases, man page formatting/lint fixes, whitespace cleanup, and **optional meson build support** (autoconf remains the default build, which this port continues to use).

## Validation (amd64)
- `bmake` build succeeds.
- `bmake fake` succeeds; plist unchanged (`bin/xsetroot` + man page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the x11/xsetroot port to the 1.1.4 upstream release and align its packaging with the new distribution format.

Enhancements:
- Switch the x11/xsetroot port to use the upstream .tar.xz release archive.

Build:
- Bump PORTVERSION for x11/xsetroot from 1.1.2 to 1.1.4 and regenerate distinfo for the new distfile.