### PR TITLE
security/vuxml: add MidnightBSD CVE candidate tooling

### DIFF
--- a/ai/claude-code/Makefile
+++ b/ai/claude-code/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	claude-code
-DISTVERSION=	2.1.221
+DISTVERSION=	2.1.223
 CATEGORIES=	ai linux
 MASTER_SITES=	https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/
 DISTNAME=	claude-code-linux-x64-${DISTVERSION}

--- a/ai/claude-code/distinfo
+++ b/ai/claude-code/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1785799591
-SHA256 (claude-code-linux-x64-2.1.221.tgz) = 3ef826073c28fece1d0522dcf1203634484508e17c3dde40e396cfa8e5a6ba6d
-SIZE (claude-code-linux-x64-2.1.221.tgz) = 88322572
+TIMESTAMP = 1786022080
+SHA256 (claude-code-linux-x64-2.1.223.tgz) = fb335c7c5b44fe9c5b48d15d41ca7903e1d0ed2a1ea932da0e8f5b09f34a1a86
+SIZE (claude-code-linux-x64-2.1.223.tgz) = 88909065

--- a/security/vuxml/Makefile
+++ b/security/vuxml/Makefile
@@ -82,6 +82,7 @@ ${VUXML_FLAT_FILE}: ${VUXML_FILE} vuln/*.xml
 	xmllint -noent ${.ALLSRC:[1]} > ${.TARGET}
 
 validate: tidy
+	@${PYTHON_CMD} ${FILESDIR}/check-shards.py "${VUXML_FILE}" "${PKGDIR}/vuln"
 	@${SH} ${FILESDIR}/validate.sh "${VUXML_FLAT_FILE}"
 	@${ECHO_MSG} Checking if tidy differs...
 	@if ${DIFF} -u "${VUXML_FLAT_FILE}" "${VUXML_FILE}.tidy"; \
@@ -114,6 +115,14 @@ tidy: ${VUXML_FLAT_FILE}
 
 newentry:
 	@${SH} ${FILESDIR}/newentry.sh "${VUXML_CURRENT_FILE}" "CVE_ID=${CVE_ID}" "SA_ID=${SA_ID}"
+
+candidates:
+.if empty(ORIGIN)
+	@${ECHO_MSG} "Set ORIGIN to one or more port origins, for example ORIGIN=dns/bind918"
+	@${FALSE}
+.else
+	@${PYTHON_CMD} ${FILESDIR}/vuxml-candidates.py --portsdir ${PORTSDIR} ${ORIGIN}
+.endif
 
 .if defined(VID) && !empty(VID)
 html: work/${VID}.html

--- a/security/vuxml/files/check-shards.py
+++ b/security/vuxml/files/check-shards.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import pathlib
+import re
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} vuln.xml vuln-directory", file=sys.stderr)
+        return 2
+
+    document = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+    shard_directory = pathlib.Path(sys.argv[2])
+    entities = re.findall(r'<!ENTITY vuln-(\d{4}) SYSTEM "vuln/(\d{4})\.xml">', document)
+    references = re.findall(r'&vuln-(\d{4});', document)
+    shards = {path.stem for path in shard_directory.glob("[0-9][0-9][0-9][0-9].xml")}
+
+    errors = []
+    entity_years = [name for name, filename in entities if name == filename]
+    malformed_entities = [(name, filename) for name, filename in entities if name != filename]
+    if malformed_entities:
+        errors.append(f"mismatched entity names: {malformed_entities}")
+
+    for label, years in (("entity", entity_years), ("reference", references)):
+        duplicates = sorted({year for year in years if years.count(year) > 1})
+        if duplicates:
+            errors.append(f"duplicate {label} years: {', '.join(duplicates)}")
+
+    entity_set = set(entity_years)
+    reference_set = set(references)
+    for label, years in (("entities", entity_set), ("references", reference_set)):
+        missing = sorted(shards - years)
+        extra = sorted(years - shards)
+        if missing:
+            errors.append(f"shards missing from {label}: {', '.join(missing)}")
+        if extra:
+            errors.append(f"{label} without shard files: {', '.join(extra)}")
+
+    if entity_set != reference_set:
+        errors.append("entity declarations and document references differ")
+
+    if errors:
+        for error in errors:
+            print(f"Error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/security/vuxml/files/vuxml-candidates.py
+++ b/security/vuxml/files/vuxml-candidates.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+
+import argparse
+import datetime
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import urllib.parse
+import urllib.request
+
+
+PORT_VARIABLES = (
+    "PKGORIGIN",
+    "PKGBASE",
+    "PKGVERSION",
+    "PORTVERSION",
+    "PORTREVISION",
+    "PORTEPOCH",
+    "CPE_STR",
+)
+
+
+def existing_cves(vulnerability_directory: pathlib.Path) -> set[str]:
+    found = set()
+    pattern = re.compile(r"<cvename>\s*(CVE-[0-9]{4}-[0-9]+)\s*</cvename>", re.IGNORECASE)
+    for shard in vulnerability_directory.glob("[0-9][0-9][0-9][0-9].xml"):
+        found.update(match.upper() for match in pattern.findall(shard.read_text(encoding="utf-8")))
+    return found
+
+
+def port_metadata(portsdir: pathlib.Path, origin: str, make_command: str) -> dict[str, str]:
+    portdir = (portsdir / origin).resolve()
+    try:
+        portdir.relative_to(portsdir.resolve())
+    except ValueError as ex:
+        raise ValueError(f"port origin escapes the ports tree: {origin}") from ex
+    if not (portdir / "Makefile").is_file():
+        raise ValueError(f"port origin does not exist: {origin}")
+
+    command = [make_command, "-C", str(portdir)]
+    for variable in PORT_VARIABLES:
+        command.extend(("-V", variable))
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    values = result.stdout.splitlines()
+    if len(values) != len(PORT_VARIABLES):
+        raise RuntimeError(f"unexpected {make_command} output for {origin}")
+    return dict(zip(PORT_VARIABLES, values))
+
+
+def fetch_ranges(api_base: str, cpe: str, start_date: str, timeout: float) -> list[dict]:
+    query = urllib.parse.urlencode({"cpe": cpe, "startDate": start_date})
+    url = f"{api_base.rstrip('/')}/api/cpe/ranges?{query}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        advisories = json.load(response)
+    if not isinstance(advisories, list) or not all(
+        isinstance(advisory, dict) for advisory in advisories
+    ):
+        raise ValueError("security advisory API returned an unexpected response")
+    return advisories
+
+
+def current_branch(portsdir: pathlib.Path) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(portsdir), "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    branch = result.stdout.strip()
+    if branch == "HEAD":
+        result = subprocess.run(
+            ["git", "-C", str(portsdir), "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        branch = result.stdout.strip()
+    return branch
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find sec.midnightbsd.org CVE candidates for MidnightBSD ports"
+    )
+    parser.add_argument("origin", nargs="+", help="port origin, for example dns/bind918")
+    parser.add_argument("--portsdir", default="/usr/mports")
+    parser.add_argument("--api-base", default="https://sec.midnightbsd.org")
+    parser.add_argument("--branch", help="branch name recorded in the output")
+    parser.add_argument("--start-date", default="2006-02-28")
+    parser.add_argument("--make", default="bmake", dest="make_command")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--output", type=pathlib.Path)
+    args = parser.parse_args()
+
+    portsdir = pathlib.Path(args.portsdir).resolve()
+    known_cves = existing_cves(portsdir / "security/vuxml/vuln")
+    ports = []
+    for origin in args.origin:
+        metadata = port_metadata(portsdir, origin, args.make_command)
+        cpe = metadata["CPE_STR"]
+        if not cpe:
+            raise ValueError(f"{origin} does not define CPE metadata")
+        advisories = fetch_ranges(args.api_base, cpe, args.start_date, args.timeout)
+        candidates_by_cve = {}
+        for advisory in advisories:
+            cve_id = advisory.get("cveId", "").upper()
+            if cve_id and cve_id not in known_cves:
+                candidates_by_cve[cve_id] = advisory
+        ports.append(
+            {
+                "origin": metadata["PKGORIGIN"],
+                "pkgbase": metadata["PKGBASE"],
+                "pkgversion": metadata["PKGVERSION"],
+                "portversion": metadata["PORTVERSION"],
+                "portrevision": int(metadata["PORTREVISION"] or 0),
+                "portepoch": int(metadata["PORTEPOCH"] or 0),
+                "cpe": cpe,
+                "candidates": [candidates_by_cve[cve] for cve in sorted(candidates_by_cve)],
+            }
+        )
+
+    document = {
+        "generatedAt": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "api": args.api_base,
+        "branch": args.branch or current_branch(portsdir),
+        "startDate": args.start_date,
+        "ports": ports,
+    }
+    output = json.dumps(document, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(output, encoding="utf-8")
+    else:
+        sys.stdout.write(output)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as ex:
+        print(f"Error: {ex}", file=sys.stderr)
+        sys.exit(1)

--- a/security/vuxml/vuln-flat.xml
+++ b/security/vuxml/vuln-flat.xml
@@ -23,9 +23,10 @@
 <!ENTITY vuln-2023 SYSTEM "vuln/2023.xml">
 <!ENTITY vuln-2024 SYSTEM "vuln/2024.xml">
 <!ENTITY vuln-2025 SYSTEM "vuln/2025.xml">
+<!ENTITY vuln-2026 SYSTEM "vuln/2026.xml">
 ]>
 <!--
-Copyright 2003-2025 Jacques Vidrine and contributors
+Copyright 2003-2026 Jacques Vidrine and contributors
 
 Redistribution and use in source (VuXML) and 'compiled' forms (SGML,
 HTML, PDF, PostScript, RTF and so forth) with or without modification,
@@ -74,6 +75,1561 @@ Notes:
   * Do not forget port variants (linux-f10-libxml2, libxml2, etc.)
 -->
 <vuxml xmlns="http://www.vuxml.org/apps/vuxml-1">
+  <vuln vid="590979aa-09f7-11f1-a730-5404a68ad561">
+    <topic>traefik -- TCP readTimeout bypass via STARTTLS on Postgres</topic>
+    <affects>
+    <package>
+	<name>traefik</name>
+	<range><lt>3.6.8</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The traefik project reports:</p>
+	<blockquote cite="https://github.com/traefik/traefik/security/advisories/GHSA-89p3-4642-cr2w">
+	  <p>There is a potential vulnerability in Traefik managing STARTTLS requests.
+	     An unauthenticated client can bypass Traefik entrypoint respondingTimeouts.readTimeout
+	     by sending the 8-byte Postgres SSLRequest (STARTTLS) prelude and then stalling,
+	     causing connections to remain open indefinitely, leading to a denial of service</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-25949</cvename>
+      <url>https://nvd.nist.gov/vuln/detail/CVE-2026-25949</url>
+    </references>
+    <dates>
+      <discovery>2026-02-11</discovery>
+      <entry>2026-02-14</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="17186409-09d2-11f1-a39c-b42e991fc52e">
+    <topic>munge -- CWE-787: Out-of-bounds Write</topic>
+    <affects>
+    <package>
+	<name>munge</name>
+	<range><lt>0.5.18</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://github.com/dun/munge/security/advisories/GHSA-r9cr-jf4v-75gh reports:</p>
+	<blockquote cite="https://github.com/dun/munge/security/advisories/GHSA-r9cr-jf4v-75gh">
+	  <p>MUNGE is an authentication service for creating and
+	  validating user credentials.  From 0.5 to 0.5.17, local
+	  attacker can exploit a buffer overflow vulnerability in
+	  munged (the MUNGE authentication daemon) to leak
+	  cryptographic key material from process memory.  With the
+	  leaked key material, the attacker could forge arbitrary
+	  MUNGE credentials to impersonate any user (including root)
+	  to services that rely on MUNGE for authentication.  The
+	  vulnerability allows a buffer overflow by sending a crafted
+	  message with an oversized address length field, corrupting
+	  munged's internal state and enabling extraction of the MAC
+	  subkey used for credential verification.  This vulnerability
+	  is fixed in 0.5.18.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-25506</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-25506</url>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-14</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="424d598b-09c4-11f1-85c5-a8a1599412c6">
+    <topic>chromium -- security fix</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>144.0.7559.75</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>144.0.7559.75</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop_13.html">
+	 <p>This update includes 1 security fix:</p>
+	 <ul>
+	    <li>[483569511] High CVE-2026-2441: Use after free in CSS. Reported by Shaheen Fazim on 2026-02-11</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-2441</cvename>
+      <url>https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop_13.html</url>
+    </references>
+    <dates>
+      <discovery>2026-02-13</discovery>
+      <entry>2026-02-14</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="027c6c07-065b-11f1-baae-589cfc023192">
+    <topic>expat -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+       <name>expat</name>
+       <range><lt>2.7.4</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+      <p>expat team reports:</p>
+      <blockquote cite="https://github.com/libexpat/libexpat/blob/R_2_7_4/expat/Changes">
+       <p>Update contains 2 security fixes:</p>
+       <ul>
+       <li>CVE-2026-24515: NULL dereference in function XML_ExternalEntityParserCreate</li>
+       <li>CVE-2026-25210: missing check for integer overflow in function doContent</li>
+       </ul>
+      </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-24515</cvename>
+      <cvename>CVE-2026-25210</cvename>
+    </references>
+    <dates>
+      <discovery>2026-01-31</discovery>
+      <entry>2026-02-10</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="e3afc190-0821-11f1-a857-6cc21735f730">
+    <topic>PostgreSQL -- Multiple vulnerabilities</topic>
+    <affects>
+      <package>
+       <name>postgresql14-server</name>
+       <range><lt>14.21</lt></range>
+      </package>
+      <package>
+       <name>postgresql15-server</name>
+       <range><lt>15.16</lt></range>
+      </package>
+      <package>
+       <name>postgresql16-server</name>
+       <range><lt>16.12</lt></range>
+      </package>
+      <package>
+       <name>postgresql17-server</name>
+       <range><lt>17.8</lt></range>
+      </package>
+      <package>
+       <name>postgresql18-server</name>
+       <range><lt>18.2</lt></range>
+      </package>
+      <package>
+       <name>postgresql14-server</name>
+       <range><lt>14.21</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The PostgreSQL project reports:</p>
+	<blockquote cite="https://www.postgresql.org/about/news/postgresql-182-178-1612-1516-and-1421-released-3235/">
+	<p>
+	  Improper validation of type oidvector in PostgreSQL
+	  allows a database user to disclose a few bytes of server
+	  memory. We have not ruled out viability of attacks that
+	  arrange for presence of confidential information in
+	  disclosed bytes, but they seem unlikely.
+	</p>
+	<p>
+	  Missing validation of type of input in PostgreSQL
+	  intarray extension selectivity estimator function allows
+	  an object creator to execute arbitrary code as the
+	  operating system user running the database.
+	</p>
+	<p>
+	  Heap buffer overflow in PostgreSQL pgcrypto allows a
+	  ciphertext provider to execute arbitrary code as the
+	  operating system user running the database.
+	</p>
+	<p>
+	  Missing validation of multibyte character length in
+	  PostgreSQL text manipulation allows a database user to
+	  issue crafted queries that achieve a buffer overrun.
+	  That suffices to execute arbitrary code as the operating
+	  system user running the database.
+	</p>
+	<p>
+	  Heap buffer overflow in PostgreSQL pg_trgm allows a
+	  database user to achieve unknown impacts via a crafted
+	  input string. The attacker has limited control over the
+	  byte patterns to be written, but we have not ruled out
+	  the viability of attacks that lead to privilege
+	  escalation.
+	</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-2003</cvename>
+      <cvename>CVE-2026-2004</cvename>
+      <cvename>CVE-2026-2005</cvename>
+      <cvename>CVE-2026-2006</cvename>
+      <cvename>CVE-2026-2007</cvename>
+      <url>https://www.postgresql.org/about/news/postgresql-182-178-1612-1516-and-1421-released-3235/</url>
+    </references>
+    <dates>
+      <discovery>2026-02-12</discovery>
+      <entry>2026-02-12</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="7f9bac32-0800-11f1-8a6f-b42e991fc52e">
+    <topic>MongoDB Server -- CWE-704 Incorrect Type Conversion or Cast</topic>
+    <affects>
+    <package>
+	<name>mongodb70</name>
+	<range><lt>7.0.29</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://jira.mongodb.org/browse/SERVER-113685 reports:</p>
+	<blockquote cite="https://jira.mongodb.org/browse/SERVER-113685">
+	  <p>An authorized user may disable the MongoDB server by
+	  issuing a query against a collection that contains an
+	  invalid compound wildcard index.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-25613</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-25613</url>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-12</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="7b5671f9-0800-11f1-8a6f-b42e991fc52e">
+    <topic>MongoDB Server -- CWE-617 Reachable Assertion</topic>
+    <affects>
+    <package>
+	<name>mongodb80</name>
+	<range><lt>8.0.13</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://jira.mongodb.org/browse/SERVER-99119 reports:</p>
+	<blockquote cite="https://jira.mongodb.org/browse/SERVER-99119">
+	  <p>An authorized user may trigger a server crash by running
+	  a $geoNear pipeline with certain invalid index hints.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-25610</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-25610</url>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-12</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="77e32b14-0800-11f1-8a6f-b42e991fc52e">
+    <topic>MongoDB Server -- Multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>mongodb80</name>
+	<range><lt>8.0.18</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://jira.mongodb.org/browse/SERVER-114126 reports:</p>
+	<blockquote cite="https://jira.mongodb.org/browse/SERVER-114126">
+	  <p>Complex queries can cause excessive memory usage in
+	  MongoDB Query Planner resulting in an Out-Of-Memory
+	    Crash.</p>
+	</blockquote>
+	<p>https://jira.mongodb.org/browse/SERVER-102364 reports:</p>
+	<blockquote cite="https://jira.mongodb.org/browse/SERVER-102364">
+	  <p>MongoDB Server may experience an out-of-memory failure while
+	  evaluating expressions that produce deeply nested documents. The
+	  issue arises in recursive functions because the server does not
+	    periodically check the depth of the expression.</p>
+	</blockquote>
+	<p>https://jira.mongodb.org/browse/SERVER-113532 reports:</p>
+	<blockquote cite="https://jira.mongodb.org/browse/SERVER-113532">
+	  <p>Inserting certain large documents into a replica set could lead to
+	  replica set secondaries not being able to fetch the oplog from the
+	  primary. This could stall replication inside the replica set leading
+	    to server crash.</p>
+	</blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-1850</cvename>
+      <cvename>CVE-2026-1849</cvename>
+      <cvename>CVE-2026-1847</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-1850</url>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-1849</url>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-1847</url>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-12</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="9d9940e7-071c-11f1-93ca-2cf05da270f3">
+    <topic>Gitlab -- vulnerabilities</topic>
+    <affects>
+<package>
+<name>gitlab-ce</name>
+<name>gitlab-ee</name>
+<range><ge>18.8.0</ge><lt>18.8.4</lt></range>
+<range><ge>18.7.0</ge><lt>18.7.4</lt></range>
+<range><ge>8.0.0</ge><lt>18.6.6</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Gitlab reports:</p>
+	<blockquote cite="https://about.gitlab.com/releases/2026/02/10/patch-release-gitlab-18-8-4-released/">
+	  <p>Incomplete Validation issue in Web IDE impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in GraphQL introspection impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in JSON validation middleware impacts GitLab CE/EE</p>
+	  <p>Cross-site Scripting issue in Code Flow impacts GitLab CE/EE</p>
+	  <p>HTML Injection issue in test case titles impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in Markdown processor impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in Markdown Preview impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in dashboard impacts GitLab EE</p>
+	  <p>Server-Side Request Forgery issue in Virtual Registry impacts GitLab EE</p>
+	  <p>Improper Validation issue in diff parser impacts GitLab CE/EE</p>
+	  <p>Server-Side Request Forgery issue in Git repository import impacts GitLab CE/EE</p>
+	  <p>Authorization Bypass issue in iterations API impacts GitLab EE</p>
+	  <p>Missing Authorization issue in GLQL API impacts GitLab CE/EE</p>
+	  <p>Stored HTML Injection issue in project label impacts GitLab CE/EE</p>
+	  <p>Authorization Bypass issue in Pipeline Schedules API impacts GitLab CE/EE</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-7659</cvename>
+      <cvename>CVE-2025-8099</cvename>
+      <cvename>CVE-2026-0958</cvename>
+      <cvename>CVE-2025-14560</cvename>
+      <cvename>CVE-2026-0595</cvename>
+      <cvename>CVE-2026-1458</cvename>
+      <cvename>CVE-2026-1456</cvename>
+      <cvename>CVE-2026-1387</cvename>
+      <cvename>CVE-2025-12575</cvename>
+      <cvename>CVE-2026-1094</cvename>
+      <cvename>CVE-2025-12073</cvename>
+      <cvename>CVE-2026-1080</cvename>
+      <cvename>CVE-2025-14592</cvename>
+      <cvename>CVE-2026-1282</cvename>
+      <cvename>CVE-2025-14594</cvename>
+      <url>https://about.gitlab.com/releases/2026/02/10/patch-release-gitlab-18-8-4-released/</url>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-11</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="8d8012e5-0705-11f1-8148-bc241121aa0a">
+    <topic>FreeBSD -- blocklistd(8) socket leak</topic>
+    <affects>
+      <package>
+	<name>FreeBSD</name>
+	<range><ge>15.0</ge><lt>15.0_3</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<h1>Problem Description:</h1>
+	<p>Due to a programming error, blocklistd leaks a socket descriptor
+	for each adverse event report it receives.</p>
+	<p>Once a certain number of leaked sockets is reached, blocklistd
+	becomes unable to run the helper script: a child process is forked,
+	but this child dereferences a null pointer and crashes before it
+	is able to exec the helper.  At this point, blocklistd still records
+	adverse events but is unable to block new addresses or unblock
+	addresses whose database entries have expired.</p>
+	<p>Once a second, much higher number of leaked sockets is reached,
+	blocklistd becomes unable to receive new adverse event reports.</p>
+	<h1>Impact:</h1>
+	<p>An attacker may take advantage of this by triggering a large
+	number of adverse events from sacrificial IP addresses to effectively
+	disable blocklistd before launching an attack.</p>
+	<p>Even in the absence of attacks or probes by would-be attackers,
+	adverse events will occur regularly in the course of normal operations,
+	and blocklistd will gradually run out file descriptors and become
+	ineffective.</p>
+	<p>The accumulation of open sockets may have knock-on effects on other
+	parts of the system, resulting in a general slowdown until blocklistd
+	is restarted.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-2261</cvename>
+      <freebsdsa>SA-26:03.blocklistd</freebsdsa>
+    </references>
+    <dates>
+      <discovery>2026-02-10</discovery>
+      <entry>2026-02-11</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="9bc5a730-0585-11f1-85c5-a8a1599412c6">
+    <topic>chromium -- multiple security fixes</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>144.0.7559.132</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>144.0.7559.132</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop.html">
+	 <p>This update includes 2 security fixes:</p>
+	 <ul>
+	    <li>[478942410] High CVE-2026-1861: Heap buffer overflow in libvpx. Reported by Google on 2026-01-26</li>
+	    <li>[479726070] High CVE-2026-1862: Type Confusion in V8. Reported by Chaoyuan Peng (@ret2happy) on 2026-01-29</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-1861</cvename>
+      <cvename>CVE-2026-1862</cvename>
+      <url>https://chromereleases.googleblog.com/2026/02/stable-channel-update-for-desktop.html</url>
+    </references>
+    <dates>
+      <discovery>2026-02-03</discovery>
+      <entry>2026-02-09</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="f301a241-04d3-11f1-a38c-8447094a420f">
+    <topic>Roundcube -- Multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>roundcube-php82</name>
+	<name>roundcube-php83</name>
+	<name>roundcube-php84</name>
+	<name>roundcube-php85</name>
+	<range><lt>1.6.13,1</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The Roundcube project reports:</p>
+	<blockquote cite="https://github.com/roundcube/roundcubemail/releases/tag/1.6.13">
+	  <p>Unspecified CSS injection vulnerability.</p>
+	  <p>Remote image blocking bypass via SVG content.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <url>https://github.com/roundcube/roundcubemail/releases/tag/1.6.13</url>
+    </references>
+    <dates>
+      <discovery>2026-02-08</discovery>
+      <entry>2026-02-08</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="73ff246b-04b2-11f1-84fc-4ccc6adda413">
+    <topic>qt6-webengine -- multiple vulnerabilities</topic>
+    <affects>
+<package>
+<name>qt6-pdf</name>
+<name>qt6-webengine</name>
+<range><lt>6.10.2</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Qt qtwebengine-chromium repo reports:</p>
+	<blockquote cite="https://code.qt.io/cgit/qt/qtwebengine-chromium.git/log/?h=134-based">
+	  <p>Backports for 7 security bugs in Chromium:</p>
+	  <ul>
+	    <li>CVE-2025-13638: Prevent media element GC in callbacks in WebMediaPlayerMS</li>
+	    <li>CVE-2025-13639: Improve validation of SDP direction in remote description</li>
+	    <li>CVE-2025-13720: Avoid downcasting Hash and Integrity reports</li>
+	    <li>CVE-2025-14174: Metal: Don't use pixelsDepthPitch to size buffers</li>
+	    <li>CVE-2025-14765: Polyfill unary negation and abs for amd mesa frontend</li>
+	    <li>CVE-2026-0908: Use CheckedNumerics in HandleAllocator</li>
+	    <li>CVE-2026-1504: Block opaque 416 responses to non-range requests</li>
+	  </ul>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-13638</cvename>
+      <cvename>CVE-2025-13639</cvename>
+      <cvename>CVE-2025-13720</cvename>
+      <cvename>CVE-2025-14174</cvename>
+      <cvename>CVE-2025-14765</cvename>
+      <cvename>CVE-2026-0908</cvename>
+      <cvename>CVE-2026-1504</cvename>
+      <url>https://code.qt.io/cgit/qt/qtwebengine-chromium.git/log/?h=134-based</url>
+    </references>
+    <dates>
+      <discovery>2026-02-02</discovery>
+      <entry>2026-02-08</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="a6effa17-1fd4-4895-8471-d5c684d7807c">
+    <topic>navidrome -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>navidrome</name>
+	<range><lt>0.60.0</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>An XSS vulnerability in the frontend allows a malicious attacker to inject code through the comment metadata of a song to exfiltrate user credentials.</p>
+	<p>Authenticated users can crash the Navidrome server by supplying an excessively large size parameter to /rest/getCoverArt or to a shared-image URL (/share/img/{token}). When processing such requests, the server attempts to create an extremely large resized image, causing uncontrolled memory growth. This triggers the Linux OOM killer, terminates the Navidrome process, and results in a full service outage.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-25578</cvename>
+      <url>https://github.com/navidrome/navidrome/security/advisories/GHSA-rh3r-8pxm-hg4w</url>
+      <cvename>CVE-2026-25579</cvename>
+      <url>https://github.com/navidrome/navidrome/security/advisories/GHSA-hrr4-3wgr-68x3</url>
+    </references>
+    <dates>
+      <discovery>2026-02-03</discovery>
+      <entry>2026-02-07</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="1a82bf18-0417-11f1-be6f-5404a68ad561">
+    <topic>traefik -- ACME TLS-ALPN fast path potential DoS</topic>
+    <affects>
+<package>
+<name>traefik</name>
+<range><lt>3.6.7</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The traefik project reports:</p>
+	<blockquote cite="https://github.com/traefik/traefik/security/advisories/GHSA-cwjm-3f7h-9hwq">
+	  <p>There is a potential vulnerability in Traefik ACME TLS certificates' automatic
+	  generation: the ACME TLS-ALPN fast path can allow unauthenticated clients to
+	  tie up goroutines and file descriptors indefinitely when the ACME TLS challenge
+	  is enabled.A malicious client can open many connections, send a minimal ClientHello
+	  with acme-tls/1, then stop responding, leading to denial of service of the entrypoint.
+	  </p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-22045</cvename>
+      <url>https://nvd.nist.gov/vuln/detail/CVE-2026-22045</url>
+    </references>
+    <dates>
+      <discovery>2026-01-15</discovery>
+      <entry>2026-02-07</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="bfe9adc8-0224-11f1-8790-c5fb948922ad">
+    <topic>python -- several security vulnerabilities</topic>
+    <affects>
+      <package><name>python310</name> <range><ge>0</ge></range></package>
+      <package><name>python311</name> <range><lt>3.11.14_2</lt></range></package>
+      <package><name>python312</name> <range><lt>3.12.12_4</lt></range></package>
+      <package><name>python313</name> <range><lt>3.13.12</lt></range></package>
+      <package><name>python313t</name> <range><lt>3.13.12</lt></range></package>
+      <package><name>python314</name> <range><lt>3.14.3</lt></range></package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The Python project announces a new release with several security fixes:</p>
+	<blockquote cite="https://docs.python.org/release/3.14.3/whatsnew/changelog.html">
+	  <ul>
+	    <li>CVE-2026-1299: gh-144125: BytesGenerator will now refuse to serialize (write) headers that are unsafely folded or delimited; see verify_generated_headers. (Contributed by Bas Bloemsaat and Petr Viktorin in gh-121650).</li>
+	    <li>gh-143935: Fixed a bug in the folding of comments when flattening an email message using a modern email policy. Comments consisting of a very long sequence of non-foldable characters could trigger a forced line wrap that omitted the required leading space on the continuation line, causing the remainder of the comment to be interpreted as a new header field. This enabled header injection with carefully crafted inputs.</li>
+	    <li>gh-143925: Reject control characters in data: URL media types.</li>
+	    <li>gh-143919: Reject control characters in http.cookies.Morsel fields and values.</li>
+	    <li>CVE-2026-0865: gh-143916: Reject C0 control characters within wsgiref.headers.Headers fields, values, and parameters.</li>
+	  </ul>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-1299</cvename>
+      <cvename>CVE-2026-0865</cvename>
+      <url>https://docs.python.org/release/3.14.3/whatsnew/changelog.html</url>
+    </references>
+    <dates>
+      <discovery>2026-01-16</discovery>
+      <entry>2026-02-04</entry>
+      <modified>2026-02-13</modified>
+    </dates>
+  </vuln>
+
+  <vuln vid="232e16cc-fd83-11f0-981a-98b78501ef2a">
+    <topic>xrdp -- remote code execution</topic>
+    <affects>
+<package>
+<name>xrdp</name>
+<range><lt>0.10.5</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Denis Skvortsov, Security Researcher at Kaspersky reports:</p>
+	<blockquote cite="https://github.com/neutrinolabs/xrdp/security/advisories/GHSA-rwvg-gp87-gh6f">
+	  <p>xrdp before v0.10.5 contains an unauthenticated stack-based buffer overflow vulnerability. The issue stems from improper bounds checking when processing user domain information during the connection sequence. If exploited, the vulnerability could allow remote attackers to execute arbitrary code on the target system.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-68670</cvename>
+      <url>https://www.cve.org/CVERecord?id=CVE-2025-68670</url>
+    </references>
+    <dates>
+      <discovery>2025-12-06</discovery>
+      <entry>2026-01-27</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="8173e68a-88f3-4862-882c-6e58779d98e7">
+    <topic>zeek -- potential DoS vulnerability</topic>
+    <affects>
+<package>
+<name>zeek</name>
+<range><lt>8.0.6</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Tim Wojtulewicz of Corelight reports:</p>
+	<blockquote cite="https://github.com/zeek/zeek/releases/tag/v8.0.6">
+	  <p>Zeek's HTTP analyzer can be tricked into interpreting
+	  Transfer-Encoding or Content-Length headers set in MIME
+	  entities within HTTP bodies and change the analyzer
+	  behavior.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <url>https://github.com/zeek/zeek/releases/tag/v8.0.6</url>
+    </references>
+    <dates>
+      <discovery>2026-01-29</discovery>
+      <entry>2026-01-29</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="409d70ab-fc23-11f0-85c5-a8a1599412c6">
+    <topic>chromium -- security fix</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>144.0.7559.109</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>144.0.7559.109</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_27.html">
+	 <p>This update includes 1 security fix:</p>
+	 <ul>
+	    <li>[474435504] High CVE-2026-1504: Inappropriate implementation in Background Fetch API. Reported by Luan Herrera (@lbherrera_) on 2026-01-09</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-1504</cvename>
+      <url>https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_27.html</url>
+    </references>
+    <dates>
+      <discovery>2026-01-27</discovery>
+      <entry>2026-01-28</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="9dac4f05-fc65-11f0-96db-b42e991fc52e">
+    <topic>Firefox -- Multiple vulnerabilities</topic>
+    <affects>
+    <package>
+	<name>firefox</name>
+	<range><lt>147.0.2,2</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://bugzilla.mozilla.org/show_bug.cgi?id=2007302 reports:</p>
+	<blockquote cite="https://bugzilla.mozilla.org/show_bug.cgi?id=2007302">
+	  <p>Mitigation bypass in the Privacy: Anti-Tracking component.</p>
+	  <p>Use-after-free in the Layout: Scrolling and Overflow component.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-24868</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-24868</url>
+      <cvename>CVE-2026-24869</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-24869</url>
+    </references>
+    <dates>
+      <discovery>2026-01-27</discovery>
+      <entry>2026-01-28</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="90071333-fbe5-11f0-a13f-bc241121aa0a">
+    <topic>FreeBSD -- Jail escape by a privileged user via nullfs</topic>
+    <affects>
+      <package>
+	<name>FreeBSD-kernel</name>
+	<range><ge>14.3</ge><lt>14.3_8</lt></range>
+	<range><ge>13.5</ge><lt>13.5_9</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<h1>Problem Description:</h1>
+	  <p>By default, jailed processes cannot mount filesystems, including
+	  nullfs(4).  However, the allow.mount.nullfs option enables mounting
+	  nullfs filesystems, subject to privilege checks.</p>
+	  <p>If a privileged user within a jail is able to nullfs-mount directories,
+	  a limitation of the kernel's path lookup logic allows that user to
+	  escape the jail's chroot, yielding access to the full filesystem
+	  of the host or parent jail.</p>
+	<h1>Impact:</h1>
+	  <p>In a jail configured to allow nullfs(4) mounts from within the
+	  jail, the jailed root user can escape the jail's filesystem root.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2025-15547</cvename>
+      <freebsdsa>SA-26:02.jail</freebsdsa>
+    </references>
+    <dates>
+      <discovery>2026-01-27</discovery>
+      <entry>2026-01-28</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="4b824428-fb93-11f0-b194-8447094a420f">
+    <topic>OpenSSL -- Multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>FreeBSD</name>
+	<range><ge>15.0</ge><lt>15.0_2</lt></range>
+	<range><ge>14.3</ge><lt>14.3_8</lt></range>
+	<range><ge>13.5</ge><lt>13.5_9</lt></range>
+      </package>
+      <package>
+	<name>openssl</name>
+	<range><lt>3.0.19,1</lt></range>
+      </package>
+      <package>
+	<name>openssl33</name>
+	<range><lt>3.3.6</lt></range>
+      </package>
+      <package>
+	<name>openssl34</name>
+	<range><lt>3.4.4</lt></range>
+      </package>
+      <package>
+	<name>openssl35</name>
+	<range><lt>3.5.5</lt></range>
+      </package>
+      <package>
+	<name>openssl36</name>
+	<range><lt>3.6.1</lt></range>
+      </package>
+      <package>
+	<name>openssl</name>
+	<range><lt>3.0.19</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The OpenSSL project reports:</p>
+	<blockquote cite="https://openssl-library.org/news/secadv/20260127.txt">
+	  <ul>
+	    <li>Improper validation of PBMAC1 parameters in PKCS#12 MAC verification (CVE-2025-11187)</li>
+	    <li>Stack buffer overflow in CMS AuthEnvelopedData parsing (CVE-2025-15467)</li>
+	    <li>NULL dereference in SSL_CIPHER_find() function on unknown cipher ID (CVE-2025-15468)</li>
+	    <li>"openssl dgst" one-shot codepath silently truncates inputs &gt;16MB (CVE-2025-15469)</li>
+	    <li>TLS 1.3 CompressedCertificate excessive memory allocation (CVE-2025-66199)</li>
+	    <li>Heap out-of-bounds write in BIO_f_linebuffer on short writes (CVE-2025-68160)</li>
+	    <li>Unauthenticated/unencrypted trailing bytes with low-level OCB function calls (CVE-2025-69418)</li>
+	    <li>Out of bounds write in PKCS12_get_friendlyname() UTF-8 conversion (CVE-2025-69419)</li>
+	    <li>Missing ASN1_TYPE validation in TS_RESP_verify_response() function (CVE-2025-69420)</li>
+	    <li>NULL Pointer Dereference in PKCS12_item_decrypt_d2i_ex function (CVE-2025-69421)</li>
+	    <li>Missing ASN1_TYPE validation in PKCS#12 parsing (CVE-2026-22795)</li>
+	    <li>ASN1_TYPE Type Confusion in the PKCS7_digest_from_attributes() function (CVE-2026-22796)</li>
+	  </ul>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-11187</cvename>
+      <cvename>CVE-2025-15467</cvename>
+      <cvename>CVE-2025-15468</cvename>
+      <cvename>CVE-2025-15469</cvename>
+      <cvename>CVE-2025-66199</cvename>
+      <cvename>CVE-2025-68160</cvename>
+      <cvename>CVE-2025-69418</cvename>
+      <cvename>CVE-2025-69419</cvename>
+      <cvename>CVE-2025-69420</cvename>
+      <cvename>CVE-2025-69421</cvename>
+      <cvename>CVE-2026-22795</cvename>
+      <cvename>CVE-2026-22796</cvename>
+      <url>https://openssl-library.org/news/secadv/20260127.txt</url>
+      <freebsdsa>SA-26:01.openssl</freebsdsa>
+    </references>
+    <dates>
+      <discovery>2026-01-27</discovery>
+      <entry>2026-01-27</entry>
+      <modified>2026-01-28</modified>
+    </dates>
+  </vuln>
+
+  <vuln vid="ab01cb11-f911-11f0-b194-8447094a420f">
+    <topic>MySQL -- Multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>mysql80-server</name>
+	<range><lt>8.0.45</lt></range>
+      </package>
+      <package>
+	<name>mysql84-server</name>
+	<range><lt>8.4.8</lt></range>
+      </package>
+      <package>
+	<name>mysql91-server</name>
+	<range><lt>9.1.3</lt></range>
+      </package>
+      <package>
+	<name>mysql94-server</name>
+	<range><lt>9.4.3</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Oracle reports:</p>
+	<blockquote cite="https://www.oracle.com/security-alerts/cpujan2026.html#AppendixMSQL">
+	  <p>Oracle reports multiple vulnerabilities in its MySQL server products.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-21949</cvename>
+      <cvename>CVE-2026-21950</cvename>
+      <cvename>CVE-2026-21968</cvename>
+      <cvename>CVE-2026-21929</cvename>
+      <cvename>CVE-2026-21936</cvename>
+      <cvename>CVE-2026-21937</cvename>
+      <cvename>CVE-2026-21941</cvename>
+      <cvename>CVE-2026-21948</cvename>
+      <cvename>CVE-2026-21952</cvename>
+      <cvename>CVE-2026-21964</cvename>
+      <cvename>CVE-2026-21965</cvename>
+      <url>https://www.oracle.com/security-alerts/cpujan2026.html#AppendixMSQL</url>
+    </references>
+    <dates>
+      <discovery>2026-01-20</discovery>
+      <entry>2026-01-24</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="65439aa0-f77d-11f0-9821-b0416f0c4c67">
+    <topic>wheel -- CWE-22: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')</topic>
+    <affects>
+    <package>
+	<name>py310-wheel</name>
+	<name>py311-wheel</name>
+	<name>py312-wheel</name>
+	<name>py313-wheel</name>
+	<name>py313t-wheel</name>
+	<name>py314-wheel</name>
+	<range><lt>0.46.2</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://github.com/pypa/wheel/security/advisories/GHSA-8rrh-rw8j-w5fx reports:</p>
+	<blockquote cite="https://github.com/pypa/wheel/security/advisories/GHSA-8rrh-rw8j-w5fx">
+	  <p>wheel is a command line tool for manipulating Python wheel files,
+as defined in PEP 427.  In versions 0.46.1 and below, the unpack
+function is vulnerable to file permission modification through
+mishandling of file permissions after extraction.  The logic blindly
+trusts the filename from the archive header for the chmod operation,
+even though the extraction process itself might have sanitized the
+path.  Attackers can craft a malicious wheel file that, when unpacked,
+changes the permissions of critical system files (e.g., /etc/passwd,
+SSH keys, config files), allowing for Privilege Escalation or
+arbitrary code execution by modifying now-writable scripts.  This
+issue has been fixed in version 0.46.2.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-24049</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-24049</url>
+    </references>
+    <dates>
+      <discovery>2026-01-22</discovery>
+      <entry>2026-01-22</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="f8560c1b-f772-11f0-85c5-a8a1599412c6">
+    <topic>chromium -- multiple security fixes</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>144.0.7559.96</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>144.0.7559.96</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_20.html">
+	 <p>This update includes 1 security fix:</p>
+	 <ul>
+	    <li>[473851441] High CVE-2026-1220: Race in V8. Reported by @p1nky4745 on 2026-01-07</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-1220</cvename>
+      <url>https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_20.html</url>
+    </references>
+    <dates>
+      <discovery>2026-01-20</discovery>
+      <entry>2026-01-22</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="61dc7f67-f6e5-11f0-b051-2cf05da270f3">
+    <topic>Gitlab -- vulnerabilities</topic>
+    <affects>
+<package>
+<name>gitlab-ce</name>
+<name>gitlab-ee</name>
+<range><ge>18.8.0</ge><lt>18.8.2</lt></range>
+<range><ge>18.7.0</ge><lt>18.7.2</lt></range>
+<range><ge>11.9.0</ge><lt>18.6.4</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Gitlab reports:</p>
+	<blockquote cite="https://about.gitlab.com/releases/2026/01/21/patch-release-gitlab-18-8-2-released/">
+	  <p>Denial of Service issue in Jira Connect integration impacts GitLab CE/EE</p>
+	  <p>Incorrect Authorization issue in Releases API impacts GitLab CE/EE</p>
+	  <p>Unchecked Return Value issue in authentication services impacts GitLab CE/EE</p>
+	  <p>Infinite Loop issue in Wiki redirects impacts GitLab CE/EE</p>
+	  <p>Denial of Service issue in API endpoint impacts GitLab CE/EE</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-13927</cvename>
+      <cvename>CVE-2025-13928</cvename>
+      <cvename>CVE-2026-0723</cvename>
+      <cvename>CVE-2025-13335</cvename>
+      <cvename>CVE-2026-1102</cvename>
+      <url>https://about.gitlab.com/releases/2026/01/21/patch-release-gitlab-18-8-2-released/</url>
+    </references>
+    <dates>
+      <discovery>2026-01-21</discovery>
+      <entry>2026-01-21</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="01f34a27-f560-11f0-bbdc-10ffe07f9334">
+    <topic>mail/mailpit -- multiple vulnerabilities</topic>
+    <affects>
+<package>
+<name>mailpit</name>
+<range><lt>1.28.3</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Mailpit author reports:</p>
+	<blockquote cite="https://github.com/axllent/mailpit/releases/tag/v1.28.3">
+	  <p>Ensure SMTP TO &amp; FROM addresses are RFC 5322
+	  compliant and prevent header injection (GHSA-54wq-72mp-cq7c)</p>
+	  <p>Prevent Server-Side Request Forgery (SSRF) via HTML
+	  Check API (GHSA-6jxm-fv7w-rw5j)</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-23829</cvename>
+      <url>https://github.com/axllent/mailpit/security/advisories/GHSA-54wq-72mp-cq7c</url>
+      <cvename>CVE-2026-23845</cvename>
+      <url>https://github.com/axllent/mailpit/security/advisories/GHSA-6jxm-fv7w-rw5j</url>
+    </references>
+    <dates>
+      <discovery>2026-01-18</discovery>
+      <entry>2026-01-19</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="fb561db9-0fc1-4d92-81a2-ee01839c9119">
+    <topic>oauth2-proxy -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>oauth2-proxy</name>
+	<range><lt>7.14.1</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out. Furthermore, the error string is constructed by repeated string concatenation, leading to quadratic runtime. Therefore, a certificate provided by a malicious actor can result in excessive resource consumption.</p>
+	<p>A flaw was found in the crypto/x509 package in the Go standard library. This vulnerability allows a certificate validation bypass via an excluded subdomain constraint in a certificated chain as it does not restrict the usage of wildcard SANs in the leaf certificate.</p>
+	<p>SSH Agent servers do not validate the size of messages when processing new identity requests, which may cause the program to panic if the message is malformed due to an out of bounds read.</p>
+	<p>SSH servers parsing GSSAPI authentication requests do not validate the number of mechanisms specified in the request, allowing an attacker to cause unbounded memory consumption.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2025-61729</cvename>
+      <cvename>CVE-2025-61727</cvename>
+      <cvename>CVE-2025-47914</cvename>
+      <cvename>CVE-2025-58181</cvename>
+    </references>
+    <dates>
+      <discovery>2026-01-16</discovery>
+      <entry>2026-01-18</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="ff20d3a3-f211-11f0-9ca3-b42e991fc52e">
+    <topic>Mozilla -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>firefox</name>
+	<range><lt>147.0.0,2</lt></range>
+      </package>
+      <package>
+	<name>thunderbird</name>
+	<range><lt>147.0.0</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>
+	Memory safety bugs present in Firefox 146 and Thunderbird
+	146. Some of these bugs showed evidence of memory corruption
+	and we presume that with enough effort some of these could
+	have been exploited to run arbitrary code.
+	</p>
+	<p>Denial-of-service in the DOM: Service Workers component.</p>
+	<p>Information disclosure in the XML component.</p>
+	<p>Sandbox escape in the Messaging System component.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-0892</cvename>
+      <cvename>CVE-2026-0889</cvename>
+      <cvename>CVE-2026-0888</cvename>
+      <cvename>CVE-2026-0881</cvename>
+    </references>
+    <dates>
+      <discovery>2026-01-13</discovery>
+      <entry>2026-01-15</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="085101eb-f212-11f0-9ca3-b42e991fc52e">
+    <topic>Mozilla -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>firefox</name>
+	<range><lt>147.0.0,2</lt></range>
+      </package>
+      <package>
+	<name>firefox-esr</name>
+	<range><lt>140.7.0</lt></range>
+      </package>
+      <package>
+	<name>thunderbird</name>
+	<range><lt>147</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Memory safety bugs present in firefox-esr 140.6,
+	Thunderbird ESR 140.6, Firefox 146 and Thunderbird 146.</p>
+	<p>Spoofing issue in the DOM: Copy &amp; Paste and Drag &amp;
+	Drop component.</p>
+	<p>Clickjacking issue and information disclosure in the PDF
+	Viewer component.</p>
+	<p>Use-after-free in the JavaScript: GC component.</p>
+	<p>Use-after-free in the JavaScript Engine component.</p>
+	<p>Information disclosure in the Networking component.</p>
+	<p>Sandbox escape due to incorrect boundary conditions in the
+	Graphics: CanvasWebGL component.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-0891</cvename>
+      <cvename>CVE-2026-0890</cvename>
+      <cvename>CVE-2026-0887</cvename>
+      <cvename>CVE-2026-0885</cvename>
+      <cvename>CVE-2026-0884</cvename>
+      <cvename>CVE-2026-0883</cvename>
+      <cvename>CVE-2026-0878</cvename>
+    </references>
+    <dates>
+      <discovery>2026-01-13</discovery>
+      <entry>2026-01-15</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="06061c59-f212-11f0-9ca3-b42e991fc52e">
+    <topic>Mozilla -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>firefox</name>
+	<range><lt>147.0.0,2</lt></range>
+      </package>
+      <package>
+	<name>firefox-esr</name>
+	<range><lt>140.7</lt></range>
+      </package>
+      <package>
+	<name>thunderbird</name>
+	<range><lt>147.0.0</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Incorrect boundary conditions in the Graphics
+	component.</p>
+	<p>Use-after-free in the IPC component.</p>
+	<p>Sandbox escape due to integer overflow in the Graphics
+	component.</p>
+	<p>Sandbox escape due to incorrect boundary conditions in the
+	Graphics component.</p>
+	<p>Mitigation bypass in the DOM: Security component.</p>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-0886</cvename>
+      <cvename>CVE-2026-0882</cvename>
+      <cvename>CVE-2026-0880</cvename>
+      <cvename>CVE-2026-0879</cvename>
+      <cvename>CVE-2026-0877</cvename>
+    </references>
+    <dates>
+      <discovery>2026-01-13</discovery>
+      <entry>2026-01-15</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="6f76a1db-f124-11f0-85c5-a8a1599412c6">
+    <topic>chromium -- multiple security fixes</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>144.0.7559.59</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>144.0.7559.59</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_13.html">
+	 <p>This update includes 10 security fixes:</p>
+	 <ul>
+	    <li>[458914193] High CVE-2026-0899: Out of bounds memory access in V8. Reported by @p1nky4745 on 2025-11-08</li>
+	    <li>[465730465] High CVE-2026-0900: Inappropriate implementation in V8. Reported by Google on 2025-12-03</li>
+	    <li>[40057499] High CVE-2026-0901: Inappropriate implementation in Blink. Reported by Irvan Kurniawan (sourc7) on 2021-10-04</li>
+	    <li>[469143679] Medium CVE-2026-0902: Inappropriate implementation in V8. Reported by 303f06e3 on 2025-12-16</li>
+	    <li>[444803530] Medium CVE-2026-0903: Insufficient validation of untrusted input in Downloads. Reported by Azur on 2025-09-13</li>
+	    <li>[452209495] Medium CVE-2026-0904: Incorrect security UI in Digital Credentials. Reported by Hafiizh on 2025-10-15</li>
+	    <li>[465466773] Medium CVE-2026-0905: Insufficient policy enforcement in Network. Reported by Google on 2025-12-02</li>
+	    <li>[467448811] Low CVE-2026-0906: Incorrect security UI. Reported by Khalil Zhani on 2025-12-10</li>
+	    <li>[444653104] Low CVE-2026-0907: Incorrect security UI in Split View. Reported by Hafiizh on 2025-09-12</li>
+	    <li>[452209503] Low CVE-2026-0908: Use after free in ANGLE. Reported by Glitchers BoB 14th. on 2025-10-15</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-0899</cvename>
+      <cvename>CVE-2026-0900</cvename>
+      <cvename>CVE-2026-0901</cvename>
+      <cvename>CVE-2026-0902</cvename>
+      <cvename>CVE-2026-0903</cvename>
+      <cvename>CVE-2026-0904</cvename>
+      <cvename>CVE-2026-0905</cvename>
+      <cvename>CVE-2026-0906</cvename>
+      <cvename>CVE-2026-0907</cvename>
+      <cvename>CVE-2026-0908</cvename>
+      <url>https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop_13.html</url>
+    </references>
+    <dates>
+      <discovery>2026-01-13</discovery>
+      <entry>2026-01-15</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="fd3855b8-efbc-11f0-9e3f-b0416f0c4c67">
+    <topic>virtualenv -- CWE-59: Improper Link Resolution Before File Access ('Link Following')</topic>
+    <affects>
+    <package>
+	<name>py310-virtualenv</name>
+	<name>py311-virtualenv</name>
+	<name>py312-virtualenv</name>
+	<name>py313-virtualenv</name>
+	<name>py313t-virtualenv</name>
+	<name>py314-virtualenv</name>
+	<range><lt>20.36.1</lt></range>
+    </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>https://github.com/pypa/virtualenv/security/advisories/GHSA-597g-3phw-6986 reports:</p>
+	<blockquote cite="https://github.com/pypa/virtualenv/security/advisories/GHSA-597g-3phw-6986">
+	  <p>virtualenv is a tool for creating isolated virtual python environments.
+Prior to version 20.36.1, TOCTOU (Time-of-Check-Time-of-Use)
+vulnerabilities in virtualenv allow local attackers to perform
+symlink-based attacks on directory creation operations.  An attacker
+with local access can exploit a race condition between directory
+existence checks and creation to redirect virtualenv's app_data and
+lock file operations to attacker-controlled locations.  This issue
+has been patched in version 20.36.1.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-22702</cvename>
+      <url>https://cveawg.mitre.org/api/cve/CVE-2026-22702</url>
+    </references>
+    <dates>
+      <discovery>2026-01-10</discovery>
+      <entry>2026-01-12</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="7e63d0dd-eeff-11f0-b135-c01803b56cc4">
+    <topic>libtasn1 -- Stack-based buffer overflow</topic>
+    <affects>
+<package>
+<name>libtasn1</name>
+<range><lt>4.21.0</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>oss-security@ list reports:</p>
+	<blockquote cite="https://www.openwall.com/lists/oss-security/2026/01/08/5">
+	<p>Stack-based buffer overflow in libtasn1 version: v4.20.0.
+	The function fails to validate the size of input data resulting
+	in a buffer overflow in asn1_expend_octet_string.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-13151</cvename>
+      <url>https://nvd.nist.gov/vuln/detail/CVE-2025-13151</url>
+    </references>
+    <dates>
+      <discovery>2026-01-07</discovery>
+      <entry>2026-01-11</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="c9b610e9-eebc-11f0-b051-2cf05da270f3">
+    <topic>Gitlab -- vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>gitlab-ce</name>
+	<name>gitlab-ee</name>
+	<range><ge>18.7.0</ge><lt>18.7.1</lt></range>
+	<range><ge>18.6.0</ge><lt>18.6.3</lt></range>
+	<range><ge>8.3.0</ge><lt>18.5.5</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Gitlab reports:</p>
+	<blockquote cite="https://about.gitlab.com/releases/2026/01/07/patch-release-gitlab-18-7-1-released/">
+	  <p>Stored Cross-site Scripting issue in GitLab Flavored Markdown placeholders impacts GitLab CE/EE</p>
+	  <p>Cross-site Scripting issue in Web IDE impacts GitLab CE/EE</p>
+	  <p>Missing Authorization issue in Duo Workflows API impacts GitLab EE</p>
+	  <p>Missing Authorization issue in AI GraphQL mutation impacts GitLab EE</p>
+	  <p>Denial of Service issue in import functionality impacts GitLab CE/EE</p>
+	  <p>Insufficient Access Control Granularity issue in GraphQL runnerUpdate mutation impacts GitLab CE/EE</p>
+	  <p>Information Disclosure issue in Mermaid diagram rendering impacts GitLab CE/EE</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-9222</cvename>
+      <cvename>CVE-2025-13761</cvename>
+      <cvename>CVE-2025-13772</cvename>
+      <cvename>CVE-2025-13781</cvename>
+      <cvename>CVE-2025-10569</cvename>
+      <cvename>CVE-2025-11246</cvename>
+      <cvename>CVE-2025-3950</cvename>
+      <url>https://about.gitlab.com/releases/2026/01/07/patch-release-gitlab-18-7-1-released/</url>
+    </references>
+    <dates>
+      <discovery>2026-01-07</discovery>
+      <entry>2026-01-11</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="d822839e-ee4f-11f0-b53e-0897988a1c07">
+    <topic>mail/mailpit -- Cross-Site WebSocket Hijacking</topic>
+    <affects>
+<package>
+<name>mailpit</name>
+<range><lt>1.28.2</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Mailpit author reports:</p>
+	<blockquote cite="https://github.com/axllent/mailpit/security/advisories/GHSA-524m-q5m7-79mm">
+	  <p>The Mailpit WebSocket server is configured to accept
+	  connections from any origin. This lack of Origin header
+	  validation introduces a Cross-Site WebSocket Hijacking
+	  (CSWSH) vulnerability.</p>
+
+	  <p>An attacker can host a malicious website that, when
+	  visited by a developer running Mailpit locally, establishes
+	  a WebSocket connection to the victim's Mailpit instance
+	  (default ws://localhost:8025). This allows the attacker
+	  to intercept sensitive data such as email contents,
+	  headers, and server statistics in real-time.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-22689</cvename>
+      <url>https://github.com/axllent/mailpit/security/advisories/GHSA-524m-q5m7-79mm</url>
+    </references>
+    <dates>
+      <discovery>2026-01-10</discovery>
+      <entry>2026-01-10</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="79c3c751-ee20-11f0-b17e-50ebf6bdf8e9">
+    <topic>phpmyfaq -- multiple vulnerabilities</topic>
+    <affects>
+      <package>
+	<name>phpmyfaq-php82</name>
+	<name>phpmyfaq-php83</name>
+	<name>phpmyfaq-php84</name>
+	<name>phpmyfaq-php85</name>
+	<range><lt>4.0.16</lt></range>
+      </package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>phpMyFAQ team reports:</p>
+	<blockquote cite="https://www.phpmyfaq.de/security/advisory-2025-12-29/">
+	  <p>Stored cross-site scripting (XSS) and unauthenticated config backup
+	    download vulnerability</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <url>https://www.phpmyfaq.de/security/advisory-2025-12-29/</url>
+    </references>
+    <dates>
+      <discovery>2025-12-29</discovery>
+      <entry>2026-01-10</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="8826fb1c-ebd8-11f0-a15a-a8a1599412c6">
+    <topic>chromium -- multiple security fixes</topic>
+    <affects>
+      <package>
+       <name>chromium</name>
+       <range><lt>143.0.7499.192</lt></range>
+      </package>
+      <package>
+       <name>ungoogled-chromium</name>
+       <range><lt>143.0.7499.192</lt></range>
+      </package>
+    </affects>
+    <description>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+       <p>Chrome Releases reports:</p>
+       <blockquote cite="https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop.html">
+	 <p>This update includes 1 security fix:</p>
+	 <ul>
+	    <li>[463155954] High CVE-2026-0628: Insufficient policy enforcement in WebView tag. Reported by Gal Weizman on 2025-11-23</li>
+	 </ul>
+       </blockquote>
+      </body>
+    </description>
+    <references>
+      <cvename>CVE-2026-0628</cvename>
+      <url>https://chromereleases.googleblog.com/2026/01/stable-channel-update-for-desktop.html</url>
+    </references>
+    <dates>
+      <discovery>2026-01-06</discovery>
+      <entry>2026-01-07</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="583b63f5-ebae-11f0-939f-47e3830276dd">
+	  <topic>security/libsodium -- crypto_core_ed25519_is_valid_point mishandles checks for whether an elliptic curve point is valid</topic>
+    <affects>
+<package>
+<name>libsodium</name>
+<range><lt>1.0.21</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Libsodium maintainer reports:</p>
+	<blockquote cite="https://00f.net/2025/12/30/libsodium-vulnerability/">
+	  <p>The function crypto_core_ed25519_is_valid_point(), a low-level function
+	  used to check if a given elliptic curve point is valid, was supposed to
+	  reject points that aren't in the main cryptographic group,
+	  but some points were slipping through.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-69277</cvename>
+      <url>https://00f.net/2025/12/30/libsodium-vulnerability/</url>
+    </references>
+    <dates>
+      <discovery>2025-12-30</discovery>
+      <entry>2026-01-07</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="df33c83b-eb4f-11f0-a46f-0897988a1c07">
+    <topic>mail/mailpit -- Server-Side Request Forgery</topic>
+    <affects>
+<package>
+<name>mailpit</name>
+<range><lt>1.28.1</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>Mailpit author reports:</p>
+	<blockquote cite="https://github.com/axllent/mailpit/security/advisories/GHSA-8v65-47jx-7mfr">
+	  <p>A Server-Side Request Forgery (SSRF) vulnerability
+	  exists in Mailpit's /proxy endpoint that allows attackers
+	  to make requests to internal network resources.</p>
+	  <p>The /proxy endpoint allows requests to internal network
+	  resources. While it validates http:// and https:// schemes,
+	  it does not block internal IP addresses, allowing attackers
+	  to access internal services and APIs.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2026-21859</cvename>
+      <url>https://github.com/axllent/mailpit/security/advisories/GHSA-8v65-47jx-7mfr</url>
+    </references>
+    <dates>
+      <discovery>2026-01-06</discovery>
+      <entry>2026-01-06</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="e2cd20fd-eb10-11f0-a1c0-0050569f0b83">
+    <topic>net-mgmt/net-snmp -- Remote Code Execution (snmptrapd)</topic>
+    <affects>
+<package>
+<name>net-snmp</name>
+<range><lt>5.9.5</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>net-snmp development team reports:</p>
+	<blockquote cite="https://github.com/net-snmp/net-snmp/security/advisories/GHSA-4389-rwqf-q9gq">
+	  <p>A specially crafted packet to an net-snmp snmptrapd daemon can cause a buffer overflow and
+	   the daemon to crash.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-68615</cvename>
+      <url>https://github.com/net-snmp/net-snmp/security/advisories/GHSA-4389-rwqf-q9gq</url>
+    </references>
+    <dates>
+      <discovery>2025-12-23</discovery>
+      <entry>2026-01-06</entry>
+    </dates>
+  </vuln>
+
+  <vuln vid="500cc49c-e93b-11f0-b8d8-4ccc6adda413">
+    <topic>gstreamer1-plugins-bad -- Out-of-bounds reads in MIDI parser</topic>
+    <affects>
+<package>
+<name>gstreamer1-plugins-bad</name>
+<range><lt>1.26.10</lt></range>
+</package>
+    </affects>
+    <description>
+	<body xmlns="http://www.w3.org/1999/xhtml">
+	<p>The GStreamer Security Center reports:</p>
+	<blockquote cite="https://gstreamer.freedesktop.org/security/sa-2025-0009.html">
+	  <p>Multiple out-of-bounds reads in the MIDI parser that can cause
+	  crashes for certain input files.</p>
+	</blockquote>
+	</body>
+    </description>
+    <references>
+      <cvename>CVE-2025-67326</cvename>
+      <cvename>CVE-2025-67327</cvename>
+      <url>https://gstreamer.freedesktop.org/security/sa-2025-0009.html</url>
+    </references>
+    <dates>
+      <discovery>2025-12-27</discovery>
+      <entry>2026-01-04</entry>
+    </dates>
+  </vuln>
+
   <vuln vid="963f4e9d-e4d5-11f0-984f-b42e991fc52e">
     <topic>Forgejo -- Symbolic Link (Symlink) Following</topic>
     <affects>

--- a/security/vuxml/vuln.xml
+++ b/security/vuxml/vuln.xml
@@ -23,9 +23,10 @@
 <!ENTITY vuln-2023 SYSTEM "vuln/2023.xml">
 <!ENTITY vuln-2024 SYSTEM "vuln/2024.xml">
 <!ENTITY vuln-2025 SYSTEM "vuln/2025.xml">
+<!ENTITY vuln-2026 SYSTEM "vuln/2026.xml">
 ]>
 <!--
-Copyright 2003-2025 Jacques Vidrine and contributors
+Copyright 2003-2026 Jacques Vidrine and contributors
 
 Redistribution and use in source (VuXML) and 'compiled' forms (SGML,
 HTML, PDF, PostScript, RTF and so forth) with or without modification,
@@ -74,6 +75,7 @@ Notes:
   * Do not forget port variants (linux-f10-libxml2, libxml2, etc.)
 -->
 <vuxml xmlns="http://www.vuxml.org/apps/vuxml-1">
+&vuln-2026;
 &vuln-2025;
 &vuln-2024;
 &vuln-2023;


### PR DESCRIPTION
## What changed

- add a `candidates` target that queries sec.midnightbsd.org using each port's CPE metadata
- record MidnightBSD package version, `PORTREVISION`, `PORTEPOCH`, and branch information in the candidate report
- omit CVEs already present in the local VuXML shards
- validate that every yearly shard is declared and referenced by `vuln.xml`
- connect the existing 2026 shard and regenerate `vuln-flat.xml`

## Why

MidnightBSD currently relies on syncing FreeBSD VuXML data. FreeBSD package versions can differ from MidnightBSD because revision and epoch values do not necessarily align. This provides the first stage of a MidnightBSD-native workflow: identify CVE candidates from the advisory service while retaining the exact local package metadata needed to construct correct VuXML ranges.

This PR expects the new `/api/cpe/ranges` endpoint from the companion security-advisory PR.

## Validation

- `bmake makesum`
- `bmake patch`
- `bmake`
- `bmake fake`
- `bmake package`
- `bmake test`
- mock API integration test using `dns/bind918`
- `git diff --check`

The generated candidates are intentionally reviewable JSON; automatic VuXML range insertion is left for a later phase after the revision/epoch translation policy is finalized.

## Summary by Sourcery

Introduce tooling to generate MidnightBSD-specific CVE candidate reports from port CPE metadata and ensure VuXML yearly shard consistency while adding 2026 vulnerabilities to the database.

New Features:
- Add a make(1) 'candidates' target that queries sec.midnightbsd.org for CVE ranges based on each port's CPE metadata and outputs a reviewable JSON report.

Enhancements:
- Connect the 2026 VuXML shard, update copyright years, and populate vuln-flat.xml/vuln.xml with new 2026 vulnerability entries.
- Add a shard consistency checker to validate that all yearly VuXML shard files are both declared and referenced in vuln.xml.

Chores:
- Bump the ai/claude-code port to version 2.1.223.