### PR TITLE
www/grafana: exclude i386 builds

### DIFF
--- a/www/grafana/Makefile
+++ b/www/grafana/Makefile
@@ -33,7 +33,7 @@ WWW=		https://grafana.com/grafana/ \
 LICENSE=	agpl
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-ONLY_FOR_ARCHS=	aarch64 amd64 i386 riscv64
+ONLY_FOR_ARCHS=	aarch64 amd64 riscv64
 
 RUN_DEPENDS=	ca_root_nss>=0:security/ca_root_nss
 


### PR DESCRIPTION
Excludes i386 after Grafana exhausts the 32-bit address space during Go wire generation.\n\nFixes Magus run 643 by reporting the platform as unsupported instead of a build failure.\n\nValidation: bmake -C www/grafana -V ONLY_FOR_ARCHS; git diff --check.

## Summary by Sourcery

Build:
- Update Grafana port Makefile to drop i386 from ONLY_FOR_ARCHS, causing i386 to be reported as an unsupported platform instead of attempting a build.