### PR TITLE
databases/libvalkey: fix fake installation

### DIFF
--- a/databases/libvalkey/Makefile
+++ b/databases/libvalkey/Makefile
@@ -14,7 +14,8 @@ USE_GITHUB=	yes
 GH_ACCOUNT=	valkey-io
 
 MAKE_ARGS=	DEBUG_FLAGS= \
-		OPTIMIZATION=
+		OPTIMIZATION= \
+		PREFIX=${TRUE_PREFIX}
 
 ALL_TARGET=	dynamic
 
@@ -26,9 +27,10 @@ TLS_USES=	ssl
 TLS_MAKE_ARGS=	USE_TLS=1
 
 post-install:
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libvalkey.so.${DISTVERSION}
+	${STRIP_CMD} ${PREFIX}/lib/libvalkey.so.${DISTVERSION}
 
-post-install-TLS-on:
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libvalkey_tls.so.${DISTVERSION}
+	@if [ -e ${PREFIX}/lib/libvalkey_tls.so.${DISTVERSION} ]; then \
+		${STRIP_CMD} ${PREFIX}/lib/libvalkey_tls.so.${DISTVERSION}; \
+	fi
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Passes the true installation prefix to gmake while staging through DESTDIR, and strips both libraries in the fake-install environment.\n\nFixes Magus run 643 fake-stage failure.\n\nValidation: bmake clean; bmake fake; bmake package; git diff --check.

## Summary by Sourcery

Fix libvalkey port fake installation by passing the true installation prefix to the build and adjusting post-install stripping to operate on the real PREFIX and handle the TLS library conditionally.