### PR TITLE
www/waterfox: update to 6.6.16.1

### DIFF
--- a/www/waterfox/Makefile
+++ b/www/waterfox/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	waterfox
-DISTVERSION=	6.6.12
-PORTREVISION=	0
+DISTVERSION=	6.6.16.1
 PORTEPOCH=	1
 CATEGORIES=	www
 
@@ -12,7 +11,7 @@ LICENSE=	MPL20
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	nspr>=4.32:devel/nspr \
-		nss>=3.122.0:security/nss \
+		nss>=3.124.0:security/nss \
 		icu>=76.1:devel/icu \
 		libevent>=2.1.8:devel/libevent \
 		harfbuzz>=10.1.0:print/harfbuzz \
@@ -33,7 +32,7 @@ USES+=		perl5
 USE_GECKO=	gecko
 USE_GITHUB=	yes
 GH_ACCOUNT=	BrowserWorks
-GH_TUPLE=	BrowserWorks:l10n:d7d584c:l10n/waterfox/browser/locales
+GH_TUPLE=	BrowserWorks:l10n:a2e5c9b:l10n/waterfox/browser/locales
 USE_MOZILLA=	-sqlite
 # work around bindgen not finding ICU, e.g.
 # dist/include/mozilla/intl/ICU4CGlue.h:8:10: fatal error: 'unicode/uenum.h' file not found, err: true
@@ -88,8 +87,6 @@ post-extract:
 post-patch:
 	@${REINPLACE_CMD} -e 's|%%LOCALBASE%%|${LOCALBASE}|g' \
 		${WRKSRC}/browser/app/nsBrowserApp.cpp
-	@${REINPLACE_CMD} -e 's|wasm32-wasi|&p1|' \
-		${WRKSRC}/build/moz.configure/toolchain.configure
 
 post-install:
 	${INSTALL_DATA} ${WRKDIR}/${MOZILLA_EXEC_NAME}.desktop ${DESKTOPDIR}

--- a/www/waterfox/distinfo
+++ b/www/waterfox/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1776969857
-SHA256 (BrowserWorks-waterfox-6.6.12_GH0.tar.gz) = 04621a7c3fd4e0737f182ab0f8f8cfcf23d6b7a63005ec8548cc8f6495b0e4a5
-SIZE (BrowserWorks-waterfox-6.6.12_GH0.tar.gz) = 926184434
-SHA256 (BrowserWorks-l10n-d7d584c_GH0.tar.gz) = 845a34b7b5d881e44a3b42133770cfb2104e3e6c4cfb4733242cca2552f3a850
-SIZE (BrowserWorks-l10n-d7d584c_GH0.tar.gz) = 25788616
+TIMESTAMP = 1783838383
+SHA256 (BrowserWorks-waterfox-6.6.16.1_GH0.tar.gz) = b0b4086cbff68cc1dc0e28321a99055482f19a243f14fa674adc8800b5b83d84
+SIZE (BrowserWorks-waterfox-6.6.16.1_GH0.tar.gz) = 926640559
+SHA256 (BrowserWorks-l10n-a2e5c9b_GH0.tar.gz) = b59e1ad5a16b3fcfb4266edb7a641098c511ce593b8f2ff291cc7dc3ca054b03
+SIZE (BrowserWorks-l10n-a2e5c9b_GH0.tar.gz) = 25811834

--- a/www/waterfox/files/patch-bug2023597
+++ b/www/waterfox/files/patch-bug2023597
@@ -1,0 +1,24 @@
+commit c41de3cb5bd2b6fb243e10b150b705435d2db63c
+Author: Alex Hochheiden <ahochheiden@mozilla.com>
+Date:   Wed Apr 1 18:11:37 2026 +0000
+
+    Bug 2023597 - Use `wasm32-wasip1` target for clang >= 22.1 r=firefox-build-system-reviewers,sergesanspaille
+
+    https://github.com/llvm/llvm-project/pull/165345
+    https://releases.llvm.org/22.1.0/tools/clang/docs/ReleaseNotes.html
+
+    Differential Revision: https://phabricator.services.mozilla.com/D291023
+
+diff --git build/moz.configure/toolchain.configure build/moz.configure/toolchain.configure
+index 10d715866b1f..4b07f9d7a8de 100644
+--- build/moz.configure/toolchain.configure
++++ build/moz.configure/toolchain.configure
+@@ -695,6 +695,9 @@ def check_compiler(configure_cache, compiler, language, target, android_version)
+         # This makes clang define __ANDROID_API__ and use versioned library
+         # directories from the NDK.
+         toolchain = "%s%d" % (target.toolchain, android_version)
++    elif target.kernel == "WASI" and info.type == "clang" and info.version >= Version("22.1"):
++        # The wasm32-wasi target was renamed to wasm32-wasip1 in LLVM 22.1.
++        toolchain = "wasm32-wasip1"
+     else:
+         toolchain = target.toolchain

