### PR TITLE
Store language defaults in Magus indexes

### DIFF
--- a/Tools/lib/Magus.pm
+++ b/Tools/lib/Magus.pm
@@ -20,6 +20,7 @@ use Magus::PortTest ();
 use Magus::Chroot ();
 use Magus::Index ();
 use Magus::Run ();
+use Magus::DefaultVersion ();
 use Magus::Log ();
 use Magus::PhaseLog ();
 use Magus::PhaseResult ();

--- a/Tools/lib/Magus/DefaultVersion.pm
+++ b/Tools/lib/Magus/DefaultVersion.pm
@@ -1,0 +1,40 @@
+package Magus::DefaultVersion;
+#
+# Copyright (c) 2026 Lucas Holt. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+# 1. Redistributions of source code must retain the above copyright notice
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+use strict;
+use warnings;
+
+use base 'Magus::DBI';
+
+__PACKAGE__->table('default_versions');
+__PACKAGE__->columns(Primary => qw(run name));
+__PACKAGE__->columns(Essential => qw(version));
+
+__PACKAGE__->has_a(run => 'Magus::Run');
+
+1;
+__END__

--- a/Tools/lib/Magus/Index.pm
+++ b/Tools/lib/Magus/Index.pm
@@ -72,6 +72,8 @@ sub sync {
   }
   
   $root ||= "$Magus::Config{MasterDataDir}/$Magus::Config{MportsVcsDir}";
+
+  $class->sync_default_versions($root, $run, $arch, $osrel, $osversion);
   
   local $| = 1;
   
@@ -287,6 +289,54 @@ sub sync {
   moved_list($run, $root);
   
   print "done.\n";
+}
+
+sub sync_default_versions {
+  my ($class, $root, $run, $arch, $osrel, $osversion) = @_;
+  my @defaults = (
+    [ python => 'PYTHON_DEFAULT' ],
+    [ perl5  => 'PERL5_DEFAULT' ],
+    [ ruby   => 'RUBY_DEFAULT' ],
+    [ php    => 'PHP_DEFAULT' ],
+  );
+  my $makefile = "$root/Mk/components/default-versions.mk";
+
+  die "Default versions makefile $makefile does not exist\n" unless -f $makefile;
+
+  local %ENV = %ENV;
+  $ENV{__MAKE_CONF} = '/dev/null';
+  $ENV{SSL_DEFAULT} = 'base';
+  $ENV{INDEXING} = 1;
+  $ENV{ARCH} = $arch;
+  $ENV{OSREL} = $osrel;
+  $ENV{OSVERSION} = $osversion;
+  $ENV{PORTSDIR} = $root;
+  $ENV{BATCH} = 1;
+  $ENV{PACKAGE_BUILDING} = 1;
+  $ENV{MAGUS} = 1;
+
+  my @args = ('make', '-f', $makefile);
+  push @args, map { ('-V', $_->[1]) } @defaults;
+
+  open(my $make, '-|', @args) ||
+    die "Unable to evaluate default versions: $!\n";
+  my @values = <$make>;
+  close($make) ||
+    die "Unable to evaluate default versions from $makefile\n";
+
+  die "Expected " . scalar(@defaults) . " default versions, got " . scalar(@values) . "\n"
+    unless @values == @defaults;
+
+  for my $i (0 .. $#defaults) {
+    chomp $values[$i];
+    die "$defaults[$i]->[1] is empty\n" unless length $values[$i];
+
+    Magus::DefaultVersion->insert({
+      run     => $run,
+      name    => $defaults[$i]->[0],
+      version => $values[$i],
+    });
+  }
 }
 
 sub moved_list {

--- a/Tools/lib/Magus/Run.pm
+++ b/Tools/lib/Magus/Run.pm
@@ -38,6 +38,7 @@ __PACKAGE__->table('runs');
 __PACKAGE__->columns(Essential => qw/id osversion arch status created blessed/);
 
 __PACKAGE__->has_many(ports => 'Magus::Port');
+__PACKAGE__->has_many(default_versions => 'Magus::DefaultVersion');
 
 =head2 Magus::Run->latest($machine)
 

--- a/Tools/magus/bless/magus-bless.cxx
+++ b/Tools/magus/bless/magus-bless.cxx
@@ -40,10 +40,6 @@ using namespace pqxx;
 #include <sha256.h>
 
 #include <ucl.h>
-#ifdef ucl_object_find_key
-#undef ucl_object_find_key
-#endif
-extern "C" const ucl_object_t *ucl_object_find_key(const ucl_object_t *, const char *);
 
 #include "sqlite3.h"
 
@@ -275,6 +271,36 @@ main(int argc, char *argv[])
         }
     }
 
