### PR TITLE
devel/rubygem-slack-messenger: make re2 build dependency explicit

### DIFF
--- a/devel/rubygem-slack-messenger/Makefile
+++ b/devel/rubygem-slack-messenger/Makefile
@@ -10,7 +10,7 @@ WWW=		https://gitlab.com/gitlab-org/ruby/gems/slack-messenger
 LICENSE=	mit
 
 RUN_DEPENDS=	rubygem-re2>=2.7.0<3:devel/rubygem-re2
-BUILD_DEPENDS=	${RUN_DEPENDS}
+BUILD_DEPENDS+=	rubygem-re2>=2.7.0<3:devel/rubygem-re2
 
 USES=		gem
 


### PR DESCRIPTION
## Summary

- explicitly add `rubygem-re2` to `BUILD_DEPENDS`
- retain the existing runtime dependency

## Root cause

Magus `fake-qa` checks RubyGem runtime dependencies during the build. The dependency scanner does not reliably expand `BUILD_DEPENDS=${RUN_DEPENDS}`, so `re2` was absent when QA inspected the staged gemspec.

## Validation

- `bmake fake`
- `bmake check-license`
- `git diff --check`

## Summary by Sourcery

Make the rubygem-slack-messenger port declare rubygem-re2 as an explicit build dependency instead of inheriting it from RUN_DEPENDS.

Bug Fixes:
- Ensure rubygem-re2 is available during QA checks by explicitly listing it in BUILD_DEPENDS instead of relying on BUILD_DEPENDS=${RUN_DEPENDS} expansion.

Enhancements:
- Clarify dependency specification for rubygem-slack-messenger by separating build and runtime dependency declarations.