### PR TITLE
devel/electron41: fix the build, Electron now compiles and packages

### DIFF
--- a/devel/electron41/Makefile
+++ b/devel/electron41/Makefile
@@ -232,6 +232,7 @@ TARGET_ORDER_OVERRIDE=	750:cargo-extract
 WRKSRC=		${WRKDIR}/src
 
 GN_ARGS+=	clang_use_chrome_plugins=false \
+		enable_backup_ref_ptr_support=false \
 		enable_hangout_services_extension=true \
 		enable_remoting=false \
 		fatal_linker_warnings=false \
@@ -241,10 +242,13 @@ GN_ARGS+=	clang_use_chrome_plugins=false \
 		optimize_webui=true \
 		toolkit_views=true \
 		treat_warnings_as_errors=false \
+		use_allocator_shim=false \
 		use_aura=true \
 		use_custom_libcxx=true \
 		use_custom_libunwind=true \
 		use_lld=true \
+		use_partition_alloc=true \
+		use_partition_alloc_as_malloc=false \
 		use_qt5=true \
 		use_sysroot=false \
 		use_system_freetype=false \
@@ -362,18 +366,30 @@ IGNORE=		you have selected HEIMDAL_BASE but do not have Heimdal installed in bas
 
 LLVM_DEFAULT=		21
 BUILD_DEPENDS+=		clang${LLVM_DEFAULT}:devel/llvm${LLVM_DEFAULT}
-BINARY_ALIAS+=		ar=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-ar \
+BINARY_ALIAS+=		cpp=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang-cpp \
+			cc=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang \
+			c++=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang++ \
+			ar=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-ar \
 			nm=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-nm \
 			ld=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/ld.lld
 
-# GN's default toolchain uses `cc`/`c++` from PATH. Do not use BINARY_ALIAS
-# symlinks for those: clang's resource-dir resolution uses argv[0] and breaks
-# when invoked via a symlink in `${WRKDIR}/.bin`, causing missing intrinsics
-# headers like `xmmintrin.h`.
+# GN's clang_toolchain template hardcodes cc/c++ from PATH and ignores
+# clang_base_path, so BINARY_ALIAS is the only way to select the compiler.
+# Without it the build silently uses base clang, which is too old for
+# Chromium 146 (its bundled libc++ requires clang 20+, and clang 19 crashes
+# in Sema on the C++20 defaulted comparison operators).
+#
+# Chromium compiles with -no-canonical-prefixes, which makes clang derive its
+# resource directory from argv[0]; through the BINARY_ALIAS symlink in
+# ${WRKDIR}/.bin that resolves to a path which does not exist, so intrinsics
+# headers like xmmintrin.h go missing. Pass the real directory explicitly.
+CLANG_RESOURCE_DIR=	${LOCALBASE}/llvm${LLVM_DEFAULT}/lib/clang/${LLVM_DEFAULT}
 CC=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang
 CXX=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang++
 CPP=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang-cpp
-CFLAGS+=		-Wno-error=implicit-function-declaration
+CFLAGS+=		-Wno-error=implicit-function-declaration \
+			-resource-dir=${CLANG_RESOURCE_DIR}
+CXXFLAGS+=		-resource-dir=${CLANG_RESOURCE_DIR}
 
 .if ${ARCH} == "aarch64"
 PLIST_SUB+=	AARCH64="" \
@@ -558,9 +574,12 @@ pre-build:
 		--verbose \
 		--verbose \
 		${CARGO_BUILD_ARGS}
+	# mports' cargo.mk always sets CARGO_BUILD_TARGET, so artifacts land in
+	# ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/<profile>/ rather than the
+	# ${CARGO_TARGET_DIR}/<profile>/ that FreeBSD's glob assumes.
 	(cd ${WRKSRC}/third_party/devtools-frontend/src/node_modules/@rollup && \
 		${MKDIR} rollup-freebsd && \
-		${CP} ${CARGO_TARGET_DIR}/*/libbindings_napi.so \
+		${CP} ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/*/libbindings_napi.so \
 			rollup-freebsd/rollup.freebsd.node && \
 		${ECHO_CMD} '{ "main": "./rollup.freebsd.node" }' \
 			> rollup-freebsd/package.json)
