### PR TITLE
mail/rspamd: update to 4.1.0

### DIFF
--- a/mail/rspamd/Makefile
+++ b/mail/rspamd/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	rspamd
-PORTVERSION=	4.0.1
-PORTREVISION=	0
+PORTVERSION=	4.1.0
 CATEGORIES=	mail
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -77,6 +76,12 @@ HYPERSCAN_CMAKE_ON=	-DENABLE_HYPERSCAN=ON
 LUAJIT_USES=		luajit
 LUAJIT_USES_OFF=	lua:51+
 LUAJIT_CMAKE_OFF=	-DENABLE_LUAJIT=OFF
+
+.include <bsd.mport.options.mk>
+
+.if ${OPTIONS_DEFINE:NHYPERSCAN}
+PLIST_SUB+=	HYPERSCAN="@comment "
+.endif
 
 post-install:
 	@${MKDIR} \

--- a/mail/rspamd/distinfo
+++ b/mail/rspamd/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1785800967
-SHA256 (rspamd-rspamd-4.0.1_GH0.tar.gz) = 68b1c662c09817f962faebcd74f20afc0b64f6d7513c3782cd2bc2b2323a5cba
-SIZE (rspamd-rspamd-4.0.1_GH0.tar.gz) = 6998348
+TIMESTAMP = 1786138252
+SHA256 (rspamd-rspamd-4.1.0_GH0.tar.gz) = 1e92b976aff69fe0b74c02819a2a26b5821e55f185b9acdb5ddc1c08bcbfde19
+SIZE (rspamd-rspamd-4.1.0_GH0.tar.gz) = 7161409

--- a/mail/rspamd/pkg-plist
+++ b/mail/rspamd/pkg-plist
@@ -16,7 +16,10 @@ etc/newsyslog.conf.d/rspamd.newsyslog.conf
 %%ETCDIR%%/local.d/antivirus.conf.example
 %%ETCDIR%%/local.d/module.conf.example
 %%ETCDIR%%/logging.inc
+%%ETCDIR%%/lua.local.d/maps/example.lua.example
 %%ETCDIR%%/lua.local.d/module.lua.example
+%%ETCDIR%%/lua.local.d/regexps/example.lua.example
+%%ETCDIR%%/lua.local.d/selectors/example.lua.example
 %%ETCDIR%%/maps.d/dmarc_whitelist.inc
 %%ETCDIR%%/maps.d/exe_clickbait.inc
 %%ETCDIR%%/maps.d/maillist.inc
@@ -106,6 +109,8 @@ etc/newsyslog.conf.d/rspamd.newsyslog.conf
 %%ETCDIR%%/statistic.conf
 %%ETCDIR%%/worker-controller.inc
 %%ETCDIR%%/worker-fuzzy.inc
+%%HYPERSCAN%%%%ETCDIR%%/worker-hs_helper.conf
+%%HYPERSCAN%%%%ETCDIR%%/worker-hs_helper.inc
 %%ETCDIR%%/worker-normal.inc
 %%ETCDIR%%/worker-proxy.inc
 lib/rspamd/librspamd-actrie.so
@@ -187,6 +192,8 @@ share/man/man8/rspamd.8.gz
 %%DATADIR%%/lualib/lua_content/vcard.lua
 %%DATADIR%%/lualib/lua_cta.lua
 %%DATADIR%%/lualib/lua_dkim_tools.lua
+%%DATADIR%%/lualib/lua_extras.lua
+%%DATADIR%%/lualib/lua_feedback_parsers.lua
 %%DATADIR%%/lualib/lua_ffi/common.lua
 %%DATADIR%%/lualib/lua_ffi/dkim.lua
 %%DATADIR%%/lualib/lua_ffi/init.lua
@@ -213,6 +220,7 @@ share/man/man8/rspamd.8.gz
 %%DATADIR%%/lualib/lua_scanners/cloudmark.lua
 %%DATADIR%%/lualib/lua_scanners/common.lua
 %%DATADIR%%/lualib/lua_scanners/dcc.lua
+%%DATADIR%%/lualib/lua_scanners/expurgate.lua
 %%DATADIR%%/lualib/lua_scanners/fprot.lua
 %%DATADIR%%/lualib/lua_scanners/icap.lua
 %%DATADIR%%/lualib/lua_scanners/init.lua
