### PR TITLE
devel/electron40: make the port buildable on MidnightBSD

### DIFF
--- a/devel/electron40/Makefile
+++ b/devel/electron40/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	electron
 DISTVERSIONPREFIX=	v
 DISTVERSION=	${ELECTRON_VER}
-PORTREVISION=	3
+PORTREVISION=	4
 PULSEMV=	16
 PULSEV=		${PULSEMV}.1
 CATEGORIES=	devel
@@ -213,6 +213,7 @@ WRKSRC=		${WRKDIR}/${PKGNAME}
 WRKSRC_SUBDIR=	src
 
 GN_ARGS+=	clang_use_chrome_plugins=false \
+		enable_backup_ref_ptr_support=false \
 		enable_hangout_services_extension=true \
 		enable_remoting=false \
 		fatal_linker_warnings=false \
@@ -222,10 +223,13 @@ GN_ARGS+=	clang_use_chrome_plugins=false \
 		optimize_webui=true \
 		toolkit_views=true \
 		treat_warnings_as_errors=false \
+		use_allocator_shim=false \
 		use_aura=true \
 		use_custom_libcxx=true \
 		use_custom_libunwind=true \
 		use_lld=true \
+		use_partition_alloc=true \
+		use_partition_alloc_as_malloc=false \
 		use_qt5=true \
 		use_sysroot=false \
 		use_system_freetype=false \
@@ -347,18 +351,29 @@ IGNORE=		you have selected HEIMDAL_BASE but do not have Heimdal installed in bas
 
 LLVM_DEFAULT=		21
 BUILD_DEPENDS+=		clang${LLVM_DEFAULT}:devel/llvm${LLVM_DEFAULT}
