### PR TITLE
graphics/drm-fbsd12.0-kmod: ignore on MidnightBSD 4

### DIFF
--- a/graphics/drm-fbsd12.0-kmod/Makefile
+++ b/graphics/drm-fbsd12.0-kmod/Makefile
@@ -30,7 +30,7 @@ GH_TAGNAME=	drm_v4.16-fbsd12
 IGNORE=		only supported on MidnightBSD 3.x
 .endif
 
-IGNORE_MidnightBSD_4.0=	too new
+IGNORE_MidnightBSD_4=	too new
 
 .if ${ARCH} == "amd64"
 PLIST_SUB+=     AMDGPU=""


### PR DESCRIPTION
## Summary

- replace the ineffective `IGNORE_MidnightBSD_4.0` guard with the framework-supported `IGNORE_MidnightBSD_4` guard
- prevent the obsolete FreeBSD 12.0 LinuxKPI module from compiling against incompatible MidnightBSD 4.x headers
- addresses Magus run 646 port 2242128

## Validation

- `bmake -V IGNORE` reports `too new`
- `bmake build` stops at the expected guard before compilation
- `portlint -C` reports 0 fatal errors and 14 pre-existing warnings
- `git diff --check`

The branch uses an `-m4` suffix because the conventional branch name is occupied by closed PR #659 and cannot be updated safely without rewriting its history.

## Summary by Sourcery

Enhancements:
- Align the MidnightBSD 4 ignore condition in the drm-fbsd12.0-kmod Makefile with the ports framework by switching to the supported IGNORE_MidnightBSD_4 variable.