### PR TITLE
Mk: default Ruby to 3.3

### DIFF
--- a/Mk/components/default-versions.mk
+++ b/Mk/components/default-versions.mk
@@ -103,7 +103,7 @@ PYTHON_DEFAULT?=	3.12
 # Possible values: 2.7
 PYTHON2_DEFAULT?=	2.7
 # Possible values: 3.2, 3.3
-RUBY_DEFAULT?=		3.2
+RUBY_DEFAULT?=		3.3
 RUST_DEFAULT?=		rust
 # Possible values: 4.16, 4.19, ... 
 SAMBA_DEFAULT?=		4.16


### PR DESCRIPTION
## Summary

- change the mports Ruby default from 3.2 to 3.3
- make unversioned Ruby and RubyGem dependencies resolve to `lang/ruby33`

Ruby 3.3 is already supported by the framework and carried as Ruby 3.3.11. No ports currently declare `BROKEN_RUBY33`.

## Validation

- verified `RUBY_DEFAULT=3.3`, `RUBY_VER=3.3`, and `RUBY_PORT=lang/ruby33` for:
  - `lang/ruby33`
  - `devel/ruby-gems`
  - `devel/rubygem-rake`
  - `databases/rubygem-pg`
- `BATCH=yes bmake -C lang/ruby33 clean`
- `BATCH=yes bmake -C lang/ruby33 patch`
- `BATCH=yes bmake -C lang/ruby33`
- `BATCH=yes bmake -C lang/ruby33 fake`
- `BATCH=yes bmake -C lang/ruby33 package`
- `BATCH=yes bmake -C lang/ruby33 test` — all 1,890 bootstrap tests passed, followed by the basic test suite passing
- `git diff --check`

The fake QA stage reports existing Ruby port warnings about unstripped extension modules and the Ruby shared-library SONAME; this one-line default change does not introduce those warnings.

## Summary by Sourcery

Enhancements:
- Change the framework-wide RUBY_DEFAULT from 3.2 to 3.3 so unversioned Ruby and RubyGem dependencies target Ruby 3.3.