-BINARY_ALIAS+=		ar=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-ar \
+BINARY_ALIAS+=		cpp=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang-cpp \
+			cc=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang \
+			c++=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang++ \
+			ar=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-ar \
 			nm=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/llvm-nm \
 			ld=${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/ld.lld
 
-# GN's default toolchain uses `cc`/`c++` from PATH. Do not use BINARY_ALIAS
-# symlinks for those: clang's resource-dir resolution uses argv[0] and breaks
-# when invoked via a symlink in `${WRKDIR}/.bin`, causing missing intrinsics
-# headers like `xmmintrin.h`.
+# GN's clang_toolchain template hardcodes cc/c++ from PATH and ignores
+# clang_base_path, so BINARY_ALIAS is the only way to select the compiler;
+# setting CC/CXX alone only affects the GN bootstrap. Without the aliases the
+# build silently uses base clang instead of devel/llvm${LLVM_DEFAULT}.
+#
+# Chromium compiles with -no-canonical-prefixes, which makes clang derive its
+# resource directory from argv[0]; through the BINARY_ALIAS symlink in
+# ${WRKDIR}/.bin that resolves to a path which does not exist, so intrinsics
+# headers like xmmintrin.h go missing. Pass the real directory explicitly.
+CLANG_RESOURCE_DIR=	${LOCALBASE}/llvm${LLVM_DEFAULT}/lib/clang/${LLVM_DEFAULT}
 CC=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang
 CXX=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang++
 CPP=			${LOCALBASE}/llvm${LLVM_DEFAULT}/bin/clang-cpp
-CFLAGS+=		-Wno-error=implicit-function-declaration
+CFLAGS+=		-Wno-error=implicit-function-declaration \
+			-resource-dir=${CLANG_RESOURCE_DIR}
+CXXFLAGS+=		-resource-dir=${CLANG_RESOURCE_DIR}
 
 .if ${ARCH} == "aarch64"
 PLIST_SUB+=	AARCH64="" \
@@ -540,39 +555,39 @@ post-build-DIST-on:
 		${SHA256} -r *-v${ELECTRON_VER}-freebsd-*.zip | ${SED} -e 's/ / */' > SHASUMS256.txt
 
 do-install:
-	${MKDIR} ${STAGEDIR}${DATADIR}
+	${MKDIR} ${DATADIR}
 .for f in electron mksnapshot v8_context_snapshot_generator
-	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
 .for f in libEGL.so libGLESv2.so libffmpeg.so libvk_swiftshader.so
-	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
-	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/libvulkan.so.1 ${STAGEDIR}${DATADIR}/libvulkan.so
+	${INSTALL_LIB} ${WRKSRC}/out/${BUILDTYPE}/libvulkan.so.1 ${DATADIR}/libvulkan.so
 .for f in LICENSE LICENSES.chromium.html snapshot_blob.bin v8_context_snapshot.bin version vk_swiftshader_icd.json
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
 .for f in chrome_100_percent.pak chrome_200_percent.pak resources.pak
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${STAGEDIR}${DATADIR}
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/${f} ${DATADIR}
 .endfor
-	${MKDIR} ${STAGEDIR}${DATADIR}/locales
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/locales/*.pak ${STAGEDIR}${DATADIR}/locales
-	${MKDIR} ${STAGEDIR}${DATADIR}/resources
+	${MKDIR} ${DATADIR}/locales
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/locales/*.pak ${DATADIR}/locales
+	${MKDIR} ${DATADIR}/resources
 .for f in default_app.asar
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/resources/${f} ${STAGEDIR}${DATADIR}/resources
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/resources/${f} ${DATADIR}/resources
 .endfor
-	cd ${WRKSRC}/out/${BUILDTYPE}/gen && ${COPYTREE_SHARE} node_headers ${STAGEDIR}${DATADIR}
-	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/electron/buildflags ${STAGEDIR}${DATADIR}
-	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/v8/embedded.S ${STAGEDIR}${DATADIR}
-	${RLN} ${STAGEDIR}${DATADIR}/electron ${STAGEDIR}${PREFIX}/bin/electron${PKGNAMESUFFIX}
+	cd ${WRKSRC}/out/${BUILDTYPE}/gen && ${COPYTREE_SHARE} node_headers ${DATADIR}
+	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/electron/buildflags ${DATADIR}
+	cd ${WRKSRC}/out/${BUILDTYPE} && ${COPYTREE_SHARE} gen/v8/embedded.S ${DATADIR}
+	${RLN} ${DATADIR}/electron ${PREFIX}/bin/electron${PKGNAMESUFFIX}
 
 post-install-DIST-on:
-	${MKDIR} ${STAGEDIR}${DATADIR}/releases
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/SHASUMS256.txt ${STAGEDIR}${DATADIR}/releases
-	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/*-v${ELECTRON_VER}-freebsd-*.zip ${STAGEDIR}${DATADIR}/releases
+	${MKDIR} ${DATADIR}/releases
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/SHASUMS256.txt ${DATADIR}/releases
+	${INSTALL_DATA} ${WRKSRC}/out/${BUILDTYPE}/*-v${ELECTRON_VER}-freebsd-*.zip ${DATADIR}/releases
 
 post-install-DRIVER-on:
 	${INSTALL_PROGRAM} ${WRKSRC}/out/${BUILDTYPE}/chromedriver.unstripped \
-		${STAGEDIR}${DATADIR}/chromedriver
+		${DATADIR}/chromedriver
 
 do-test:
 	cd ${WRKSRC}/electron && \

--- a/devel/electron40/files/patch-build_config_linux_pkg-config.py
+++ b/devel/electron40/files/patch-build_config_linux_pkg-config.py
@@ -5,7 +5,7 @@
    # success. This allows us to "kind of emulate" a Linux build from other
    # platforms.
 -  if "linux" not in sys.platform:
-+  if not sys.platform.startswith(tuple(['linux', 'openbsd', 'freebsd'])):
++  if not sys.platform.startswith(tuple(['linux', 'openbsd', 'freebsd', 'midnightbsd'])):
      print("[[],[],[],[],[]]")
      return 0
  

--- a/devel/electron40/files/patch-build_landmine__utils.py
+++ b/devel/electron40/files/patch-build_landmine__utils.py
@@ -1,0 +1,11 @@
+--- build/landmine_utils.py.orig	2025-04-22 20:15:27 UTC
++++ build/landmine_utils.py
+@@ -11,7 +11,7 @@ def IsWindows():
+
+
+ def IsLinux():
+-  return sys.platform.startswith(('linux', 'freebsd', 'netbsd', 'openbsd'))
++  return sys.platform.startswith(('linux', 'freebsd', 'netbsd', 'openbsd', 'midnightbsd'))
+
+
+ def IsMac():

--- a/devel/electron40/files/patch-media_ffmpeg_scripts_robo__lib_config.py
+++ b/devel/electron40/files/patch-media_ffmpeg_scripts_robo__lib_config.py
@@ -38,7 +38,7 @@
              self._host_operating_system = "win"
 +        elif platform.system() == "OpenBSD":
 +            self._host_operating_system = "openbsd"
-+        elif platform.system() == "FreeBSD":
++        elif platform.system() == "FreeBSD" or platform.system() == "MidnightBSD":
 +            self._host_operating_system = "freebsd"
          else:
              raise ValueError(f"Unsupported platform: {platform.system()}")

--- a/devel/electron40/files/patch-third__party_blink_renderer_bindings_scripts_bind__gen_style__format.py
+++ b/devel/electron40/files/patch-third__party_blink_renderer_bindings_scripts_bind__gen_style__format.py
@@ -5,7 +5,7 @@
      # Determine //buildtools/<platform>/ directory
      new_path_platform_suffix = ""
 -    if sys.platform.startswith("linux"):
-+    if sys.platform.startswith(("linux","openbsd","freebsd")):
++    if sys.platform.startswith(("linux","openbsd","freebsd","midnightbsd")):
          platform = "linux64"
          exe_suffix = ""
      elif sys.platform.startswith("darwin"):

--- a/devel/electron40/files/patch-third__party_node_node.py
+++ b/devel/electron40/files/patch-third__party_node_node.py
@@ -1,11 +1,12 @@
 --- third_party/node/node.py.orig	2025-04-22 20:15:27 UTC
 +++ third_party/node/node.py
-@@ -20,6 +20,8 @@ def GetBinaryPath():
+@@ -20,6 +20,9 @@ def GetBinaryPath():
    return os_path.join(os_path.dirname(__file__), *{
      'Darwin': (darwin_path, darwin_name, 'bin', 'node'),
      'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
 +    'OpenBSD': ('openbsd', 'node-openbsd', 'bin', 'node'),
 +    'FreeBSD': ('freebsd', 'node-freebsd', 'bin', 'node'),
++    'MidnightBSD': ('freebsd', 'node-freebsd', 'bin', 'node'),
      'Windows': ('win', 'node.exe'),
    }[platform.system()])
  

--- a/devel/electron40/files/patch-tools_gn_build_gen.py
+++ b/devel/electron40/files/patch-tools_gn_build_gen.py
@@ -1,6 +1,15 @@
 --- tools/gn/build/gen.py.orig	2025-08-26 20:49:50 UTC
 +++ tools/gn/build/gen.py
-@@ -94,6 +94,12 @@ class Platform(object):
+@@ -47,6 +47,8 @@ class Platform(object):
+       self._platform = 'fuchsia'
+     elif self._platform.startswith('freebsd'):
+       self._platform = 'freebsd'
++    elif self._platform.startswith('midnightbsd'):
++      self._platform = 'freebsd'
+     elif self._platform.startswith('netbsd'):
+       self._platform = 'netbsd'
+     elif self._platform.startswith('openbsd'):
+@@ -94,6 +96,12 @@ class Platform(object):
    def is_solaris(self):
      return self._platform == 'solaris'
  
@@ -13,7 +22,7 @@
    def is_posix(self):
      return self._platform in ['linux', 'freebsd', 'darwin', 'aix', 'openbsd', 'haiku', 'solaris', 'msys', 'netbsd', 'serenity']
  
-@@ -308,7 +314,7 @@ def WriteGenericNinja(path, static_libraries, executab
+@@ -308,7 +316,7 @@ def WriteGenericNinja(path, static_libraries, executab
        'linux': 'build_linux.ninja.template',
        'freebsd': 'build_linux.ninja.template',
        'aix': 'build_aix.ninja.template',
@@ -22,7 +31,7 @@
        'haiku': 'build_haiku.ninja.template',
        'solaris': 'build_linux.ninja.template',
        'netbsd': 'build_linux.ninja.template',
-@@ -552,6 +558,9 @@ def WriteGNNinja(path, platform, host, options, args_l
+@@ -552,6 +560,9 @@ def WriteGNNinja(path, platform, host, options, args_l
  
      if platform.is_posix() and not platform.is_haiku():
        ldflags.append('-pthread')


### PR DESCRIPTION
`devel/electron40` has never been build-ported: it carried **no `midnightbsd` patches at all**. #671 fixed its fetch, which only got it as far as *starting* a build — configure then failed immediately on the first Python platform check.

This applies the same set of changes that make #672/#682's `devel/electron41` build.

## MidnightBSD portability (6 patches)

Only Python is affected. C and C++ are carried by the base compiler defining `__FreeBSD__` alongside `__MidnightBSD__`, and GN reports `host_os=freebsd` via `OS_FREEBSD`.

| File | Failure |
|---|---|
| `build/config/linux/pkg-config.py` | early-returned on any platform not matching linux/openbsd/freebsd, so **every** `pkg_config` lookup silently produced empty results |
| `tools/gn/build/gen.py` | `KeyError: 'midnightbsd4'` during GN bootstrap |
| `media/ffmpeg/scripts/robo_lib/config.py` | `ValueError: Unsupported platform: MidnightBSD` |
| `third_party/node/node.py` | `KeyError` on the node binary path lookup |
| `bind_gen/style_format.py` | `AssertionError: Unknown platform: midnightbsd4` |
| `build/landmine_utils.py` | `IsLinux()` returned False (new patch) |

All six were dry-run against the Chromium 144 sources before use — the relevant lines are unchanged between 144 and 146, so they transfer directly from electron41.

## Port defects (3, shared with electron41)

**Base clang instead of `devel/llvm21`.** GN's `clang_toolchain` template hardcodes `cc`/`c++` from PATH and ignores `clang_base_path`, so `BINARY_ALIAS` is the only way to select a compiler — setting `CC`/`CXX` alone only affects the GN bootstrap. The port declared `LLVM_DEFAULT=21` and build-depended on `devel/llvm21` while not actually using it.

The `cc`/`c++` aliases were presumably dropped because Chromium builds with `-no-canonical-prefixes`, making clang derive its resource directory from `argv[0]` and resolve it through the alias symlink to a nonexistent path. Fix: restore the aliases and pass `-resource-dir` explicitly.

**Allocator GN args.** `use_allocator_shim=false`, `use_partition_alloc=true`, `use_partition_alloc_as_malloc=false` and `enable_backup_ref_ptr_support=false` had been removed. Without them the allocator shim is compiled, and it does not build here: `/usr/include/stdlib.h` declares `malloc`/`free`/`realloc` without `__THROW`.

**Staging.** `do-install` used FreeBSD's `${STAGEDIR}${PREFIX}`; in mports `${PREFIX}` already has `FAKE_DESTDIR` prepended during `do-install`, so every path was staged twice over.

`PORTREVISION` 3 → 4.

## Validation

Configures from a clean tree — **28489 targets from 4367 files** — verified using **clang 21.1.8** with the allocator arguments and `-resource-dir` confirmed present in `args.gn`.

**Not verified:** the full build. `devel/electron41` builds and packages with the identical set of changes, but electron40 was not compiled end to end. Given electron40 is EOL upstream, that seemed a poor use of ~5 hours of machine time — happy to run it if you'd rather have the confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make electron40 buildable with the same MidnightBSD support and toolchain configuration as electron41, and correct staging behaviour in mports.

Bug Fixes:
- Ensure GN and related Python helpers treat MidnightBSD as FreeBSD so configuration and landmine checks succeed.
- Fix node binary path resolution on MidnightBSD by mapping it to the FreeBSD node bundle.
- Allow pkg-config, FFmpeg config scripts, and Blink bind_gen to run correctly on MidnightBSD instead of failing or returning empty results.
- Correct allocator-related GN arguments to avoid building the unsupported allocator shim on this platform.
- Fix do-install and post-install staging paths to avoid double-prefixing under mports.

Enhancements:
- Reinstate LLVM clang via BINARY_ALIAS and pass an explicit clang resource directory so Chromium builds use the intended compiler without missing intrinsics headers.

Chores:
- Bump PORTREVISION from 3 to 4 to reflect the MidnightBSD and port build fixes.