### PR TITLE
graphics/drm-fbsd11.2-kmod: mark broken on MidnightBSD 4

### DIFF
--- a/graphics/drm-fbsd11.2-kmod/Makefile
+++ b/graphics/drm-fbsd11.2-kmod/Makefile
@@ -14,7 +14,7 @@ BROKEN_MidnightBSD_1.2=      too old
 BROKEN_MidnightBSD_3.0=      too new
 BROKEN_MidnightBSD_3.1=      too new
 BROKEN_MidnightBSD_3.2=      too new
-BROKEN_MidnightBSD_4.0=      too new
+BROKEN_MidnightBSD_4=        too new
 
 ONLY_FOR_ARCHS=	amd64
 ONLY_FOR_ARCHS_REASON=	the new KMS components are only supported on amd64


### PR DESCRIPTION
## Summary

- replace the ineffective `BROKEN_MidnightBSD_4.0` guard with the framework-supported `BROKEN_MidnightBSD_4` guard
- prevent the obsolete FreeBSD 11.2 LinuxKPI module from compiling against incompatible MidnightBSD 4.x headers
- addresses Magus run 646 port 2242127

## Validation

- `bmake -V IGNORE` reports `is marked as broken on MidnightBSD 4.0: too new`
- `bmake build` stops at the expected guard before compilation
- `portlint -C` reports 0 fatal errors and 6 pre-existing warnings
- `git diff --check`

## Summary by Sourcery

Bug Fixes:
- Ensure drm-fbsd11.2-kmod does not build against incompatible MidnightBSD 4.x headers by correctly marking the port as broken on MidnightBSD 4.