### PR TITLE
mail/py-email-validator: update to 2.3.0

### DIFF
--- a/mail/py-email-validator/Makefile
+++ b/mail/py-email-validator/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	email-validator
-DISTVERSION=	2.1.0
-PORTREVISION=	1
+DISTVERSION=	2.3.0
 CATEGORIES=	mail python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -10,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Robust email address syntax and deliverability validation library
 WWW=		https://github.com/JoshData/python-email-validator
 
-LICENSE=	CC0-1.0
+LICENSE=	unlicense
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}dnspython>=1.15.0:dns/py-dnspython@${PY_FLAVOR} \

--- a/mail/py-email-validator/distinfo
+++ b/mail/py-email-validator/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1700065811
-SHA256 (email_validator-2.1.0.tar.gz) = 5f511cca8856bb03251d6292ba59e7f98978aae13fa5823ddd8bf885c56a6260
-SIZE (email_validator-2.1.0.tar.gz) = 46254
+TIMESTAMP = 1786245194
+SHA256 (email_validator-2.3.0.tar.gz) = 9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426
+SIZE (email_validator-2.3.0.tar.gz) = 51238


### PR DESCRIPTION
Update `mail/py-email-validator` from 2.1.0 to 2.3.0, and correct the license.

## LICENSE correction — CC0-1.0 → unlicense

The port declared `LICENSE= CC0-1.0`, but 2.3.0's `setup.cfg` says `license = Unlicense`, `PKG-INFO` says `License: Unlicense` / `Classifier: License :: OSI Approved :: The Unlicense`, and the `LICENSE` file is verbatim Unlicense text ("This is free and unencumbered software released into the public domain") — not CC0. mports has a valid `unlicense` identifier (`Mk/components/licenses.db.mk:392`). `bmake check-license` passes.

FreeBSD also carries `CC0-1.0`, which suggests the error is long-standing rather than introduced at 2.3.0 — but that's inference: the 2.1.0 distfile is no longer in `Distfiles/`, so it couldn't be verified against the old metadata.

Because this port uses `autoplist`, the license identifier is part of the packing list (`share/licenses/py312-email-validator-2.3.0/CC0-1.0` → `unlicense`), so this is a real plist change. Verified after a clean rebuild: the staged catalog reads `_LICENSE=unlicense` and the installed license file is named `unlicense`.

## Version bump

**No build-backend change.** 2.3.0 does add a `pyproject.toml`, but it contains only `[tool.mypy]` and `[tool.pytest.ini_options]` — no `[build-system]` — and the real metadata still lives in `setup.cfg` with `setup.py` present. So this remains a setuptools build; `USE_PYTHON= autoplist concurrent distutils` stays and no `${PY_SETUPTOOLS}` is needed. FreeBSD reached the same conclusion at this version.

**Dependencies unchanged.** Both origins exist and `bmake missing` was empty.

**Verification:** makesum/build/fake/package all OK → `py312-email-validator-2.3.0.mport`. distinfo matches FreeBSD byte-for-byte. No `files/` dir. amd64 only; no `TEST_TARGET` defined.

## Noted, not changed

Upstream raised its floor to `dnspython>=2.0.0` while the port (and FreeBSD) still declares `>=1.15.0`. Not a practical hazard — `dns/py-dnspython` is at 2.8.0, so the stale floor is unreachable in this tree. Tightening it would be a correctness improvement but is a separate maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the py-email-validator port to the latest upstream release and correct its recorded license.

Build:
- Bump DISTVERSION from 2.1.0 to 2.3.0 and drop PORTREVISION for the mail/py-email-validator port.

Chores:
- Correct the port's license metadata from CC0-1.0 to unlicense, updating the installed license identifier accordingly.