+    printf("Load default versions\n");
+    snprintf(query_def, sizeof(query_def),
+      "SELECT name, version FROM default_versions WHERE run=%d ORDER BY name", runid);
+    result R5(N.exec(string(query_def)));
+    unsigned int default_count = 0;
+    for (result::const_iterator c = R5.begin(); c != R5.end(); ++c)
+    {
+        if (sqlite3_prepare_v2(db,
+            "INSERT INTO default_versions (name, version) VALUES(?,?)",
+            -1, &stmt, 0) != SQLITE_OK)
+        {
+            errx(1, "Could not prepare default version statement");
+        }
+
+        string name = c[0].as(string());
+        string version = c[1].as(string());
+        sqlite3_bind_text(stmt, 1, name.c_str(), name.length(), SQLITE_TRANSIENT);
+        sqlite3_bind_text(stmt, 2, version.c_str(), version.length(), SQLITE_TRANSIENT);
+
+        if (sqlite3_step(stmt) != SQLITE_DONE)
+            errx(1, "Could not insert default version");
+        sqlite3_finalize(stmt);
+        default_count++;
+    }
+    if (default_count != 4) {
+        fprintf(stderr,
+            "Warning: run %d has %u default versions; expected 4\n",
+            runid, default_count);
+    }
+
 	printf("Load ALIASES not included in current run\n");
 	snprintf(query_def, sizeof(query_def), "select distinct(pkgname, name, moved_to), pkgname, name, moved.moved_to from ports inner join runs on ports.run = runs.id left join moved on moved.port = ports.name where moved.run = %d and ports.run < %d and moved.port not in (SELECT name from ports where run = %d) and runs.arch = (select arch from runs where id = %d) group by pkgname, name, moved_to order by pkgname, name, moved_to;", runid, runid, runid, runid);
 	result R4(N.exec(string(query_def)));
