### PR TITLE
x11-fonts/py-compreffor: fix Cython dependency

### DIFF
--- a/x11-fonts/py-compreffor/Makefile
+++ b/x11-fonts/py-compreffor/Makefile
@@ -12,7 +12,7 @@ WWW=		https://github.com/googlefonts/compreffor
 LICENSE=	Apache-2.0
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}cython>=0.29.30:devel/py-cython@${PY_FLAVOR} \
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}cython>=0.29.30:lang/cython@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}setuptools-scm>=0:devel/py-setuptools-scm@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}setuptools_git_ls_files>=0:devel/py-setuptools_git_ls_files@${PY_FLAVOR}
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}fonttools>=4:print/py-fonttools@${PY_FLAVOR}


### PR DESCRIPTION
Uses the lang/cython provider for the Cython build dependency.\n\nFixes Magus run 643 dependency resolution.\n\nValidation: bmake -C x11-fonts/py-compreffor FLAVOR=py312 -V BUILD_DEPENDS; bmake patch; git diff --check.

## Summary by Sourcery

Build:
- Switch py-compreffor BUILD_DEPENDS from devel/py-cython to lang/cython to align with the shared Cython provider.