### PR TITLE
converters/p5-Unicode-UTF8: new port

### DIFF
--- a/converters/Makefile
+++ b/converters/Makefile
@@ -48,6 +48,7 @@
     SUBDIR += p5-Unicode-MapUTF8
     SUBDIR += p5-Unicode-RecursiveDowngrade
     SUBDIR += p5-Unicode-String
+    SUBDIR += p5-Unicode-UTF8
     SUBDIR += php82-iconv
     SUBDIR += php82-mbstring
     SUBDIR += php83-iconv

--- a/converters/p5-Unicode-UTF8/Makefile
+++ b/converters/p5-Unicode-UTF8/Makefile
@@ -1,0 +1,19 @@
+PORTNAME=	Unicode-UTF8
+PORTVERSION=	0.62
+CATEGORIES=	converters perl5 textproc
+MASTER_SITES=	CPAN
+PKGNAMEPREFIX=	p5-
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Encoding and decoding of UTF-8 encoding form
+WWW=		https://metacpan.org/pod/Unicode::UTF8
+
+LICENSE=	artistic gpl+
+LICENSE_COMB=	dual
+
+TEST_DEPENDS=	p5-Test-Fatal>=0.006:devel/p5-Test-Fatal
+
+USES=		perl5
+USE_PERL5=	configure
+
+.include <bsd.port.mk>

--- a/converters/p5-Unicode-UTF8/distinfo
+++ b/converters/p5-Unicode-UTF8/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1736948730
+SHA256 (Unicode-UTF8-0.62.tar.gz) = fa8722d0b74696e332fddd442994436ea93d3bfc7982d4babdcedfddd657d0f6
+SIZE (Unicode-UTF8-0.62.tar.gz) = 87838

--- a/converters/p5-Unicode-UTF8/pkg-descr
+++ b/converters/p5-Unicode-UTF8/pkg-descr
@@ -1,0 +1,4 @@
+Unicode::UTF8 - Encoding and decoding of UTF-8 encoding form
+
+This module provides functions to encode and decode UTF-8 encoding form as
+specified by Unicode and ISO/IEC 10646:2011.

--- a/converters/p5-Unicode-UTF8/pkg-plist
+++ b/converters/p5-Unicode-UTF8/pkg-plist
@@ -1,0 +1,4 @@
+%%SITE_ARCH%%/Unicode/UTF8.pm
+%%SITE_ARCH%%/Unicode/UTF8.pod
+%%SITE_ARCH%%/auto/Unicode/UTF8/UTF8.so
+%%PERL5_MAN3%%/Unicode::UTF8.3.gz


### PR DESCRIPTION
New port: `converters/p5-Unicode-UTF8` 0.62 — encoding and decoding of the UTF-8 encoding form as specified by Unicode and ISO/IEC 10646:2011.

## Why

`mail/sympa` 6.2.76 adds this as a dependency, and it is not optional. `src/cgi/wwsympa.fcgi.in:1909` calls it unguarded inside the request-parameter loop:

```perl
unless (Encode::is_utf8($v) or Unicode::UTF8::valid_utf8($v)) {
```

Perl short-circuits `or`, so any parameter lacking the UTF-8 flag reaches that call and dies with an undefined-subroutine error. FASTCGI is default-on, so sympa's web UI is affected in the default configuration. (Upstream's `cpanfile` files it under an optional `safe-unicode` feature, but that code path isn't guarded.) The sympa 6.2.76 bump is blocked on this port.

## Import notes

Based on FreeBSD `converters/p5-Unicode-UTF8`, adapted to MidnightBSD conventions:

- `MAINTAINER= ports@MidnightBSD.org`
- `LICENSE= artistic gpl+` with `LICENSE_COMB= dual` — the mports identifiers for FreeBSD's `ART10 GPLv1+`, matching what `converters/p5-Convert-ASN1` already uses for the same dual license.

One deliberate improvement over the FreeBSD port: **`TEST_DEPENDS= p5-Test-Fatal>=0.006:devel/p5-Test-Fatal`**. `Makefile.PL` declares `test_requires 'Test::Fatal' => '0.006'`, and without it 10 of 17 test files abort at `BEGIN` with `Can't locate Test/Fatal.pm`. FreeBSD's port omits it, so `make test` there is effectively broken. `devel/p5-Test-Fatal` already exists in mports.

## Verification

`makesum`, `build`, `test`, `fake`, `package` all succeeded on amd64 with perl 5.40 → `p5-Unicode-UTF8-0.62.mport`.

```
All tests successful.
Files=17, Tests=12031
Result: PASS
```

Three test files skip cleanly on optional modules not installed here (Test::LeakTrace, Taint::Runtime, Test::Pod). distinfo and pkg-plist are byte-identical to FreeBSD's.

Added to `converters/Makefile` `SUBDIR` in sort order after `p5-Unicode-String`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new p5-Unicode-UTF8 port and register it in the converters category to satisfy the Unicode::UTF8 dependency for other ports.

New Features:
- Introduce the converters/p5-Unicode-UTF8 port providing UTF-8 encoding and decoding functionality for Perl.
- Expose the Unicode::UTF8 module via mports for use by dependent software such as mail/sympa.

Enhancements:
- Declare an explicit Test::Fatal test dependency so the port's upstream test suite runs successfully during builds.