### PR TITLE
mail/rubygem-mail: update to 2.9.1

### DIFF
--- a/japanese/rubygem-mail-iso-2022-jp/Makefile
+++ b/japanese/rubygem-mail-iso-2022-jp/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	mail-iso-2022-jp
 PORTVERSION=	2.1.0
+PORTREVISION=	1
 CATEGORIES=	japanese mail rubygems
 MASTER_SITES=	RG
 
@@ -10,7 +11,7 @@ WWW=		https://github.com/kuroda/mail-iso-2022-jp
 LICENSE=	mit
 
 BUILD_DEPENDS=	${RUN_DEPENDS}
-RUN_DEPENDS=	rubygem-mail>=2.6.1,2<2.8.1_99,2:mail/rubygem-mail
+RUN_DEPENDS=	rubygem-mail>=2.6.1,2:mail/rubygem-mail
 
 USES=		gem
 

--- a/mail/rubygem-mail/Makefile
+++ b/mail/rubygem-mail/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	mail
-PORTVERSION=	2.8.1
+PORTVERSION=	2.9.1
 PORTEPOCH=	2
 CATEGORIES=	mail rubygems
 MASTER_SITES=	RG
@@ -12,7 +12,8 @@ LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/MIT-LICENSE
 
 BUILD_DEPENDS=	${RUN_DEPENDS}
-RUN_DEPENDS=	rubygem-mini_mime>=0.1.1:mail/rubygem-mini_mime \
+RUN_DEPENDS=	rubygem-logger>=0:devel/rubygem-logger \
+		rubygem-mini_mime>=0.1.1:mail/rubygem-mini_mime \
 		rubygem-net-imap>=0:mail/rubygem-net-imap \
 		rubygem-net-pop>=0:mail/rubygem-net-pop \
 		rubygem-net-smtp>=0:mail/rubygem-net-smtp

--- a/mail/rubygem-mail/distinfo
+++ b/mail/rubygem-mail/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1677771827
-SHA256 (rubygem/mail-2.8.1.gem) = ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
-SIZE (rubygem/mail-2.8.1.gem) = 396800
+TIMESTAMP = 1786280114
+SHA256 (rubygem/mail-2.9.1.gem) = 06574eca475253d6c18145dd70af80d0eb970182d55053497c5f4d797ea160e8
+SIZE (rubygem/mail-2.9.1.gem) = 396288


### PR DESCRIPTION
Update `mail/rubygem-mail` from 2.8.1 to 2.9.1.

## Companion fix included

`japanese/rubygem-mail-iso-2022-jp` pinned `rubygem-mail>=2.6.1,2<2.8.1_99,2`, which 2.9.1,2 exceeds — it would become **uninstallable** the moment this lands. The upper bound is dropped and `PORTREVISION` bumped to 1. FreeBSD already carries the same port at 2.1.0 with the bound removed. This is in the same PR deliberately: shipping the bump without it ships known breakage.

## Dependency change

The 2.9 gemspec adds `logger >= 0`, so `rubygem-logger>=0:devel/rubygem-logger` is added to `RUN_DEPENDS`. That port exists in mports at 1.6.1 and is installed. `mini_mime >= 0.1.1` and `net-smtp`/`net-imap`/`net-pop >= 0` are unchanged. `required_ruby_version >= 2.5` unchanged; mports default is 3.3.

## Other dependents checked — all compatible

`devel/rubygem-validate_email` (>=2.2.5), `mail/rubygem-valid_email` (>=2.6.1), `mail/rubygem-actionmailer-gitlab` and `mail/rubygem-actionmailbox-gitlab` (>=2.8.0,2), `mail/rubygem-actionmailer4` (>=2.5.4,2<3,2), `www/tdiary` (>=2.8.1), `net/rubygem-openid_connect` (>=0), `net/rubygem-aws-ses` (>=2.2.5).

**No PORTREVISION bumps needed** beyond the iso-2022-jp one — these are pure-Ruby `NO_ARCH` gems with no shared libraries, so the `bump_revision.pl` trigger doesn't apply.

## Verification

makesum/patch/build/fake/package all OK → `rubygem-mail-2.9.1,2.mport`. distinfo matches FreeBSD. No `files/` dir. LICENSE unchanged — gemspec still MIT, `MIT-LICENSE` present; mports keeps lowercase `mit`. Plist is autoplist via `USES=gem`.

MidnightBSD delta preserved: `MAINTAINER`, lowercase LICENSE, and `BUILD_DEPENDS=${RUN_DEPENDS}` (FreeBSD dropped it).

amd64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update rubygem-mail to 2.9.1 and adjust a dependent port to remain compatible while adding the new runtime dependency required by the gem.

New Features:
- Track rubygem-mail gem at version 2.9.1 in the mail/rubygem-mail port.

Bug Fixes:
- Relax the rubygem-mail version constraint in japanese/rubygem-mail-iso-2022-jp so it remains installable with the updated mail gem.

Enhancements:
- Add rubygem-logger as a runtime dependency for rubygem-mail to reflect the 2.9 gemspec requirements.