### PR TITLE
mail/squirrelmail: update to snapshot 20250613

### DIFF
--- a/mail/squirrelmail/Makefile
+++ b/mail/squirrelmail/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	squirrelmail
-DISTVERSION=	20240929
+DISTVERSION=	20250613
 CATEGORIES=	mail www
 MASTER_SITES=	http://snapshots.squirrelmail.org/ \
 		http://freebsd.uzsolt.hu/src/

--- a/mail/squirrelmail/distinfo
+++ b/mail/squirrelmail/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1727633278
-SHA256 (squirrelmail/squirrelmail-20240929_0200-SVN.stable.tar.bz2) = d8bbccb38b04f5eaf17b951719922c4664034e5923448dbff17038e04dc5b8ba
-SIZE (squirrelmail/squirrelmail-20240929_0200-SVN.stable.tar.bz2) = 577387
+TIMESTAMP = 1786139778
+SHA256 (squirrelmail/squirrelmail-20250613_0200-SVN.stable.tar.bz2) = 9994fa3bf8105b646859157fb9eb5315f54dbf7e6492526b86c998c730a8ea1d
+SIZE (squirrelmail/squirrelmail-20250613_0200-SVN.stable.tar.bz2) = 577715


### PR DESCRIPTION
Update `mail/squirrelmail` from snapshot 20240929 to 20250613. Two files changed: `Makefile` (`DISTVERSION` only) and `distinfo`.

## Distfile availability — worth knowing

The distfile genuinely fetched (no cached copy existed beforehand), but **`snapshots.squirrelmail.org` returned 404** — the snapshot has been rotated off the primary site. It came from `freebsd.uzsolt.hu/src/`, the persistence mirror already listed in `MASTER_SITES`.

The resulting checksum reproduces FreeBSD's byte-for-byte, so the mirror copy is authentic:

```
SHA256 = 9994fa3bf8105b646859157fb9eb5315f54dbf7e6492526b86c998c730a8ea1d
SIZE   = 577715
```

`MASTER_SITES` is functional only because that mirror is in it. If it ever goes away this port becomes unfetchable.

## Patches and plist

No changes to either. The `files/` patch set (`patch-plugins__squirrelspell__sqspell_config.php`) is byte-identical to FreeBSD's, which is already at 20250613, so it is pre-validated for this snapshot — it applies clean with no fuzz. pkg-plist is likewise identical to FreeBSD's 20250613.

There is no `PORTREVISION` line, so nothing to reset.

## Plugin ports

None. A tree-wide grep found only the `SUBDIR` entry in `mail/Makefile`. The slave-port framework (`bsd.squirrelmail.mk`, `files/plugin-pkg-message.in`) is carried but has no consumers in mports, so nothing needs a matching bump.

## Verification

`makesum`, `patch`, `build`, `fake`, `package` all succeeded → `squirrelmail-php83-20250613.mport`. No breakages, no workarounds.

LICENSE unchanged — mports' `gpl2+` vs FreeBSD's `GPLv2+` is the mports identifier convention, not a relicense.

`USES= php:web,flavors` carries no version constraint, so there's nothing to reconcile against the available PHP versions.

**Not validated:** default php83 flavor only, amd64.

## Adjacent, not fixed

`files/pkg-install.in` and `files/pkg-deinstall.in` are mports-only files, but `SUB_FILES` lists only `pkg-message` — they appear unreferenced. Pre-existing; flagged rather than fixed. The Makefile also ends with `.include <bsd.port.mk>` rather than `bsd.mport.mk`; pre-existing and working, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Track the latest squirrelmail snapshot by bumping DISTVERSION and regenerating distinfo entries.