### PR TITLE
ai/py-einops: fix PyTorch test dependency

### DIFF
--- a/ai/py-einops/Makefile
+++ b/ai/py-einops/Makefile
@@ -15,7 +15,7 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hatchling>=1.10.0:devel/py-hatchling@${PY_FLAVOR}
 TEST_DEPENDS=	${PYTHON_PKGNAMEPREFIX}nbconvert>0:devel/py-nbconvert@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}parameterized>0:devel/py-parameterized@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}pytorch>0:misc/py-pytorch@${PY_FLAVOR}
+		${PYTHON_PKGNAMEPREFIX}pytorch>0:ai/py-pytorch@${PY_FLAVOR}
 
 USES=		python
 USE_PYTHON=	pep517 autoplist pytest


### PR DESCRIPTION
Corrects the PyTorch test dependency origin after its move to ai.\n\nFixes Magus run 643 dependency resolution.\n\nValidation: bmake -C ai/py-einops FLAVOR=py312 -V TEST_DEPENDS; bmake patch; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Fix PyTorch test dependency resolution for the py-einops port after the PyTorch port relocation.