### PR TITLE
Mk: default PostgreSQL to 15

### DIFF
--- a/Mk/components/default-versions.mk
+++ b/Mk/components/default-versions.mk
@@ -88,8 +88,8 @@ _PERL5_FROM_BIN!=       ${LOCALBASE}/bin/perl -e 'printf "%vd\n", $$^V;'
 _EXPORTED_VARS+=        _PERL5_FROM_BIN
 PERL5_DEFAULT:=         ${_PERL5_FROM_BIN:R}
 .  endif
-# Possible values: 10, 11, 12, 13, 14
-PGSQL_DEFAULT?=		14
+# Possible values: 12, 13, 14, 15, 16, 17, 18
+PGSQL_DEFAULT?=		15
 # Possible values: 8.1, 8.2, 8.3
 PHP_DEFAULT?=		8.3
 # Possible values: rust, legacy

--- a/Mk/components/default-versions.mk
+++ b/Mk/components/default-versions.mk
@@ -88,7 +88,7 @@ _PERL5_FROM_BIN!=       ${LOCALBASE}/bin/perl -e 'printf "%vd\n", $$^V;'
 _EXPORTED_VARS+=        _PERL5_FROM_BIN
 PERL5_DEFAULT:=         ${_PERL5_FROM_BIN:R}
 .  endif
-# Possible values: 12, 13, 14, 15, 16, 17, 18
+# Possible values: 14, 15, 16, 17, 18
 PGSQL_DEFAULT?=		15
 # Possible values: 8.1, 8.2, 8.3
 PHP_DEFAULT?=		8.3

--- a/ports-mgmt/magus-utils/Makefile
+++ b/ports-mgmt/magus-utils/Makefile
@@ -1,11 +1,12 @@
 PORTNAME=	magus-utils
 PORTVERSION=	2.1
+PORTREVISION=	1
 CATEGORIES=	ports-mgmt
 MASTER_SITES=	# none
 DISTFILES=	# none
 
-MAINTAINER=     luke@MidnightBSD.org
-COMMENT=        Magus runtime utilities for build cluster
+MAINTAINER=	luke@MidnightBSD.org
+COMMENT=	Magus runtime utilities for build cluster
 
 LICENSE=	agg
 
@@ -19,7 +20,7 @@ RUN_DEPENDS=	p5-DBD-Pg>=0:databases/p5-DBD-Pg \
 		yara:security/yara \
 		git:devel/git
 
-USES=		perl5 pgsql:14
+USES=		perl5 pgsql:15
 
 NO_WRKSUBDIR=	YES
 NO_BUILD=	YES


### PR DESCRIPTION
## Summary

- change the framework PostgreSQL default from 14 to 15
- update `ports-mgmt/magus-utils` to require PostgreSQL 15
- bump `magus-utils` `PORTREVISION` so existing installations receive the dependency change
- refresh the documented set of supported PostgreSQL versions

## Validation

- `bmake -C ports-mgmt/magus-utils check-license`
- `portlint -AC ports-mgmt/magus-utils` (0 fatal errors; existing-style warnings for missing `WWW`, `PORTREVISION`, and maintainer mode)
- `INDEXING=yes PACKAGE_BUILDING=yes BATCH=yes bmake -C ports-mgmt/magus-utils describe`
- `INDEXING=yes PACKAGE_BUILDING=yes BATCH=yes bmake -C databases/postgresql15-client describe`
- `INDEXING=yes PACKAGE_BUILDING=yes BATCH=yes bmake -C databases/postgresql15-server describe`
- verified `magus-utils` resolves `PGSQL_DEFAULT=15`, `PGSQL_VER=15`, and `libpq.so.5:databases/postgresql15-client`
- `git diff --check`

The full local port build was not run because this host has PostgreSQL 14 installed. The framework correctly stops with `the port wants postgresql-client version 15 and you have version 14 installed`; the compatibility guard was not bypassed.

## Summary by Sourcery

Update the ports framework to default PostgreSQL to version 15 and align magus-utils with the new default.

Enhancements:
- Refresh the documented set of supported PostgreSQL versions in the framework to include newer releases and set the default to 15.

Build:
- Adjust magus-utils port metadata to depend on PostgreSQL 15 and bump PORTREVISION so existing installations pick up the new dependency.