### PR TITLE
graphics/drm-fbsd12.0-kmod: exclude MidnightBSD 4.1

### DIFF
--- a/graphics/drm-fbsd12.0-kmod/Makefile
+++ b/graphics/drm-fbsd12.0-kmod/Makefile
@@ -31,6 +31,7 @@ IGNORE=		only supported on MidnightBSD 3.x
 .endif
 
 IGNORE_MidnightBSD_4.0=	too new
+IGNORE_MidnightBSD_4.1=	too new
 
 .if ${ARCH} == "amd64"
 PLIST_SUB+=     AMDGPU=""


### PR DESCRIPTION
The fbsd12 DRM code conflicts with the current 4.1 LinuxKPI headers. Mark the unsupported base version explicitly instead of reporting a compiler failure.\n\nFixes Magus run 643 i386 failure classification.\n\nValidation: bmake -C graphics/drm-fbsd12.0-kmod -V IGNORE_MidnightBSD_4.0; git diff --check.

## Summary by Sourcery

Chores:
- Update port metadata to treat MidnightBSD 4.1 as "too new" and ignore building drm-fbsd12.0-kmod on that version.