### PR TITLE
www/gitlab-pages: fix fake install paths

### DIFF
--- a/www/gitlab-pages/Makefile
+++ b/www/gitlab-pages/Makefile
@@ -29,16 +29,16 @@ post-patch:
 	${REINPLACE_CMD} -e "s|%%PREFIX%%|${PREFIX}|" ${WRKSRC}/gitlab-pages.conf.sample
 
 do-install:
-	@${MKDIR} ${STAGEDIR}${DATADIR}
-	${MKDIR} ${STAGEDIR}${DATADIR}/bin
-	(cd ${WRKDIR}/bin/ && ${COPYTREE_BIN} .  ${STAGEDIR}${DATADIR}/bin)
+	@${MKDIR} ${DATADIR}
+	${MKDIR} ${DATADIR}/bin
+	(cd ${WRKDIR}/bin/ && ${COPYTREE_BIN} .  ${DATADIR}/bin)
 .for x in gitlab-pages.conf.sample
-	${INSTALL_DATA} ${WRKSRC}/${x} ${STAGEDIR}${DATADIR}/
+	${INSTALL_DATA} ${WRKSRC}/${x} ${DATADIR}/
 .endfor
 
 post-install:
-	${FIND} -s ${STAGEDIR}${DATADIR} -not -type d | ${SORT} | \
-		${SED} -e 's#^${STAGEDIR}${PREFIX}/##' | \
+	${FIND} -s ${DATADIR} -not -type d | ${SORT} | \
+		${SED} -e 's#^${PREFIX}/##' | \
 		${SED} -E -e '/sample$$/ s#^#@sample #; \
 		s#${DATADIR_REL}/bin#@(,,555) ${DATADIR_REL}/bin#; ' >> ${TMPPLIST}
 	cat ${TMPPLIST}


### PR DESCRIPTION
Uses the fake-rooted DATADIR and PREFIX directly in install and plist-generation hooks.\n\nFixes Magus run 643 fake-stage plist failure.\n\nValidation: bmake -n fake; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Resolve fake-stage plist generation failure by correcting paths used in install and post-install hooks for gitlab-pages.