### PR TITLE
devel/electron40: fix fetch on clean builders

### DIFF
--- a/devel/electron40/Makefile
+++ b/devel/electron40/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	electron
 DISTVERSIONPREFIX=	v
 DISTVERSION=	${ELECTRON_VER}
-PORTREVISION=	2
+PORTREVISION=	3
 PULSEMV=	16
 PULSEV=		${PULSEMV}.1
 CATEGORIES=	devel
@@ -26,11 +26,11 @@ LICENSE_FILE=	${WRKSRC}/electron/LICENSE
 BROKEN_i386=	fetch fails: node process stalls during fetch phase and eats up all CPUs
 ONLY_FOR_ARCHS=	aarch64 amd64 i386
 
+# node is needed at fetch time too: pre-fetch runs corepack to drive yarn
 FETCH_DEPENDS=	git:devel/git \
-		${NULL}
+		node:www/node${NODEJS_VERSION}
 PATCH_DEPENDS=	git:devel/git \
 		jq:textproc/jq
-# NOTE: devel/esbuild must be added to mports before electron40 can build
 BUILD_DEPENDS=	esbuild:devel/esbuild \
 		gperf:devel/gperf \
 		bindgen:devel/rust-bindgen-cli \
@@ -120,7 +120,25 @@ NODE_MODULES_TARBALL=	${DISTDIR}/${DIST_SUBDIR}/${_DISTFILE_NODE_MODULES}
 
 YARN_NPM_URL=	https://registry.npmjs.org/@yarnpkg/cli-dist/-/cli-dist-${NPM_VER}.tgz
 
-pre-fetch: electron-fetch-node-package-manager electron-fetch-node-modules electron-archive-node-modules
+# The Electron source tarball as USE_GITHUB names it. electron-fetch-node-modules
+# needs it to read package.json/yarn.lock, but pre-fetch runs before do-fetch, so
+# it has to be fetched explicitly here rather than assumed present.
+ELECTRON_SRC_TGZ=	${DISTDIR}/${DIST_SUBDIR}/${DISTNAME}.tar.gz
+ELECTRON_SRC_URL=	https://codeload.github.com/${GH_ACCOUNT}/${GH_PROJECT}/tar.gz/${DISTVERSIONFULL}?dummy=/${DISTNAME}.tar.gz
+
+pre-fetch: electron-fetch-node-package-manager electron-fetch-source \
+	electron-fetch-node-modules electron-archive-node-modules
+
+electron-fetch-source:
+	@if [ -f ${ELECTRON_SRC_TGZ} ]; then \
+		${ECHO_MSG} "===>  Using prefetched ${DISTNAME}.tar.gz"; \
+	else \
+		${ECHO_MSG} "===>  Fetching ${DISTNAME}.tar.gz"; \
+		${MKDIR} ${DISTDIR}/${DIST_SUBDIR}; \
+		${SETENV} ${FETCH_ENV} ${FETCH_CMD} ${FETCH_BEFORE_ARGS} \
+			-o ${ELECTRON_SRC_TGZ} "${ELECTRON_SRC_URL}" \
+			${FETCH_AFTER_ARGS}; \
+	fi
 
 electron-fetch-node-package-manager:
 	@if [ -f ${YARN_TGZ} ]; then \
@@ -170,7 +188,11 @@ electron-archive-node-modules:
 		exit 0; \
 	fi; \
 	${ECHO_MSG} "===>  Archiving node modules offline cache"; \
-	cd ${NPM_EXTRACT_WRKSRC} && ${TAR} -cJf ${NODE_MODULES_TARBALL} ${NPM_MODULE_CACHE}
+	cd ${NPM_EXTRACT_WRKSRC} && \
+		${FIND} ${NPM_MODULE_CACHE} -exec ${TOUCH} -h -d 1970-01-01T00:00:00Z {} + && \
+		${FIND} ${NPM_MODULE_CACHE} -print0 | LC_ALL=C ${SORT} -z | \
+		${TAR} -cJf ${NODE_MODULES_TARBALL} --format=bsdtar --gid 0 --uid 0 \
+			--no-recursion --null -T -
 
 SHEBANG_FILES=	chrome/tools/build/linux/chrome-wrapper buildtools/linux64/clang-format
 
@@ -314,7 +336,7 @@ MANTLE_VER=			78d3966b3c331292ea29ec38661b25df0a245948
 # See ${WRKSRC}/electron/DEPS for ENGFLOW_RECLIENT_CONFIGS_VER
 ENGFLOW_RECLIENT_CONFIGS_VER=	955335c30a752e9ef7bff375baab5e0819b6c00d
 # Keep in sync with devel/esbuild
-ESBUILD_VER=			0.27.1
+ESBUILD_VER=			0.28.1
 
 .include "Makefile.version"
 .include <bsd.port.pre.mk>

--- a/devel/electron40/distinfo
+++ b/devel/electron40/distinfo
@@ -1,4 +1,4 @@
-TIMESTAMP = 1777116979
+TIMESTAMP = 1785551035
 SHA256 (electron/chromium-144.0.7559.236.tar.xz.0) = 21556e44d5f5e464a7603afc1e912127c4546d3c55d777055614b769247d2714
 SIZE (electron/chromium-144.0.7559.236.tar.xz.0) = 2000000000
 SHA256 (electron/chromium-144.0.7559.236.tar.xz.1) = 389e96ab80e7f3ea7a330060c51ed714f2277810b13bbd1d72bb9e6119dce3a2
