### PR TITLE
sysutils/beats8: fix i386 Go type conversions

### DIFF
--- a/sysutils/beats8/files/patch-go-sysinfo
+++ b/sysutils/beats8/files/patch-go-sysinfo
@@ -657,7 +657,7 @@ diff -urN vendor.orig/github.com/elastic/go-sysinfo/providers/freebsd/process_fr
 +
 +	const maxlen = uint(1024)
 +	out := make([]C.char, maxlen)
-+	if res, err := C.procstat_getpathname(procstat, &p.kinfo, &out[0], C.ulong(maxlen)); res != 0 {
++	if res, err := C.procstat_getpathname(procstat, &p.kinfo, &out[0], C.size_t(maxlen)); res != 0 {
 +		return "", err
 +	}
 +	return C.GoString(&out[0]), nil
@@ -954,7 +954,7 @@ diff -urN vendor.orig/github.com/elastic/go-sysinfo/providers/freebsd/sysctl_fre
 +		return time.Time{}, fmt.Errorf("failed to get host uptime: %w", err)
 +	}
 +
-+	bootTime := time.Unix(tv.Sec, tv.Usec*int64(time.Microsecond))
++	bootTime := time.Unix(int64(tv.Sec), int64(tv.Usec)*int64(time.Microsecond))
 +	return bootTime, nil
 +}
 +


### PR DESCRIPTION
Casts FreeBSD timeval fields to int64 and uses C.size_t for procstat pathname length on i386.\n\nFixes the two Magus run 643 Go compile errors.\n\nValidation: bmake patch; git diff --check. Full build was started but module download did not complete in this environment.

## Summary by Sourcery

Bug Fixes:
- Cast FreeBSD timeval fields to int64 and use C.size_t for procstat pathname length to resolve i386 Go compilation errors in beats8.