@@ -287,6 +295,7 @@ share/man/man8/rspamd.8.gz
 %%DATADIR%%/lualib/rspamadm/autolearnstats.lua
 %%DATADIR%%/lualib/rspamadm/logstats.lua
 %%DATADIR%%/lualib/rspamadm/mapstats.lua
+%%DATADIR%%/lualib/rspamadm/memstat.lua
 %%DATADIR%%/lualib/rspamadm/neural_export.lua
 %%DATADIR%%/lualib/rspamadm/publicsuffix.lua
 %%DATADIR%%/lualib/rspamadm/ratelimit.lua
@@ -429,6 +438,9 @@ share/man/man8/rspamd.8.gz
 %%DATADIR%%/www/js/main.js
 %%DATADIR%%/www/mstile-150x150.png
 %%DATADIR%%/www/safari-pinned-tab.svg
+@dir %%ETCDIR%%/lua.local.d/maps
+@dir %%ETCDIR%%/lua.local.d/regexps
+@dir %%ETCDIR%%/lua.local.d/selectors
 @owner rspamd
 @group rspamd
 @dirrmtry /var/db/rspamd


### PR DESCRIPTION
Update `mail/rspamd` from 4.0.1 to 4.1.0.

## Changes

- `PORTVERSION` 4.0.1 → 4.1.0, dropped `PORTREVISION= 0`.
- Added `PLIST_SUB+= HYPERSCAN="@comment "` under `.if ${OPTIONS_DEFINE:NHYPERSCAN}` (via `bsd.mport.options.mk`) so `%%HYPERSCAN%%` resolves on architectures without hyperscan. Mirrors FreeBSD c6b24b28a177.
- pkg-plist: 12 additions — `lua.local.d/{maps,regexps,selectors}/example.lua.example` plus their `@dir` entries, the hyperscan-gated `worker-hs_helper.{conf,inc}`, `lua_extras.lua`, `lua_feedback_parsers.lua`, `lua_scanners/expurgate.lua`, `rspamadm/memstat.lua`.

## No dependency or patch changes

FreeBSD's 4.1.0 commit (2feabcfbd8cb) touched only `Makefile` and `distinfo`, and the Makefile hunk was the version line alone. `files/patch-contrib_xxhash_xxhash.h` is byte-identical to FreeBSD's and applies cleanly with no fuzz.

## Verification

`makesum`, `patch`, `build`, `fake`, `package` all succeeded → `rspamd-4.1.0.mport`. distinfo matches FreeBSD's byte-for-byte.

The plist was cross-checked against a `bmake makeplist` gen-plist, and `work/.PLIST.mktmp` confirms `@comment etc/rspamd/worker-hs_helper.conf` — i.e. the substitution works rather than leaving a literal token. `PLIST_SUB` verified on three branches: amd64 default → `HYPERSCAN="@comment "`, `WITH=HYPERSCAN` → `HYPERSCAN=""`, `ARCH=i386` → `HYPERSCAN="@comment "`. Gating those two files is correct per `cmake/InstallRspamdFiles.cmake:24`, which removes them when hyperscan is off.

LICENSE unchanged (Apache 2.0).

**Not validated:** built on amd64 only. The i386 path was checked at the make-variable level, not compiled.

## Adjacent, not fixed

`post-install` runs `${RM} ${FAKE_DESTDIR}/${ETCDIR}/rspamd.systemd.conf`, which doubles the staging prefix and is therefore a silent no-op. Harmless today (upstream doesn't stage those files) but will bite if that changes. Pre-existing, left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the rspamd port to 4.1.0 and adjust packaging metadata for optional Hyperscan support and new installed files.

Enhancements:
- Extend the pkg-plist to cover new example Lua configs, Lua helper scripts, Hyperscan-gated worker configuration files, and additional admin utilities introduced in rspamd 4.1.0.

Build:
- Bump PORTVERSION of mail/rspamd from 4.0.1 to 4.1.0 and remove explicit PORTREVISION.
- Include bsd.mport.options.mk and define a PLIST_SUB HYPERSCAN substitution so plist tokens resolve correctly when Hyperscan is unavailable.