### PR TITLE
x11-clocks/xclock: update to 1.2.1

### DIFF
--- a/x11-clocks/xclock/Makefile
+++ b/x11-clocks/xclock/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xclock
-PORTVERSION=	1.0.9
+PORTVERSION=	1.2.1
 CATEGORIES=	x11-clocks
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -8,7 +8,7 @@ WWW=		https://www.freedesktop.org/Software/xapps
 
 LICENSE=	mit
 
-USES=		iconv xorg xorg-cat:app
+USES=		iconv tar:xz xorg xorg-cat:app
 USE_XORG=	x11 xaw xft xkbfile xmu xrender xt
 
 .include <bsd.port.mk>

--- a/x11-clocks/xclock/distinfo
+++ b/x11-clocks/xclock/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1590341864
-SHA256 (xorg/app/xclock-1.0.9.tar.bz2) = cf461fb2c6f2ac42c54d8429ee2010fdb9a1442a370adfbfe8a7bfaf33c123bb
-SIZE (xorg/app/xclock-1.0.9.tar.bz2) = 175372
+TIMESTAMP = 1784497384
+SHA256 (xorg/app/xclock-1.2.1.tar.xz) = e326cac20f7ad2af5412b9c4b70b1c3d392e08cd3cc6246e0a77b7c3935a4851
+SIZE (xorg/app/xclock-1.2.1.tar.xz) = 180196

--- a/x11-clocks/xclock/pkg-plist
+++ b/x11-clocks/xclock/pkg-plist
@@ -1,4 +1,6 @@
 bin/xclock
 share/man/man1/xclock.1.gz
+share/X11/app-defaults/XClock-ampm
 share/X11/app-defaults/XClock-color
+share/X11/app-defaults/XClock-grandfather
 share/X11/app-defaults/XClock


### PR DESCRIPTION
## Summary

- update xclock from 1.0.9 to 1.2.1
- switch to the upstream `.tar.xz` archive
- add the new `XClock-ampm` and `XClock-grandfather` app-defaults files

## Validation

- `bmake extract`
- `bmake fake`
- `bmake package`
- `bmake check-license`
- `bmake test`
- `portlint -N`
- `git diff --check`

## Summary by Sourcery

Update the xclock port to the 1.2.1 release and align packaging with the upstream tar.xz distribution.

New Features:
- Add packaging for the new XClock-ampm and XClock-grandfather app-defaults files introduced upstream.

Enhancements:
- Refresh distinfo and plist entries to match the 1.2.1 release contents.

Build:
- Switch the port to use the upstream .tar.xz source archive format.