### PR TITLE
x11/xwd: update to 1.0.10

### DIFF
--- a/x11/xwd/Makefile
+++ b/x11/xwd/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xwd
-PORTVERSION=	1.0.8
+PORTVERSION=	1.0.10
 CATEGORIES=	x11
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -7,7 +7,7 @@ COMMENT=	Dump an image of an X window
 
 LICENSE=	mit
 
-USES=		xorg xorg-cat:app
+USES=		tar:xz xorg xorg-cat:app
 USE_XORG=	x11 xkbfile
 
 PLIST_FILES=	bin/xwd share/man/man1/xwd.1.gz

--- a/x11/xwd/distinfo
+++ b/x11/xwd/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1722515044
-SHA256 (xorg/app/xwd-1.0.8.tar.bz2) = fbaa2b34163714fe7be22b60920ea4683f63b355babb1781aec2e452a033031b
-SIZE (xorg/app/xwd-1.0.8.tar.bz2) = 151153
+TIMESTAMP = 1783877494
+SHA256 (xorg/app/xwd-1.0.10.tar.xz) = 4909eacc26c4cd5a9afcd1468aec26e7c646544639031bdad4f71173aa82f3c3
+SIZE (xorg/app/xwd-1.0.10.tar.xz) = 147932


### PR DESCRIPTION
Updates `x11/xwd` from 1.0.8 to 1.0.10 (X.Org announcement 2026-07-11).

## Changes
- `PORTVERSION` 1.0.8 → 1.0.10.
- Add `tar:xz` to `USES` — upstream switched the release tarball to `.tar.xz`.
- Regenerated `distinfo` (SHA256 matches the upstream announcement).

## Upstream
Man page formatting/lint fixes, malloc-failure checks, optional meson build support (autoconf still default).

## Validation (amd64)
`bmake` + `bmake fake` succeed; plist unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Adjust port metadata to use tar:xz in USES for the updated distfile format.