--- a/www/waterfox/files/patch-build_moz.configure_toolchain.configure
+++ b/www/waterfox/files/patch-build_moz.configure_toolchain.configure
@@ -1,0 +1,46 @@
+commit 7503d73295e6a6fd84c35ffabce08e3d2f3b56de
+Author: Christoph Moench-Tegeder <cmt@FreeBSD.org>
+
+    catch wasm32-wasi target naming in FreeBSD
+
+    Freebsd ports 7c5b2039a45ad renamed the WebAssemply target to
+    wasm32-wasip1 in all LLVM versions when LLVM 22.1 switched to
+    the new name. Make sure to catch it in toolchain.configure, so
+    the compiler can find it's assorted files.
+
+diff --git build/moz.configure/toolchain.configure build/moz.configure/toolchain.configure
+index 5ca00b2b62a1..0e66441d8692 100644
+--- build/moz.configure/toolchain.configure
++++ build/moz.configure/toolchain.configure
+@@ -653,6 +653,7 @@ def same_arch_different_bits():
+
+ @imports(_from="mozshellutil", _import="quote")
+ @imports(_from="mozbuild.configure.constants", _import="OS_preprocessor_checks")
++@imports(_from="sys", _import="platform")
+ def check_compiler(configure_cache, compiler, language, target, android_version):
+     info = get_compiler_info(configure_cache, compiler, language)
+
+@@ -695,8 +696,9 @@ def check_compiler(configure_cache, compiler, language, target, android_version)
+         # This makes clang define __ANDROID_API__ and use versioned library
+         # directories from the NDK.
+         toolchain = "%s%d" % (target.toolchain, android_version)
+-    elif target.kernel == "WASI" and info.type == "clang" and info.version >= Version("22.1"):
+-        # The wasm32-wasi target was renamed to wasm32-wasip1 in LLVM 22.1.
++    elif (target.kernel == "WASI" and info.type == "clang") and (info.version >= Version("22.1") or platform.startswith("freebsd")):
++        # The wasm32-wasi target was renamed to wasm32-wasip1 in LLVM 22.1
++        # and FreeBSD uses it since ports 7c5b2039a45ad for all LLVM ports
+         toolchain = "wasm32-wasip1"
+     else:
+         toolchain = target.toolchain
+@@ -954,8 +956,10 @@ def compiler_wrapper(wrapper, ccache):
+
+
+ @dependable
++@imports(_from="sys", _import="platform")
+ def wasm():
+-    return split_triplet("wasm32-wasi", allow_wasi=True)
++    log.warning("USING PLATFORM %s" % platform)
++    return split_triplet("wasm32-wasip1" if platform.startswith("freebsd") else "wasm32-wasi", allow_wasi=True)
+
+
+ @template

--- a/www/waterfox/files/patch-dns-resolve-https-rr
+++ b/www/waterfox/files/patch-dns-resolve-https-rr
@@ -1,0 +1,34 @@
+commit be323da0618d99573ef61a096fa4ae1b147378d9
+Author: Christoph Moench-Tegeder <cmt@FreeBSD.org>
+
+    enable resolving HTTPS RRs via the OS's resolver on FreeBSD
+
+    see RFC 9460 https://www.rfc-editor.org/rfc/rfc9460  for details
+    on HTTPS RRs.
+
+diff --git netwerk/dns/moz.build netwerk/dns/moz.build
+index b2456d23a6df..3785da5d6e87 100644
+--- netwerk/dns/moz.build
++++ netwerk/dns/moz.build
+@@ -58,6 +58,8 @@ if CONFIG["MOZ_WIDGET_TOOLKIT"] == "windows":
+ elif CONFIG["OS_TARGET"] == "Linux":
+     SOURCES += ["PlatformDNSUnix.cpp"]
+     OS_LIBS += ["resolv"]
++elif CONFIG["OS_TARGET"] == "FreeBSD":
++    SOURCES += ["PlatformDNSUnix.cpp"]
+ elif CONFIG["MOZ_WIDGET_TOOLKIT"] == "cocoa":
+     SOURCES += ["PlatformDNSMac.cpp"]
+ elif CONFIG["MOZ_WIDGET_TOOLKIT"] == "android":
+diff --git netwerk/dns/nsHostResolver.cpp netwerk/dns/nsHostResolver.cpp
+index b7e3763ffeb5..a36edf32dc76 100644
+--- netwerk/dns/nsHostResolver.cpp
++++ netwerk/dns/nsHostResolver.cpp
+@@ -213,7 +213,7 @@ nsresult nsHostResolver::Init() MOZ_NO_THREAD_SAFETY_ANALYSIS {
+ #elif defined(MOZ_WIDGET_ANDROID)
+   // android_res_nquery only got added in API level 29
+   sNativeHTTPSSupported = jni::GetAPIVersion() >= 29;
+-#elif defined(XP_LINUX) || defined(XP_MACOSX)
++#elif defined(XP_LINUX) || defined(XP_MACOSX) || defined(XP_FREEBSD)
+   sNativeHTTPSSupported = true;
+ #endif
+   LOG(("Native HTTPS records supported=%d", bool(sNativeHTTPSSupported)));


### PR DESCRIPTION
Update Waterfox to 6.6.16.1 based on the current FreeBSD port.

Changes:
- Update Waterfox and locale distfiles.
- Raise the NSS build requirement to 3.124.0.
- Import current WASI and HTTPS DNS compatibility patches.

Validation: bmake check-license and git diff --check pass. Full patch/build validation was blocked because the large GitHub source archive was truncated during download.

## Summary by Sourcery

Update the Waterfox port to the 6.6.16.1 release and sync it with the current upstream/FreeBSD packaging.

Enhancements:
- Bump Waterfox to version 6.6.16.1 and refresh associated distfiles and locales.
- Raise the minimum NSS dependency version required for building Waterfox.
- Replace the previous WASI toolchain tweak with updated upstream-compatible patches, including HTTPS DNS compatibility changes.

Build:
- Adjust build dependency constraints to require a newer NSS version.