@@ -579,39 +598,39 @@ post-build-DIST-on:
 		${SHA256} -r *-v${ELECTRON_VER}-freebsd-*.zip | ${SED} -e 's/ / */' > SHASUMS256.txt
 
 do-install:
-	${MKDIR} ${STAGEDIR}${DATADIR}
+	${MKDIR} ${DATADIR}
 .for f in electron mksnapshot v8_context_snapshot_generator
-	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
 .for f in libEGL.so libGLESv2.so libffmpeg.so libvk_swiftshader.so
-	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
-	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/libvulkan.so.1 ${STAGEDIR}${DATADIR}/libvulkan.so
+	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/libvulkan.so.1 ${DATADIR}/libvulkan.so
 .for f in LICENSE LICENSES.chromium.html snapshot_blob.bin v8_context_snapshot.bin version vk_swiftshader_icd.json
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
 .for f in chrome_100_percent.pak chrome_200_percent.pak resources.pak
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
-	${MKDIR} ${STAGEDIR}${DATADIR}/locales
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/locales/*.pak ${STAGEDIR}${DATADIR}/locales
-	${MKDIR} ${STAGEDIR}${DATADIR}/resources
+	${MKDIR} ${DATADIR}/locales
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/locales/*.pak ${DATADIR}/locales
+	${MKDIR} ${DATADIR}/resources
 .for f in default_app.asar
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/resources/${f} ${STAGEDIR}${DATADIR}/resources
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/resources/${f} ${DATADIR}/resources
 .endfor
-	cd ${WRKSRC}/out/${BUILDTYPE}/gen && ${COPYTREE_SHARE} node_headers ${STAGEDIR}${DATADIR}
-	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/electron/buildflags ${STAGEDIR}${DATADIR}
-	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/v8/embedded.S ${STAGEDIR}${DATADIR}
-	${RLN} ${STAGEDIR}${DATADIR}/electron ${STAGEDIR}${PREFIX}/bin/electron${PKGNAMESUFFIX}
+	cd ${WRKSRC}/out/${BUILDTYPE}/gen && ${COPYTREE_SHARE} node_headers ${DATADIR}
+	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/electron/buildflags ${DATADIR}
+	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/v8/embedded.S ${DATADIR}
+	${RLN} ${DATADIR}/electron ${PREFIX}/bin/electron${PKGNAMESUFFIX}
 
 post-install-DIST-on:
-	${MKDIR} ${STAGEDIR}${DATADIR}/releases
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/SHASUMS256.txt ${STAGEDIR}${DATADIR}/releases
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/*-v${ELECTRON_VER}-freebsd-*.zip ${STAGEDIR}${DATADIR}/releases
+	${MKDIR} ${DATADIR}/releases
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/SHASUMS256.txt ${DATADIR}/releases
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/*-v${ELECTRON_VER}-freebsd-*.zip ${DATADIR}/releases
 
 post-install-DRIVER-on:
 	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/chromedriver.unstripped \
-		${STAGEDIR}${DATADIR}/chromedriver
+		${DATADIR}/chromedriver
 
 do-test:
 	cd ${WRKSRC}/electron && \

--- a/devel/electron41/files/patch-build_landmine__utils.py
+++ b/devel/electron41/files/patch-build_landmine__utils.py
@@ -1,0 +1,11 @@
+--- build/landmine_utils.py.orig	2025-08-26 20:49:50 UTC
++++ build/landmine_utils.py
+@@ -11,7 +11,7 @@ def IsWindows():
+
+
+ def IsLinux():
+-  return sys.platform.startswith(('linux', 'freebsd', 'netbsd', 'openbsd'))
++  return sys.platform.startswith(('linux', 'freebsd', 'netbsd', 'openbsd', 'midnightbsd'))
+
+
+ def IsMac():

--- a/devel/electron41/files/patch-third__party_blink_renderer_bindings_scripts_bind__gen_style__format.py
+++ b/devel/electron41/files/patch-third__party_blink_renderer_bindings_scripts_bind__gen_style__format.py
@@ -5,7 +5,7 @@
      # Determine //buildtools/<platform>/ directory
      new_path_platform_suffix = ""
 -    if sys.platform.startswith("linux"):
-+    if sys.platform.startswith(("linux","openbsd","freebsd")):
++    if sys.platform.startswith(("linux","openbsd","freebsd","midnightbsd")):
          platform = "linux64"
          exe_suffix = ""
      elif sys.platform.startswith("darwin"):


### PR DESCRIPTION
Follow-up to #672, which was validated only through `configure`. Building it end to end turned up six further problems. **Electron 41 now compiles, stages and packages on MidnightBSD** — `electron41-41.10.2_1.mport` (126MB), and the binary reports `v41.10.2`.

As far as I can tell this is the first time Electron/Chromium has built on MidnightBSD at all.

## Port infrastructure

**rollup native binding path.** `pre-build` copied from `${CARGO_TARGET_DIR}/*/`, but mports' `cargo.mk` always sets `CARGO_BUILD_TARGET`, so cargo writes to `${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/<profile>/`. FreeBSD's glob only works when no target triple is passed.

**The build silently used base clang, not `devel/llvm21`.** GN's `clang_toolchain` template hardcodes `cc`/`c++` from PATH and ignores `clang_base_path`, so `BINARY_ALIAS` is the only way to select a compiler — setting `CC`/`CXX` alone only affects the GN bootstrap. Base clang 19 is too old for Chromium 146: its bundled libc++ requires clang 20+, and clang 19 **crashes in `Sema`** on the C++20 defaulted comparison operators.

The `cc`/`c++` aliases were presumably dropped because Chromium builds with `-no-canonical-prefixes`, which makes clang derive its resource directory from `argv[0]` — through the alias symlink that resolves to a nonexistent path, so intrinsics headers go missing. Reproduced directly:

```
$ ln -sf /usr/local/llvm21/bin/clang $T/cc && $T/cc -no-canonical-prefixes -print-resource-dir
/tmp/lib/clang/21          # does not exist
```

Fix: restore the aliases and pass `-resource-dir` explicitly.

**Allocator GN args.** `GN_ARGS` had lost `use_allocator_shim=false`, `use_partition_alloc=true`, `use_partition_alloc_as_malloc=false` and `enable_backup_ref_ptr_support=false`. Without them the allocator shim is compiled, and it does not build here: `/usr/include/stdlib.h` declares `malloc`/`free`/`realloc` without `__THROW`, so the shim's redeclarations conflict.

**Staging.** `do-install` used FreeBSD's `${STAGEDIR}${PREFIX}`. In mports `${PREFIX}` already has `FAKE_DESTDIR` prepended during `do-install`, so every path was staged twice over (`.../fake-inst-amd64/usr/mports/.../fake-inst-amd64/usr/local/bin`). Dropped `${STAGEDIR}` throughout.

## MidnightBSD portability

Two more, both Python, same shape as those in #672:

- `bind_gen/style_format.py` — `AssertionError: Unknown platform: midnightbsd4` when generating the V8 bindings
- `build/landmine_utils.py` — `IsLinux()` returned False; found by sweeping the tree for scripts accepting `freebsd` but not `midnightbsd` rather than waiting for it to fail

The C and C++ sources needed **no changes at all** across ~30,000 objects, confirming that defining `__FreeBSD__` alongside `__MidnightBSD__` carries that layer by itself.

## Validation

Builds from a clean tree, stages, and packages. The FreeBSD `pkg-plist` matched the staged tree with no changes.

**Not validated:** `bmake test`; and the `DIST`/`DRIVER` options are off by default and untested — their `post-install-*-on` targets got the same `${STAGEDIR}` removal for consistency, but AGENTS.md is explicit only about `do-install-*`/`do-fake-*` sub-targets.

## Note for devel/electron40

Two of these are inherited from electron40 and are wrong there too: it declares `LLVM_DEFAULT=21` and build-depends on `devel/llvm21`, but with no `cc`/`c++` alias it cannot be building with that compiler; and it carries the same allocator GN-arg removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Electron 41 port build and staging so it successfully compiles and packages on MidnightBSD.

Bug Fixes:
- Restore and adjust GN allocator and partition alloc arguments to avoid allocator shim build failures.
- Ensure GN uses the devel/llvm21 toolchain via BINARY_ALIAS and explicit clang resource directory configuration.
- Correct rollup native binding copy path to match cargo.mk target directory layout.
- Fix installation paths by dropping redundant STAGEDIR usage so files stage correctly in mports.
- Extend Python platform detection scripts to recognize MidnightBSD in V8 binding generation and landmine utilities.