### PR TITLE
devel/libgdata: drop obsolete test dependency

### DIFF
--- a/devel/libgdata/Makefile
+++ b/devel/libgdata/Makefile
@@ -10,7 +10,6 @@ COMMENT=	GLib based implimentation of the GData protocol
 LICENSE=	lgpl2.1
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	uhttpmock>0:net/uhttpmock
 LIB_DEPENDS=	libsoup-2.4.so:devel/libsoup \
 		libjson-glib-1.0.so:devel/json-glib \
 		libp11-kit.so:security/p11-kit \


### PR DESCRIPTION
## Summary

- remove the obsolete `net/uhttpmock` build dependency
- retain Meson’s disabled always-built tests configuration

## Root cause

`libgdata` tests are disabled, but the old dependency caused the current `uhttpmock` port to be installed. That port provides `libuhttpmock-1.0`, while the disabled test path requested `libuhttpmock-0.0`.

## Validation

- `bmake check-license`
- `bmake -n configure`
- `git diff --check`

A direct Meson configure confirmed that `-Dalways_build_tests=false` skips the obsolete uhttpmock probe.

## Summary by Sourcery

Build:
- Drop the net/uhttpmock build dependency now that libgdata tests are disabled and the dependency is no longer needed.