@@ -9,8 +9,8 @@ SHA256 (electron/pulseaudio-16.1.tar.gz) = 027266c62f2a84422ac45fa721a649508f0f1
 SIZE (electron/pulseaudio-16.1.tar.gz) = 2763111
 SHA256 (electron/yarn-4.12.0.tgz) = c60829c8dbf2263e6c6be34c15ebb2830f67a267de4b7d646f4043680fe47a66
 SIZE (electron/yarn-4.12.0.tgz) = 1059585
-SHA256 (electron/electron40-40.9.2-node-modules.tar.xz) = b0068fa06ba9c5bc449a2ab423a3a4c65e77a7f6cff3255e2d9aae61ac036df1
-SIZE (electron/electron40-40.9.2-node-modules.tar.xz) = 59792711
+SHA256 (electron/electron40-40.9.2-node-modules.tar.xz) = 8082169273422927da9b68935a50f9d1b75acc73fa612f960a76cc4529d5bf09
+SIZE (electron/electron40-40.9.2-node-modules.tar.xz) = 28617732
 SHA256 (electron/electron-electron-v40.9.2_GH0.tar.gz) = f066f2e6b6d878fce77bbbd64316f8848acb3bbc5827ab9f6220f4a0700bd58c
 SIZE (electron/electron-electron-v40.9.2_GH0.tar.gz) = 17293190
 SHA256 (electron/nodejs-node-v24.14.1_GH0.tar.gz) = dd9da50596e7b1c4edeb56daf0e81f57e1b61e43c36f40eadeee77be7d779e08
@@ -25,5 +25,5 @@ SHA256 (electron/Mantle-Mantle-78d3966b3c331292ea29ec38661b25df0a245948_GH0.tar.
 SIZE (electron/Mantle-Mantle-78d3966b3c331292ea29ec38661b25df0a245948_GH0.tar.gz) = 62962
 SHA256 (electron/EngFlow-reclient-configs-955335c30a752e9ef7bff375baab5e0819b6c00d_GH0.tar.gz) = c148f76220fc41a89ffeaf370c2cc175577be184688b12aa6fec5f8ac6c714c4
 SIZE (electron/EngFlow-reclient-configs-955335c30a752e9ef7bff375baab5e0819b6c00d_GH0.tar.gz) = 13014
-SHA256 (electron/evanw-esbuild-v0.27.1_GH0.tar.gz) = bcc3abdc911961ef04340714dc69ddc34af6d2e2c60a1c4036d1c7f1a3fc4a23
-SIZE (electron/evanw-esbuild-v0.27.1_GH0.tar.gz) = 1978868
+SHA256 (electron/evanw-esbuild-v0.28.1_GH0.tar.gz) = 65c756fa87d43178ac4a5242454c2bd0fde325f8ecf77997f8fa4b88f94d5cd2
+SIZE (electron/evanw-esbuild-v0.28.1_GH0.tar.gz) = 1997481


### PR DESCRIPTION
`devel/electron40` has never fetched successfully on a machine without a pre-populated `Distfiles` directory. Magus reports fetch failures on both 4.0/amd64 and 4.1/amd64, and the failure reproduces locally.

## Three separate defects

**1. `pre-fetch` ordering.** `electron-fetch-node-modules` untars the Electron source tarball to read `package.json`/`yarn.lock`, but `pre-fetch` runs *before* `do-fetch`, so the tarball does not exist yet. It only appeared to work where the distfile happened to already be cached. Magus log:

```
===>  Prefetching node modules (offline cache)
tar: Error opening archive: Failed to open '/magus/distfiles/electron/electron-electron-v40.9.2_GH0.tar.gz'
```

Fixed with a new `electron-fetch-source` target that fetches the tarball explicitly, mirroring what `electron-fetch-node-package-manager` already does for yarn.

**2. The generated node-modules offline cache was not reproducible.** It was archived with a plain `tar -cJf` — no entry ordering, no timestamp normalisation — so its checksum could never match `distinfo` on another machine. The recorded entry (59792711 bytes) did not match a regenerated tarball at all (32363708 bytes, different hash). Entries are now sorted with timestamps/uid/gid zeroed, the same approach `ai/llama-cpp` uses for its WebUI cache. Two independent cold runs now produce byte-identical output. `distinfo` regenerated.

**3. `node` was only a `BUILD_DEPENDS`** but `pre-fetch` runs `corepack` to drive yarn, so it must be a `FETCH_DEPENDS` too.

Also syncs `ESBUILD_VER` to 0.28.1 (see #670, which must land first) and drops a stale note claiming `devel/esbuild` does not exist in mports.

## Validation

With the node-modules distfile deleted, `bmake checksum` fetches and regenerates everything and every checksum passes, including the regenerated tarball.

**Not validated:** the full build was not run — it is unchanged by this commit, and this PR is scoped to the fetch phase. portlint's pre-existing FATALs are all over-100-character patch filenames inherited from FreeBSD; no `files/` were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure electron40 fetch phase works reliably on clean builders by fixing source tarball prefetching, making the node-modules offline cache reproducible, and updating related dependencies and metadata.

Bug Fixes:
- Fetch the Electron source tarball explicitly during pre-fetch so node module caching works on clean machines.
- Make the node-modules offline cache tarball reproducible by normalizing timestamps, ownership, and entry ordering.
- Treat node as a fetch-time dependency so pre-fetch can run corepack/yarn correctly.

Enhancements:
- Synchronize ESBUILD_VER with the newer esbuild 0.28.1 release.