### PR TITLE
databases/postgresql-relay: fix fake install paths

### DIFF
--- a/databases/postgresql-relay/Makefile
+++ b/databases/postgresql-relay/Makefile
@@ -18,10 +18,10 @@ PLIST_FILES=	bin/postgresql-relay etc/postgresql-relay.conf-sample \
 		share/man/man8/postgresql-relay.8.gz
 
 do-install:
-	${INSTALL_PROGRAM} ${WRKSRC}/postgresql-relay ${STAGEDIR}${PREFIX}/bin
+	${INSTALL_PROGRAM} ${WRKSRC}/postgresql-relay ${PREFIX}/bin
 	${INSTALL_DATA} ${WRKSRC}/postgresql-relay.conf-sample \
-		${STAGEDIR}${PREFIX}/etc/postgresql-relay.conf-sample
+		${PREFIX}/etc/postgresql-relay.conf-sample
 	${INSTALL_MAN} ${WRKSRC}/postgresql-relay.8 \
-		${STAGEDIR}${PREFIX}/share/man/man8
+		${PREFIX}/share/man/man8
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Uses the fake-rooted PREFIX directly in do-install.\n\nFixes Magus run 643 fake-stage failure.\n\nValidation: bmake fake; bmake package; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Correct install destinations for binaries, config samples, and man pages in the postgresql-relay port to avoid fake-stage failures.