### PR TITLE
mail/thunderbird: fix libxul undefined symbol with libproxy enabled

### DIFF
--- a/mail/thunderbird/Makefile
+++ b/mail/thunderbird/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	thunderbird
 DISTVERSION=	152.0.1
+PORTREVISION=	1
 CATEGORIES=	mail news net-im wayland
 MASTER_SITES=	MOZILLA/${PORTNAME}/releases/${DISTVERSION}${DISTVERSIONSUFFIX}/source \
 		MOZILLA/${PORTNAME}/candidates/${DISTVERSION}${DISTVERSIONSUFFIX}-candidates/build1/source

--- a/mail/thunderbird/files/patch-bug2040125
+++ b/mail/thunderbird/files/patch-bug2040125
@@ -1,0 +1,38 @@
+commit 40a17bafb1d1c647b2548c53cf948f900a43fae0
+Author: Christoph Moench-Tegeder <cmt@burggraben.net>
+
+    Bug 2040125 - add GetSystemProxyDirect() to libproxy path r=kershaw,valentin,#necko-reviewers
+    
+    In bmo #2028356 a "fast-path to skip proxy resolution[...]" was added,
+    but the required method GetSystemProxyDirect() was not added for
+    libproxy-enabled builds (all other cases - general Unix without
+    libproxy, OSX, Windows - got that function).
+    
+    This makes a "--enable-libproxy" build (MOZ_ENABLE_LIBPROXY) fail at
+    startup, as the symbol for nsUnixSystemProxySettings::GetSystemProxyDirect()
+    does not resolve.
+    
+    This adds GetSystemProxyDirect() to the MOZ_ENABLE_LIBPROXY case - it's
+    trivial, as we cannot know what libproxy will return for a specific URL,
+    thus the fast-path does not apply and we can just return "false".
+    
+    Differential Revision: https://phabricator.services.mozilla.com/D300937
+
+diff --git toolkit/system/unixproxy/nsLibProxySettings.cpp toolkit/system/unixproxy/nsLibProxySettings.cpp
+index 3de1b7ce9b8f..8b063d446c1e 100644
+--- toolkit/system/unixproxy/nsLibProxySettings.cpp
++++ toolkit/system/unixproxy/nsLibProxySettings.cpp
+@@ -111,6 +111,13 @@ nsUnixSystemProxySettings::GetSystemWPADSetting(bool* aSystemWPADSetting) {
+   return NS_OK;
+ }
+ 
++// we do not know if libproxy would return DIRECT or PROXY
++NS_IMETHODIMP
++nsUnixSystemProxySettings::GetSystemProxyDirect(bool* aResult) {
++  *aResult = false;
++  return NS_OK;
++}
++
+ NS_IMPL_COMPONENT_FACTORY(nsUnixSystemProxySettings) {
+   return do_AddRef(new nsUnixSystemProxySettings()).downcast<nsISupports>();
+ }


### PR DESCRIPTION
## Problem

Thunderbird 152.0.1 aborts at startup with:

```
XPCOMGlueLoad error for file /usr/local/lib/thunderbird/libxul.so:
Undefined symbol "_ZN25nsUnixSystemProxySettings20GetSystemProxyDirectEPb"
Couldn't load XPCOM.
```

## Root cause

The port builds with `--enable-libproxy` and depends on `net/libproxy`, so
`configure` sets `MOZ_ENABLE_LIBPROXY=1`. In that mode
`toolkit/system/unixproxy/moz.build` compiles `nsLibProxySettings.cpp`
**instead of** `nsUnixSystemProxySettings.cpp`.

`GetSystemProxyDirect()` was recently added to the `nsISystemProxySettings`
interface. Upstream added implementations to the plain-unix, macOS and
Windows backends but **not** the libproxy backend. That file declares the
full interface via `NS_DECL_NSISYSTEMPROXYSETTINGS` yet never defines
`GetSystemProxyDirect`, leaving an unresolved vtable slot. Undefined symbols
are permitted in a shared object, so the build/link succeeds and only fails
at `dlopen` time — which is why the 152.0.1 build looked clean.

This is Mozilla [bug 2040125](https://bugzilla.mozilla.org/show_bug.cgi?id=2040125);
FreeBSD's port carries the identical patch.

## Fix

- Add `files/patch-bug2040125` implementing the trivial libproxy variant
  (`GetSystemProxyDirect` returns `false` — libproxy cannot cheaply report a
  direct connection, so the fast-path is skipped).
- Bump `PORTREVISION`.

## Verification

- `bmake build` relinks `libxul.so`; `nsLibProxySettings.o` now defines
  `_ZN25nsUnixSystemProxySettings20GetSystemProxyDirectEPb` (`T`).
- `llvm-nm -D` on the old installed lib shows the symbol as `U` (undefined);
  the rebuilt lib resolves it internally (no undefined dynamic reference).
- `bmake package` succeeds (`thunderbird-152.0.1_1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Thunderbird startup crash caused by unresolved libxul symbol when built with libproxy on FreeBSD.

Bug Fixes:
- Resolve missing GetSystemProxyDirect symbol in libxul when libproxy support is enabled by adding the upstream bug 2040125 patch.
- Ensure Thunderbird starts correctly on systems using the libproxy-based system proxy backend.

Build:
- Bump Thunderbird port revision to 1 to trigger rebuild with the libproxy fix applied.