### PR TITLE
mail/rubygem-gitlab-mail_room: update to 1.1.0

### DIFF
--- a/mail/rubygem-gitlab-mail_room/Makefile
+++ b/mail/rubygem-gitlab-mail_room/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gitlab-mail_room
-PORTVERSION=	1.0.0
+PORTVERSION=	1.1.0
 CATEGORIES=	mail rubygems
 MASTER_SITES=	RG
 
@@ -10,11 +10,11 @@ WWW=		https://gitlab.com/gitlab-org/ruby/gems/gitlab-mail_room
 LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 
-RUN_DEPENDS=	rubygem-jwt>=2.0:www/rubygem-jwt \
-		rubygem-net-imap>=0.2.1:mail/rubygem-net-imap \
-		rubygem-oauth2-gitlab>=1.4.4<3:net/rubygem-oauth2-gitlab \
+RUN_DEPENDS=	rubygem-jwt>=2.0<4:www/rubygem-jwt \
+		rubygem-net-imap>=0.5<0.7:mail/rubygem-net-imap \
+		rubygem-oauth2-gitlab>=2.0.9<3:net/rubygem-oauth2-gitlab \
 		rubygem-redis-gitlab>=5<6:databases/rubygem-redis-gitlab \
-		rubygem-redis-namespace-gitlab>=1.8.2:databases/rubygem-redis-namespace-gitlab
+		rubygem-redis-namespace-gitlab>=1.8.2<2:databases/rubygem-redis-namespace-gitlab
 BUILD_DEPENDS=	${RUN_DEPENDS}
 
 USES=		gem

--- a/mail/rubygem-gitlab-mail_room/distinfo
+++ b/mail/rubygem-gitlab-mail_room/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1773989881
-SHA256 (rubygem/gitlab-mail_room-1.0.0.gem) = 00910bc000ff819f8e2030fd2260f7b40f025c410b11b82de8f67de7922c0159
-SIZE (rubygem/gitlab-mail_room-1.0.0.gem) = 41472
+TIMESTAMP = 1786280123
+SHA256 (rubygem/gitlab-mail_room-1.1.0.gem) = 784847b914a6636b30264fd8a042c15e39f3473f3acd78ebd254ac0a885a5878
+SIZE (rubygem/gitlab-mail_room-1.1.0.gem) = 41984


### PR DESCRIPTION
Update `mail/rubygem-gitlab-mail_room` from 1.0.0 to 1.1.0. `Makefile` (PORTVERSION + tightened `RUN_DEPENDS` bounds) and `distinfo`.

## Gemspec dependency changes — all satisfied by existing mports ports

| gem | old | new | mports port / version |
|---|---|---|---|
| net-imap | >=0.2.1 | >=0.5, <0.7 | mail/rubygem-net-imap 0.5.15 ✓ |
| oauth2 | >=1.4.4,<3 | >=2.0.9,<3 | net/rubygem-oauth2-gitlab 2.0.18 ✓ |
| jwt | >=2.0 | >=2.0,<4 | www/rubygem-jwt 3.1.2 ✓ |
| redis | >=5,<6 | >=5,<6 | databases/rubygem-redis-gitlab 5.4.1 ✓ |
| redis-namespace | >=1.8.2 | >=1.8.2,<2 | databases/rubygem-redis-namespace-gitlab 1.10.0 ✓ |

## No new port needed, unlike FreeBSD

FreeBSD's 1.1.0 depends on `mail/rubygem-net-imap-gitlab`, which **does not exist in mports and is referenced nowhere in the tree** (verified by full-tree grep). That port is just the net-imap gem at 0.6.4.1 with `PKGNAMESUFFIX=-gitlab` — a co-installable slot so GitLab can use 0.6 while the default net-imap stays pinned at 0.5. The gemspec constraint here is `net-imap >= 0.5, < 0.7`, which mports' plain `mail/rubygem-net-imap` at 0.5.15 satisfies outright, so the existing mports delta is kept.

`required_ruby_version` moved `>= 0` → `>= 3.1`, inert here: the only mports slots are ruby32/33/34, all ≥3.1, default 3.3.

**Verification:** makesum/patch/build/fake/package all OK → `rubygem-gitlab-mail_room-1.1.0.mport`. distinfo matches FreeBSD. No `files/` dir. LICENSE unchanged — the gemspec carries no `licenses:` field in either version and `LICENSE.txt` is still MIT. `PLIST_FILES= bin/mail_room` still correct.

## Pre-existing, not caused by this change

`www/gitlab` requires `rubygem-gitlab-mail_room>=0.0.27<0.1.0`, which was already unsatisfiable at 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the gitlab-mail_room Ruby gem port to version 1.1.0 and align its runtime dependencies with the upstream gemspec constraints.

Enhancements:
- Tighten version bounds for jwt, net-imap, oauth2-gitlab, and redis-namespace-gitlab runtime dependencies to match upstream requirements.

Build:
- Regenerate distinfo for gitlab-mail_room 1.1.0.