@@ -354,7 +380,7 @@ config_string(const ucl_object_t *root, const char *key, const char *default_val
     const ucl_object_t *obj;
     const char *value;
 
-    obj = ucl_object_find_key(root, key);
+    obj = ucl_object_lookup(root, key);
     if (obj == NULL)
         return string(default_value);
 
@@ -410,14 +436,14 @@ exec_indexdb(sqlite3 *db, const char *fmt, ...)
 
   sqlcode = sqlite3_exec(db, sql, 0, 0, 0);
   /* if we get an error code, we want to run it again in some cases */
-  if (sqlcode == SQLITE_BUSY || sqlcode == SQLITE_LOCKED) {
+    if (sqlcode == SQLITE_BUSY || sqlcode == SQLITE_LOCKED) {
     if (sqlite3_exec(db, sql, 0, 0, 0) != SQLITE_OK) {
       sqlite3_free(sql);
-      errx(1, sqlite3_errmsg(db));
+      errx(1, "%s", sqlite3_errmsg(db));
     }
   } else if (sqlcode != SQLITE_OK) {
     sqlite3_free(sql);
-    errx(1, sqlite3_errmsg(db));
+    errx(1, "%s", sqlite3_errmsg(db));
   }
 
   sqlite3_free(sql);
@@ -435,6 +461,7 @@ create_indexdb(sqlite3 *db)
 	exec_indexdb(db, "CREATE TABLE IF NOT EXISTS aliases (alias text NOT NULL, pkg text NOT NULL)");
 	exec_indexdb(db, "CREATE TABLE IF NOT EXISTS depends (pkg text NOT NULL, version text NOT NULL, d_pkg text NOT NULL, d_version text NOT NULL)");
 	exec_indexdb(db, "CREATE TABLE IF NOT EXISTS moved (port text NOT NULL, moved_to text, why text, date text)");
+	exec_indexdb(db, "CREATE TABLE IF NOT EXISTS default_versions (name text PRIMARY KEY, version text NOT NULL)");
 }
 
 void

--- a/Tools/magus/migrations/20260727_default_versions.sql
+++ b/Tools/magus/migrations/20260727_default_versions.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS default_versions (
+    run integer NOT NULL REFERENCES runs(id) ON DELETE CASCADE,
+    name varchar(32) NOT NULL,
+    version varchar(32) NOT NULL,
+    PRIMARY KEY (run, name)
+);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON default_versions TO magus;
+
+COMMIT;

--- a/Tools/magus/schema.sql
+++ b/Tools/magus/schema.sql
@@ -256,6 +256,19 @@ CREATE INDEX idx_runs_arch_osversion_status
 ON runs (arch, osversion, status);
 
 --
+-- Table structure for table default_versions
+--
+
+DROP TABLE "default_versions" CASCADE\g
+
+CREATE TABLE "default_versions" (
+   "run" integer NOT NULL,
+   "name" varchar(32) NOT NULL,
+   "version" varchar(32) NOT NULL,
+   primary key ("run", "name")
+);
+
+--
 -- Table structure for table distfiles
 --
 
@@ -383,6 +396,7 @@ alter table distfiles add foreign key (port) references ports(id);
 alter table restricted_distfiles add foreign key (port) references ports(id);
 alter table master_sites add foreign key (port) references ports(id);
 alter table moved add foreign key (run) references runs(id);
+alter table default_versions add foreign key (run) references runs(id) on delete cascade;
 alter table events add foreign key ("machine") references machines("id");
 alter table events add foreign key ("port") references ports("id");
 ALTER TABLE "depends" ADD FOREIGN KEY ("port") REFERENCES "ports"("id");


### PR DESCRIPTION
## What

- add a per-run PostgreSQL `default_versions` table
- capture the Python, Perl, Ruby, and PHP defaults from `Mk/components/default-versions.mk` during Magus indexing
- evaluate defaults with the run's architecture and OS environment
- export the selected run's defaults into a compact SQLite table during `magus-bless`
- include a migration for existing Magus databases

## Why

The package index currently records available package versions but not the framework defaults that selected them. When a default changes, for example Python 3.11 to 3.12, mport cannot distinguish an intended language-runtime transition from an unrelated package update.

The SQLite metadata produced here is consumed by the companion mport PR so updates can make an informed transition.

## Impact

Each Magus run retains the defaults used while indexing, so blessing an older run remains reproducible. The SQLite schema adds one small `default_versions(name, version)` table and remains readable by older mport clients.

## Checks

- `bmake -C Tools/magus/bless clean all`
- Perl syntax checks for `Magus::DefaultVersion` and `Magus::Index`
- mocked framework capture: Python 3.12, Perl 5.40, Ruby 3.2, PHP 8.3
- `git diff --check`

Build validation used the installed `postgresql-libpqxx-7.10.1` dependency.

## Summary by Sourcery

Capture per-run language default versions in Magus and export them into the blessed SQLite index for use by mport.

Enhancements:
- Record Python, Perl, Ruby, and PHP default versions for each Magus run by evaluating the ports default-versions makefile in the run environment.
- Expose per-run default versions through a new Magus::DefaultVersion model and associate them with runs.
- Export the recorded default versions into the SQLite index during magus-bless so clients can see the framework language defaults used for that run.
- Align UCL configuration lookup with current APIs and improve SQLite error reporting in magus-bless.

Chores:
- Add PostgreSQL schema updates and a migration to create the default_versions table with proper run foreign-key relationships.