### PR TITLE
mail/py-postfix-mta-sts-resolver: update to 1.5.1

### DIFF
--- a/mail/py-postfix-mta-sts-resolver/Makefile
+++ b/mail/py-postfix-mta-sts-resolver/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	postfix-mta-sts-resolver
-PORTVERSION=	1.4.0
-PORTREVISION=	2
+PORTVERSION=	1.5.1
 DISTVERSIONPREFIX=	v
 CATEGORIES=	mail python
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -11,7 +10,8 @@ WWW=		https://pypi.python.org/pypi/postfix-mta-sts-resolver
 
 LICENSE=	mit
 
-BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}wheel>0:devel/py-wheel@${PY_FLAVOR}
+BUILD_DEPENDS=	${PY_SETUPTOOLS} \
+		${PYTHON_PKGNAMEPREFIX}wheel>0:devel/py-wheel@${PY_FLAVOR}
 RUN_DEPENDS=	${LOCALBASE}/share/certs/ca-root-nss.crt:security/ca_root_nss \
 		${PYTHON_PKGNAMEPREFIX}aiodns>=3.0.0:dns/py-aiodns@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}aiohttp>=3.4.4:www/py-aiohttp@${PY_FLAVOR} \
@@ -20,7 +20,7 @@ RUN_DEPENDS=	${LOCALBASE}/share/certs/ca-root-nss.crt:security/ca_root_nss \
 USES=		python
 USE_GITHUB=	yes
 GH_ACCOUNT=	Snawoot
-USE_PYTHON=	autoplist distutils
+USE_PYTHON=	autoplist pep517
 USE_RC_SUBR=	mta_sts
 
 NO_ARCH=	yes

--- a/mail/py-postfix-mta-sts-resolver/distinfo
+++ b/mail/py-postfix-mta-sts-resolver/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1695492126
-SHA256 (Snawoot-postfix-mta-sts-resolver-v1.4.0_GH0.tar.gz) = 6fe07c9076e329fe3a9a347d7f9f8b2885526067dd7ea906b8916cd0dd5040ab
-SIZE (Snawoot-postfix-mta-sts-resolver-v1.4.0_GH0.tar.gz) = 54627
+TIMESTAMP = 1786138369
+SHA256 (Snawoot-postfix-mta-sts-resolver-v1.5.1_GH0.tar.gz) = ed398e2a652c6f89e32ca7bb64ee30ab6309b692bcbac1b9f13affc9fc39ac04
+SIZE (Snawoot-postfix-mta-sts-resolver-v1.5.1_GH0.tar.gz) = 54992


### PR DESCRIPTION
Update `mail/py-postfix-mta-sts-resolver` from 1.4.0 to 1.5.1.

## Changes

- `PORTVERSION` 1.4.0 → 1.5.1, dropped `PORTREVISION= 2`.
- `USE_PYTHON= autoplist distutils` → `autoplist pep517`.
- Added `${PY_SETUPTOOLS}` to `BUILD_DEPENDS`.

The setuptools line is not a new dependency in substance. `Mk/extensions/python.mk:703-712` auto-injects setuptools under `_PYTHON_FEATURE_DISTUTILS`, and the pep517 branch at line 714 does not — the explicit add restores what the mode switch removed. Upstream's `pyproject.toml` still declares `setuptools.build_meta` and `setup.py` is still present, so FreeBSD's move to pep517 is a framework modernization, not an upstream backend change. pep517 also pulls in `devel/py-build` and `devel/py-installer`; both exist in mports.

Runtime dependencies are unchanged between 1.4.0 and 1.5.1 (`install_requires`: aiodns, aiohttp, PyYAML; extras: aiosqlite, redis, asyncpg). All verified present in mports — no missing dependency ports.

`USES= python` with no version spec, matching FreeBSD. Upstream declares `python_requires='>=3.5.3'`; mports has 3.9–3.14, so no spec is needed.

## MidnightBSD delta preserved

`MAINTAINER= ports@MidnightBSD.org`, lowercase `LICENSE= mit`, and `post-install` writing to bare `${PREFIX}` rather than `${STAGEDIR}${PREFIX}` — confirmed staged correctly at `work-py312/fake-inst-amd64/usr/local/etc/mta-sts-daemon.yml.sample`.

## Verification

`makesum`, `patch`, `build`, `fake`, `package` all succeeded → `py312-postfix-mta-sts-resolver-1.5.1.mport`. distinfo matches FreeBSD's byte-for-byte.

No patches exist for this port — `files/` contains only `mta_sts.in`, identical to FreeBSD's.

There is no `pkg-plist`; the port uses `PLIST_FILES` + `autoplist`. The pep517 switch changed the generated metadata directory from `*.egg-info` to `*.dist-info` (plus a `zip-safe` entry), which autoplist absorbed with no manual edit. Both `@sample etc/mta-sts-daemon.yml.sample` and `rc.d/mta_sts` appear in the generated plist.

LICENSE unchanged — upstream is still MIT.

**Not run:** upstream's pytest suite. The port declares no `TEST_TARGET`, so `bmake test` exits clean without executing it; wiring it up would mean adding pytest/pytest-asyncio/pytest-timeout `TEST_DEPENDS`, which is out of scope for this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the py-postfix-mta-sts-resolver port to version 1.5.1 and modernize its Python build backend.

Enhancements:
- Switch the port from the legacy distutils backend to the pep517 framework while keeping autoplist packaging.
- Add an explicit setuptools build dependency to align with the pep517-based build process.

Build:
- Bump PORTVERSION from 1.4.0 to 1.5.1 and drop the previous PORTREVISION.
- Refresh distinfo for the new upstream release.