### PR TITLE
japanese/today: make CR stripping locale-independent

### DIFF
--- a/japanese/today/Makefile
+++ b/japanese/today/Makefile
@@ -30,7 +30,7 @@ post-extract:
 		gengo.tbl hist??.tbl history.tbl holiday.tbl magazine.tbl \
 		monthly.tbl schedule.tbl suffix.tbl week.tbl; \
 	do \
-		nkf -Se $$i | ${TR} -d '\015' > $$i.tmp ;\
+		nkf -Se $$i | LC_ALL=C ${TR} -d '\015' > $$i.tmp ;\
 		${MV} -f $$i.tmp $$i ; \
 	done)
 


### PR DESCRIPTION
Uses the C locale for byte-oriented CR stripping after nkf conversion.\n\nFixes the Magus run 643 extract failure caused by tr rejecting non-ASCII bytes.\n\nValidation: bmake extract; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Prevent extract failures caused by tr rejecting non-ASCII bytes when processing files after nkf conversion.