### PR TITLE
mail/roundcube: update to 1.7.2

### DIFF
--- a/mail/roundcube/Makefile
+++ b/mail/roundcube/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	roundcube
-DISTVERSION=	1.6.16
+DISTVERSION=	1.7.2
 PORTEPOCH=	1
 CATEGORIES?=	mail www
 MASTER_SITES=	https://github.com/roundcube/roundcubemail/releases/download/${DISTVERSION}/
@@ -11,7 +11,7 @@ COMMENT=	Fully skinnable XHTML/CSS webmail written in PHP
 WWW=		https://roundcube.net/
 
 LICENSE=	gpl3+
-LICENSE_FILE=	${WRKSRC}/LICENSE
+LICENSE_FILE=	${WRKSRC}/docs/LICENSE.md
 
 USES=		cpe php:web,flavors
 
@@ -19,9 +19,9 @@ NO_ARCH=	yes
 NO_BUILD=	yes
 WRKSRC=		${WRKDIR}/${PORTNAME}mail-${DISTVERSION}
 
-RCUBECOMP=	SQL config .htaccess index.php installer logs \
+RCUBECOMP=	SQL config index.php installer logs \
 		plugins program public_html skins temp vendor
-PORTDOCS=	CHANGELOG.md INSTALL README.md UPGRADING
+PORTDOCS=	CHANGELOG.md INSTALL.md README.md UPGRADING.md
 
 CPE_PRODUCT=	webmail
 CPE_VENDOR=	roundcube
@@ -75,9 +75,10 @@ do-install-NSC-on:
 
 do-install-DOCS-on:
 	${MKDIR} ${FAKE_DESTDIR}${DOCSDIR}
-.for i in ${PORTDOCS}
-	@${INSTALL_DATA} ${WRKSRC}/${i} ${FAKE_DESTDIR}${DOCSDIR}/
-.endfor
+	${INSTALL_DATA} ${WRKSRC}/CHANGELOG.md ${FAKE_DESTDIR}${DOCSDIR}/
+	${INSTALL_DATA} ${WRKSRC}/README.md ${FAKE_DESTDIR}${DOCSDIR}/
+	${INSTALL_DATA} ${WRKSRC}/docs/INSTALL.md ${FAKE_DESTDIR}${DOCSDIR}/
+	${INSTALL_DATA} ${WRKSRC}/docs/UPGRADING.md ${FAKE_DESTDIR}${DOCSDIR}/
 
 do-install-EXAMPLES-on:
 	${MKDIR} ${FAKE_DESTDIR}${EXAMPLESDIR}

--- a/mail/roundcube/distinfo
+++ b/mail/roundcube/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1780514948
-SHA256 (roundcubemail-1.6.16-complete.tar.gz) = 554f88f642d2d709916e9fd674239a83189a956e7258ce72a1d927c84ecd7e1a
-SIZE (roundcubemail-1.6.16-complete.tar.gz) = 5879804
+TIMESTAMP = 1786138382
+SHA256 (roundcubemail-1.7.2-complete.tar.gz) = 01bf9ede1665e507db94bab1361ebed20ee353dba04bc628b00fb6eca05af3d1
+SIZE (roundcubemail-1.7.2-complete.tar.gz) = 6380572

--- a/mail/roundcube/files/patch-config_defaults.inc.php
+++ b/mail/roundcube/files/patch-config_defaults.inc.php
@@ -1,6 +1,6 @@
---- config/defaults.inc.php.orig	2017-06-26 20:56:47.000000000 +0200
-+++ config/defaults.inc.php	2017-06-30 10:19:42.733949000 +0200
-@@ -739,8 +739,8 @@ $config['spellcheck_dictionary'] = false
+--- config/defaults.inc.php.orig	2026-05-24 08:01:37 UTC
++++ config/defaults.inc.php
+@@ -1009,8 +1009,8 @@ $config['spellcheck_engine'] = 'googie';
  // You can connect to any other googie-compliant service by setting 'spellcheck_uri' accordingly.
  $config['spellcheck_engine'] = 'googie';
  
