### PR TITLE
x11-fonts/libXfont2: update to 2.0.9 to fix two font-server vulnerabilities

### DIFF
--- a/x11-fonts/libXfont2/Makefile
+++ b/x11-fonts/libXfont2/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libXfont2
-PORTVERSION=	2.0.8
+PORTVERSION=	2.0.9
 CATEGORIES=	x11-fonts
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -12,9 +12,9 @@ LIB_DEPENDS=	libfreetype.so:print/freetype2
 USES=		tar:xz xorg xorg-cat:lib
 USE_XORG=	xorgproto xtrans fontenc
 INSTALL_TARGET=	install-strip
-#USES+=	cpe
-#CPE_PRODUCT=	libxfont
-#CPE_VENDOR=	x
+USES+=	cpe
+CPE_PRODUCT=	libxfont
+CPE_VENDOR=	x
 
 CONFIGURE_ARGS=--without-xmlto --disable-devel-docs --without-fop
 

--- a/x11-fonts/libXfont2/distinfo
+++ b/x11-fonts/libXfont2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1783521974
-SHA256 (xorg/lib/libXfont2-2.0.8.tar.xz) = f556c0e1093a4e6911cc90bc4b106d201902ee187fd74af206ff162f7e6a24d5
-SIZE (xorg/lib/libXfont2-2.0.8.tar.xz) = 474560
+TIMESTAMP = 1785899945
+SHA256 (xorg/lib/libXfont2-2.0.9.tar.xz) = f042a370666815e7b941e9b7019024755bd1c6c2954afbfa515af378251799e2
+SIZE (xorg/lib/libXfont2-2.0.9.tar.xz) = 478844


### PR DESCRIPTION
Updates `x11-fonts/libXfont2` 2.0.8 → 2.0.9, released 2026-08-05.

## Vulnerabilities fixed

Both are in the font-server client code and reachable from a malicious or compromised font server:

**CVE-2026-44950** — `fs_read_glyphs()` copies each glyph's bitmap into a single `allbits` buffer sized to `rep->nbytes`. The per-glyph guard only validated that the *source* slice lay within the source buffer, not that the running *destination* cursor stayed within the allocation. Overlapping source offsets (e.g. 1000 glyphs each referencing `{position:0, length:64}` with `nbytes=64`) each pass validation individually while cumulatively writing 64000 bytes into a 64-byte buffer.

**CVE-2026-59679** — the `encoding[]` array is allocated while handling `FS_QueryXExtents16` and filled while handling `FS_QueryXBitmaps16`, with no check that the allocation was large enough. A small `numExtents` with a large `num_chars` forces an underallocation and an out-of-bounds read/write.

Both were found by Zhixi "Jace" Sun and carry regression tests upstream.

## Note on the June 2026 advisory

The three CVEs from the [June 2026 X.Org advisory](https://www.openwall.com/lists/oss-security/2026/06/02/1) — CVE-2026-56001, CVE-2026-56002, CVE-2026-56003 — were already fixed in **2.0.8**, which this port was on. The two above are new in 2.0.9 and are not covered by that advisory.

## Also: enable CPE, so `mport audit` can see this port at all

`USES=cpe` and the vendor/product were present but **commented out**, so the built package shipped an empty `cpe` field:

```
libXfont2|            <- cpe column empty
```

`mport audit` matches installed packages against `sec.midnightbsd.org` by CPE:

```
%s/api/cpe/partial-match?includeVersion=true&cpe=%s&startDate=2006-02-28
```

so with no CPE, audit could not report libXfont2 vulnerabilities **at any version** — including the three fixed in 2.0.8. The commented-out vendor/product were already correct: NVD lists these CVEs under `cpe:2.3:a:x:libxfont`. The package now carries:

```
libXfont2|2.0.9|cpe:2.3:a:x:libxfont:2.0.9:::::midnightbsd4:x64:0
```

Note that CVE-2026-44950 and CVE-2026-59679 are still `RESERVED` in NVD, so audit will not match them until NVD publishes; the 2.0.8 CVEs are already published and will match.

## Impact on dependents

The shared library version is unchanged at `libXfont2.so.2.0.0`, so no dependent ports need a `PORTREVISION` bump.

## Validation

Builds and packages cleanly; `pkg-plist` unchanged. The distfile checksum was cross-checked against an independent download from x.org:

```
f042a370666815e7b941e9b7019024755bd1c6c2954afbfa515af378251799e2
```

portlint reports 0 fatal errors. Its two warnings about the `WWW:` line in `pkg-descr` are pre-existing and unrelated; left alone to keep this change reviewable as a security fix.

## Worth checking more broadly

If CPE is commented out here, it may well be commented out across other x11 ports too — which would leave the same audit blind spot elsewhere. Worth a sweep as separate work.

Sources: [X.Org release](https://www.x.org/releases/individual/lib/), upstream `ChangeLog` in the 2.0.9 tarball, [NVD CVE-2026-56001](https://nvd.nist.gov/vuln/detail/CVE-2026-56001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)