### PR TITLE
devel/p5-MetaCPAN-Client: update plist

### DIFF
--- a/devel/p5-MetaCPAN-Client/pkg-plist
+++ b/devel/p5-MetaCPAN-Client/pkg-plist
@@ -1,6 +1,7 @@
 %%SITE_PERL%%/MetaCPAN/Client.pm
 %%SITE_PERL%%/MetaCPAN/Client/Author.pm
 %%SITE_PERL%%/MetaCPAN/Client/Cover.pm
+%%SITE_PERL%%/MetaCPAN/Client/Cve.pm
 %%SITE_PERL%%/MetaCPAN/Client/Distribution.pm
 %%SITE_PERL%%/MetaCPAN/Client/DownloadURL.pm
 %%SITE_PERL%%/MetaCPAN/Client/Favorite.pm
@@ -10,7 +11,6 @@
 %%SITE_PERL%%/MetaCPAN/Client/Package.pm
 %%SITE_PERL%%/MetaCPAN/Client/Permission.pm
 %%SITE_PERL%%/MetaCPAN/Client/Pod.pm
-%%SITE_PERL%%/MetaCPAN/Client/Rating.pm
 %%SITE_PERL%%/MetaCPAN/Client/Release.pm
 %%SITE_PERL%%/MetaCPAN/Client/Request.pm
 %%SITE_PERL%%/MetaCPAN/Client/ResultSet.pm
@@ -21,6 +21,7 @@
 %%PERL5_MAN3%%/MetaCPAN::Client.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Author.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Cover.3.gz
+%%PERL5_MAN3%%/MetaCPAN::Client::Cve.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Distribution.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::DownloadURL.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Favorite.3.gz
@@ -30,7 +31,6 @@
 %%PERL5_MAN3%%/MetaCPAN::Client::Package.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Permission.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Pod.3.gz
-%%PERL5_MAN3%%/MetaCPAN::Client::Rating.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Release.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::Request.3.gz
 %%PERL5_MAN3%%/MetaCPAN::Client::ResultSet.3.gz


### PR DESCRIPTION
Synchronizes the plist with the installed Cve module and removes absent Rating entries.\n\nFixes Magus run 643 fake-stage failure.\n\nValidation: bmake fake; bmake package; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Resolve fake-stage failure in Magus run 643 by aligning the plist with the actual installed files.