### PR TITLE
mail/libetpan: update to 1.10.1

### DIFF
--- a/mail/claws-mail/Makefile
+++ b/mail/claws-mail/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	claws-mail
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	mail news
 
 COMMENT=	Lightweight and featureful GTK based e-mail and news client

--- a/mail/libetpan/Makefile
+++ b/mail/libetpan/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libetpan
-PORTVERSION=	1.9.4
+PORTVERSION=	1.10.1
 CATEGORIES=	mail
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/mail/libetpan/distinfo
+++ b/mail/libetpan/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1572709692
-SHA256 (dinhviethoa-libetpan-1.9.4_GH0.tar.gz) = 82ec8ea11d239c9967dbd1717cac09c8330a558e025b3e4dc6a7594e80d13bb1
-SIZE (dinhviethoa-libetpan-1.9.4_GH0.tar.gz) = 5000025
+TIMESTAMP = 1786279972
+SHA256 (dinhviethoa-libetpan-1.10.1_GH0.tar.gz) = 87bacdc62661a2a7aa5fe9f1f28d2f7c7a53256633ac5129903916c59f80c4c2
+SIZE (dinhviethoa-libetpan-1.10.1_GH0.tar.gz) = 8878422

--- a/mail/libetpan/pkg-plist
+++ b/mail/libetpan/pkg-plist
@@ -165,6 +165,6 @@ include/libetpan/xgmthrid.h
 include/libetpan/xlist.h
 lib/libetpan.a
 lib/libetpan.so
-lib/libetpan.so.20
-lib/libetpan.so.20.5.0
+lib/libetpan.so.26
+lib/libetpan.so.26.0.0
 libdata/pkgconfig/libetpan.pc


### PR DESCRIPTION
Update `mail/libetpan` from 1.9.4 to 1.10.1, and bump the one dependent.

## Shared library version change

- OLD: `lib/libetpan.so.20` / `libetpan.so.20.5.0`
- NEW: `lib/libetpan.so.26` / `libetpan.so.26.0.0`

Confirmed from the staged tree, not inferred. FreeBSD handled it the same way — commit `a3f7a76fe829` bumped their dependents.

`mail/claws-mail` is the **only** dependent in mports (whole-tree grep including `*.mk`/`*.options`), so its `PORTREVISION` goes 1 → 2 in this PR. FreeBSD also bumped `deskutils/cairo-dock-plugins`, which mports doesn't have.

**API note:** despite the 20 → 26 soname jump, the staged-vs-plist diff shows **zero header changes** — none added, removed, or renamed. That suggests claws-mail needs only a rebuild, not source work. Not verified by building claws-mail.

## Patch set

Unchanged. `files/patch-configure.ac` is the only patch, applies cleanly, and is byte-identical to FreeBSD's (which they still ship at 1.10.1). Verified it still does its job: `-liconv` appears in the link line and `libiconv.so.2` in `ldd` of the built library.

Not adopted: FreeBSD's `files/patch-libetpan.pc.in` (pkgconfig overlinking fix) — out of scope for a version bump.

## Verification

makesum/patch/build/fake/package all OK → `libetpan-1.10.1.mport`. distinfo matches FreeBSD (only TIMESTAMP differs). pkg-plist changed only in the two soname lines, verified against the staged tree rather than copied. LICENSE unchanged — `COPYRIGHT` in 1.10.1 is still 3-clause BSD; `bsd3` vs FreeBSD's `BSD3CLAUSE` is mports naming.

**Packaging gotcha worth knowing:** the first `bmake package` failed with `Could not stat .../libetpan.so.20` because `work/.PLIST.mktmp` had been generated by an earlier `bmake fake`, before pkg-plist was edited. Removing `.PLIST.mktmp` and `.fake_done.*` and re-running `fake` fixed it.

## Not adopted from FreeBSD's Makefile

- `--enable-lmdb` — defaults to `no` (configure.ac:361), so no guard needed. If wanted later, note mports `databases/lmdb` @ 0.9.33 is the ABI match for FreeBSD's `lmdb0`, not their `lmdb` @ 1.0.0.
- `--disable-db` — verified unnecessary: no `-ldb` in the link line, no libdb in `ldd`. **Residual hazard worth flagging:** `enable_db` defaults to `yes` and autodetects, so a build jail with db5/db18 headers in `/usr/local/include` could pick up an undeclared BDB dependency. Pre-existing, not introduced here.
- `--with-poll` — a select→poll behavior change, out of scope.

amd64 only; no test target defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update libetpan to the 1.10.1 release and bump its dependent port to reflect the shared library version change.

New Features:
- Adopt libetpan 1.10.1, updating distinfo and plist to the new shared library soname.

Enhancements:
- Bump mail/claws-mail PORTREVISION to trigger rebuild against the new libetpan shared library.