### PR TITLE
lang/php85: complete PHP 8.5 port support

### DIFF
--- a/Mk/components/default-versions.mk
+++ b/Mk/components/default-versions.mk
@@ -90,7 +90,7 @@ PERL5_DEFAULT:=         ${_PERL5_FROM_BIN:R}
 .  endif
 # Possible values: 14, 15, 16, 17, 18
 PGSQL_DEFAULT?=		15
-# Possible values: 8.1, 8.2, 8.3
+# Possible values: 8.1, 8.2, 8.3, 8.4, 8.5
 PHP_DEFAULT?=		8.3
 # Possible values: rust, legacy
 .  if empty(ARCH:Naarch64:Namd64:Narmv7:Ni386:Npowerpc64:Npowerpc64le:Npowerpc:Nriscv64)

--- a/Mk/extensions/php.mk
+++ b/Mk/extensions/php.mk
@@ -110,7 +110,7 @@ DIST_SUBDIR=	PECL
 
 PHPBASE?=	${LOCALBASE}
 
-_ALL_PHP_VERSIONS=	82 83 84
+_ALL_PHP_VERSIONS=	82 83 84 85
 
 # Make the already installed PHP the default one.
 .  if exists(${PHPBASE}/etc/php.conf) && !defined(INDEXING)
@@ -179,7 +179,13 @@ PHP_VER=	${FLAVOR:S/^php//}
 	(${FLAVOR:Mphp[0-9][0-9]} && ${FLAVOR} != ${FLAVORS:[1]})
 # When adding a version, please keep the comment in
 # Mk/components/default-versions.mk in sync.
-.    if ${PHP_VER} == 83
+.    if ${PHP_VER} == 85
+PHP_EXT_DIR=   20250925
+PHP_EXT_INC=    hash json opcache openssl pcre random spl
+.    elif ${PHP_VER} == 84
+PHP_EXT_DIR=   20240924
+PHP_EXT_INC=    hash json openssl pcre random spl
+.    elif ${PHP_VER} == 83
 PHP_EXT_DIR=   20230831
 PHP_EXT_INC=    hash json openssl pcre random spl
 .    elif ${PHP_VER} == 82

--- a/lang/php85/Makefile
+++ b/lang/php85/Makefile
@@ -132,7 +132,8 @@ PLIST_SUB+=	SAPI_INC=""
 PLIST_SUB+=	SAPI_INC="@comment "
 .  endif
 
-.  if ((${OSVERSION} >= 1500059 && ${SSL_DEFAULT} == base) || (${SSL_DEFAULT:Mopenssl*} && ${OPENSSL_SHLIBVER} >= 15)) && empty(PORT_OPTIONS:MZTS)
+.  if (${SSL_DEFAULT:Mopenssl*} && ${OPENSSL_SHLIBVER:U0} >= 15) && \
+	empty(PORT_OPTIONS:MZTS)
 CONFIGURE_ARGS+=	--with-openssl-argon2
 .  else
 LIB_DEPENDS+=		libargon2.so:security/libargon2

--- a/www/Makefile
+++ b/www/Makefile
@@ -114,6 +114,7 @@
     SUBDIR += mod_perl2
     SUBDIR += mod_php82
     SUBDIR += mod_php83
+    SUBDIR += mod_php85
     SUBDIR += mod_security
     SUBDIR += mod_tls
     SUBDIR += mod_webauth

--- a/www/mod_php85/Makefile
+++ b/www/mod_php85/Makefile
@@ -1,0 +1,19 @@
+CATEGORIES=	www devel
+PKGNAMEPREFIX=	mod_
+
+MAINTAINER=	ports@MidnightBSD.org
+
+CONFLICTS_INSTALL=	mod_php[0-9][0-9]
+
+MASTERDIR=	${.CURDIR}/../../lang/php85
+
+OPTIONS_DEFINE=		AP2FILTER
+OPTIONS_EXCLUDE=	CGI CLI EMBED FPM
+
+AP2FILTER_DESC=	Use Apache 2.x filter interface (experimental)
+
+AP2FILTER_CONFIGURE_ON=		--with-apxs2filter=${APXS}
+AP2FILTER_CONFIGURE_OFF=	--with-apxs2=${APXS}
+CONFIGURE_ENV+=			pthreads_working=yes
+
+.include "${MASTERDIR}/Makefile"


### PR DESCRIPTION
## Summary

- register PHP 8.5 in the PHP framework and default-version documentation
- add PHP 8.4 and 8.5 extension ABI metadata
- add and register www/mod_php85 from the local FreeBSD ports tree
- remove the FreeBSD 15-only OSVERSION argon2 condition
- provide the MidnightBSD pthread configure result needed for Apache ZTS builds

## Validation

- all 56 PHP 8.5 origins parse with PHP_DEFAULT=8.5
- bmake makesum, patch, build, fake, and package pass for lang/php85
- bmake makesum, patch, build, fake, and package pass for www/mod_php85
- bmake check-license passes for both ports
- generated php85-8.5.9.mport and mod_php85-8.5.9.mport packages
- PHP extension ABI resolves to 20250925-zts for PHP 8.5 and 20240924-zts for PHP 8.4 on this host

The full upstream PHP test suite reached 12,727 of 14,223 tests before a proc_open stream test hung. Several proc_open tests failed because subprocesses inherited the host PHP configuration and attempted to load PHP 8.5 extensions that are not installed. No tests were disabled.

## Summary by Sourcery

Add full PHP 8.5 port support and integrate it into the MidnightBSD PHP framework and web modules.

New Features:
- Register PHP 8.5 as a supported PHP version in the extensions framework and default-version configuration.
- Introduce PHP 8.4 and 8.5 extension ABI metadata for PHP modules.
- Add a new mod_php85 Apache module port based on the php85 language port.

Enhancements:
- Adjust argon2 OpenSSL handling in the PHP 8.5 port to rely on OpenSSL version instead of OSVERSION constraints.
- Provide pthreads configuration for Apache ZTS builds in the mod_php85 port.

Documentation:
- Update default-version documentation to list PHP 8.4 and 8.5 as possible PHP defaults.