### PR TITLE
ai/py-evaluate: add to category index

### DIFF
--- a/ai/Makefile
+++ b/ai/Makefile
@@ -21,6 +21,7 @@
     SUBDIR += py-datasets
     SUBDIR += py-diffusers
     SUBDIR += py-einops
+    SUBDIR += py-evaluate
     SUBDIR += py-google-genai
     SUBDIR += py-groq
     SUBDIR += py-headroom-ai


### PR DESCRIPTION
Adds py-evaluate to the ai category index so dependency resolution can find the py312 flavor.

Run 643 failed ai/py-accelerate because Magus did not inventory the provider.

Validation: bmake -C ai/py-evaluate FLAVOR=py312 -V PKGNAME; git diff --check; portlint -A ai/py-evaluate.

## Summary by Sourcery

New Features:
- Include py-evaluate in the ai category Makefile subdirectories to make the port available under the ai collection.