@@ -9,5 +9,5 @@
 +// For a locally installed spellcheker, specify the URI to call it, for example:
 +// 'http://' . $_SERVER['HTTP_HOST'] . '/spellchecker.php?lang='
  // Get Nox Spell Server from http://orangoo.com/labs/?page_id=72 or
- // the After the Deadline package from http://www.afterthedeadline.com.
+ // the After the Deadline package from https://www.afterthedeadline.com.
  // Leave empty to use the public API of service.afterthedeadline.com

--- a/mail/roundcube/files/patch-program_lib_Roundcube_rcube_message.php
+++ b/mail/roundcube/files/patch-program_lib_Roundcube_rcube_message.php
@@ -1,12 +1,14 @@
---- program/lib/Roundcube/rcube_message.php.orig	2022-06-26 20:26:58 UTC
+--- program/lib/Roundcube/rcube_message.php.orig	2026-05-24 08:01:37 UTC
 +++ program/lib/Roundcube/rcube_message.php
-@@ -914,8 +914,7 @@ class rcube_message
-                 else if (
+@@ -1006,9 +1006,8 @@ class rcube_message
+                 elseif (
                      preg_match('/^(inline|attach)/', $mail_part->disposition)
                      || !empty($mail_part->headers['content-id'])
--                    || ($mail_part->filename &&
--                        (empty($mail_part->disposition) || preg_match('/^[a-z0-9!#$&.+^_-]+$/i', $mail_part->disposition)))
+-                    || ($mail_part->filename
+-                        && (empty($mail_part->disposition) || preg_match('/^[a-z0-9!#$&.+^_-]+$/i', $mail_part->disposition)))
+-                ) {
 +                    || $mail_part->filename
-                 ) {
++		) {
                      // skip apple resource forks
                      if ($message_ctype_secondary == 'appledouble' && $secondary_type == 'applefile') {
+                         continue;

--- a/mail/roundcube/pkg-message
+++ b/mail/roundcube/pkg-message
@@ -2,29 +2,39 @@
 { type: install
   message: <<EOM
 If this is a first installation of RoundCube you have to create
-a new database and a db user. Read INSTALL for detailed instructions.
+a new database and a db user. Read INSTALL.md for detailed instructions.
 EOM
 }
 { type: upgrade
   message: <<EOM
 If you already had a previous version of RoundCube installed,
 you should check your config files and DB schema are up-to-date.
-Read UPGRADING for detailed instructions.
+Read UPGRADING.md for detailed instructions.
+EOM
+}
+{ type: upgrade
+  maximum_version: "1.7.0"
+  message: <<EOM
+Roundcube 1.7 has a number of breaking changes. Check
+https://roundcube.net/news/2026/05/10/roundcube-1.7.0-released for
+details.
+
+Read UPGRADING.md for detailed instructions.
 EOM
 }
 { type: upgrade
   maximum_version: "1.6.0"
   message: <<EOM
 Roundcube 1.6 has a number of breaking changes in the smtp, imap,
-ldap, and managesieve connection configuration. Check 
+ldap, and managesieve connection configuration. Check
 https://roundcube.net/news/2022/07/28/roundcube-1.6.0-released for
 details.
- 
+
 Roundcube 1.6 no longer includes the "Classic" and "Larry" skins.
-The skins can be found as mail/rouncube-larry and
+The skins can be found as mail/roundcube-larry and
 mail/roundcube-classic ports.
 
-Read UPGRADING for detailed instructions.
+Read UPGRADING.md for detailed instructions.
 EOM
 }
 ]


### PR DESCRIPTION
Update `mail/roundcube` from 1.6.16 to 1.7.2. This is a minor-version jump, not a patch bump.

## Real breakage found

1.7.2 no longer ships a top-level `.htaccess`, but mports carried it in `RCUBECOMP` (FreeBSD never did). `COPYTREE_SHARE` on a missing source would have failed `do-install`. Each `RCUBECOMP` member was verified with `test -e`; only `.htaccess` was missing, so it was dropped. The four **nested** `.htaccess` files (`config/`, `logs/`, `public_html/`, `temp/`) are still collected by the recursive `FIND`, so nothing is lost from the package. This isn't discarding mports delta — the delta had gone stale.

## Patch set

Both patches were 1.6-era and would **not** have applied to 1.7.2 (`patch-config_defaults.inc.php` was pinned at `@@ -739` with 2017 context; the real hunk in 1.7.2 is near line 1009). Contents replaced with FreeBSD's 1.7.2 versions, mports filenames kept — deliberately **not** adopting FreeBSD's doubled-underscore `patch-program_lib_Roundcube_rcube__message.php` name, which would have left the single-underscore file in place and applied the same hunk twice. Neither patch was upstreamed; both are still needed. `bmake patch` applies cleanly with no fuzz and no `.rej`/`.orig`.

## pkg-message — one deliberate divergence from FreeBSD

FreeBSD's 1.7 breaking-changes block carries `maximum_version: "1.6.0"`, which gates the notice to users coming from ≤1.6.0 — so nobody on 1.6.1–1.6.16 would ever see it. Ours uses `"1.7.0"`. The 1.6 skins block was **added to** rather than replaced, since `mail/roundcube-larry` and `mail/roundcube-classic` both still exist in mports. Also fixed a `rouncube` typo in that reference.

Verified by extracting the built `.mport` and confirming the message is embedded and the UCL parsed — a successful `bmake package` alone wouldn't prove that.

## PHP version

No change needed. 1.7.2's `composer.json` requires `"php": ">=8.1 <8.6"`; mports flavors are php82–php85 (default 8.3), so every flavor satisfies it. Matches FreeBSD's unconstrained `php:web,flavors`.

## pkg-plist

This port has no static `pkg-plist` — `do-install` generates it by walking `bin` + `RCUBECOMP` and appending to `TMPPLIST`. `bmake makeplist` was deliberately not run, since a static plist layered on the dynamic one appends rather than replaces. The 1.6→1.7 file churn is absorbed automatically; the generated `.PLIST.mktmp` came out at 3167 entries.

## Verification

`makesum`, `patch`, `build`, `fake`, `package` all succeeded → `roundcube-php83-1.7.2,1.mport`. distinfo matches FreeBSD's byte-for-byte. `portlint`: 0 fatal, 4 warnings, all on untouched lines.

LICENSE is not a relicense — `composer.json` still declares GPL-3.0-or-later, matching the existing `gpl3+`. Only the license file path moved to `docs/LICENSE.md`.

**Not validated:** php83 flavor only, amd64. `do-install-NSC-on` was not exercised (NSC is off by default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Roundcube port to 1.7.2 and align packaging, local patches, and messages with the new upstream layout and FreeBSD’s 1.7.2 port.

Bug Fixes:
- Refresh the local attachment-handling and spellchecker configuration patches so they still apply cleanly against Roundcube 1.7.2.

Enhancements:
- Adjust installed documentation and license paths to match Roundcube 1.7.2’s new docs layout and filenames.
- Stop including the obsolete top-level .htaccess from RCUBECOMP while retaining nested .htaccess files collected recursively.
- Tweak pkg-message version gating and content so 1.6.x users upgrading to 1.7.x still see the relevant breaking-changes and skins notices.

Build:
- Update DISTVERSION and distinfo and keep the dynamic plist generation compatible with the 1.7.2 distfile contents.

Documentation:
- Update installed documentation files to the new INSTALL.md/UPGRADING.md locations under docs/ and fix a typo in the pkg-message.