### PR TITLE
mail/mlmmj: update to 2.1.0

### DIFF
--- a/mail/mlmmj/Makefile
+++ b/mail/mlmmj/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	mlmmj
-PORTVERSION=	1.5.0
+PORTVERSION=	2.1.0
 CATEGORIES=	mail
-MASTER_SITES=	https://codeberg.org/mlmmj/mlmmj/releases/download/RELEASE_${PORTVERSION:S/./_/g}/
+MASTER_SITES=	https://codeberg.org/mlmmj/mlmmj/releases/download/RELEASE_${PORTVERSION:C/\./_/g}/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Simple and slim mailing list manager
@@ -12,9 +12,8 @@ LICENSE_FILE=	${WRKSRC}/LICENSE
 
 USES=		cpe iconv shebangfix tar:xz pkgconfig
 SHEBANG_FILES=	contrib/web/perl-user/mlmmj.cgi
-GNU_CONFIGURE=	yes
-CONFIGURE_ARGS=	--enable-receive-strip
-GNU_CONFIGURE_MANPREFIX=	${PREFIX}/share
+HAS_CONFIGURE=	yes
+CONFIGURE_ARGS=	--enable-receive-strip --mandir=${PREFIX}/share/man
 
 CPPFLAGS+=	-I${ICONV_INCLUDE_PATH}
 LDFLAGS+=	${ICONV_LIB_PATH}

--- a/mail/mlmmj/distinfo
+++ b/mail/mlmmj/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1738143224
-SHA256 (mlmmj-1.5.0.tar.xz) = de0be6c2910ac8bf8291dc86a3819a08b7cdb1019c54ede1791e166967bf1baa
-SIZE (mlmmj-1.5.0.tar.xz) = 278204
+TIMESTAMP = 1786279988
+SHA256 (mlmmj-2.1.0.tar.xz) = 319bf4d4156efa8c938edc5ab15060ff7ad8c7d712e5f70cb5894b4db47f6659
+SIZE (mlmmj-2.1.0.tar.xz) = 211928

--- a/mail/mlmmj/files/patch-mk_common.mk
+++ b/mail/mlmmj/files/patch-mk_common.mk
@@ -1,0 +1,25 @@
+Put the in-tree include directories (LOCAL_CFLAGS) ahead of CFLAGS/CPPFLAGS.
+
+On MidnightBSD iconv comes from converters/libiconv, so the port adds
+-I${LOCALBASE}/include via CPPFLAGS.  With the original ordering that
+directory is searched before ${WRKSRC}/include, so mlmmj's own archive.h
+and unistr.h are shadowed by libarchive's and libunistring's installed
+headers, and the build fails with -Werror=implicit-function-declaration
+on archive_open() and unistr_utf8_to_header().
+
+--- mk/common.mk.orig
++++ mk/common.mk
+@@ -18,10 +18,10 @@
+ .SUFFIXES: .pico
+ 
+ .c.o:
+-	$(CC) -Wall -Wextra -std=gnu17 -D_GNU_SOURCE=1 -MT $@ -MD -MP -MF $*.Tpo -o $@ -c $(CFLAGS) $(LOCAL_CFLAGS) $<
++	$(CC) -Wall -Wextra -std=gnu17 -D_GNU_SOURCE=1 -MT $@ -MD -MP -MF $*.Tpo -o $@ -c $(LOCAL_CFLAGS) $(CFLAGS) $<
+ 	mv $*.Tpo $*.Po
+ 
+ .c.pico:
+-	$(CC) -Wall -Wextra -std=gnu17 -D_GNU_SOURCE=1 -MT $@ -MD -MP -MF $*.Tpico -o $@ -c $(CFLAGS) $(LOCAL_CFLAGS) $(SHOBJ_CFLAGS) $<
++	$(CC) -Wall -Wextra -std=gnu17 -D_GNU_SOURCE=1 -MT $@ -MD -MP -MF $*.Tpico -o $@ -c $(LOCAL_CFLAGS) $(CFLAGS) $(SHOBJ_CFLAGS) $<
+ 	mv $*.Tpico $*.Ppico
+ 
+ clean: clean-files

--- a/mail/mlmmj/pkg-plist
+++ b/mail/mlmmj/pkg-plist
@@ -252,8 +252,10 @@ share/man/man1/mlmmj-unsub.1.gz
 %%PHP%%%%WWWDIR%%/php-admin/htdocs/dot.htaccess
 %%PHP%%%%WWWDIR%%/php-admin/htdocs/edit.php
 %%PHP%%%%WWWDIR%%/php-admin/htdocs/index.php
+%%PHP%%%%WWWDIR%%/php-admin/htdocs/logs.php
 %%PHP%%%%WWWDIR%%/php-admin/htdocs/save.php
 %%PHP%%%%WWWDIR%%/php-admin/htdocs/subscribers.php
+%%PHP%%%%WWWDIR%%/php-admin/htdocs/texts.php
 %%PHP%%%%WWWDIR%%/php-admin/templates/edit.html
 %%PHP%%%%WWWDIR%%/php-admin/templates/edit_boolean.html
 %%PHP%%%%WWWDIR%%/php-admin/templates/edit_list.html


### PR DESCRIPTION
Update `mail/mlmmj` from 1.5.0 to 2.1.0.

## New MidnightBSD-specific patch required

`files/patch-mk_common.mk` reorders the compile rules from `$(CFLAGS) $(LOCAL_CFLAGS)` to `$(LOCAL_CFLAGS) $(CFLAGS)`.

MidnightBSD gets iconv from `converters/libiconv`, so `USES=iconv` puts `-I/usr/local/include` into CPPFLAGS **ahead** of `-I${WRKSRC}/include`. mlmmj 2.x's new `include/archive.h` and `include/unistr.h` were then shadowed by libarchive's `/usr/local/include/archive.h` and libunistring's `/usr/local/include/unistr.h`:

```
listcontrol.c:631:12: error: call to undeclared function 'archive_open'; ISO C99 and later
do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
prepstdreply.c:1704:11: error: call to undeclared function 'unistr_utf8_to_header'; ...
```

FreeBSD 14+ has iconv in base, so no `-I/usr/local/include` is added there and they never hit this. No `files/` directory existed in this port before.

## Build system change

2.x replaced autotools with the hand-rolled "bbuild" system, so `GNU_CONFIGURE`+`GNU_CONFIGURE_MANPREFIX` becomes `HAS_CONFIGURE` plus an explicit `--mandir=${PREFIX}/share/man` — autoconf-only args must not be injected. `MASTER_SITES` modifier `:S/./_/g` → `:C/\./_/g`, matching FreeBSD.

## pkg-plist

Adds two new PHP-option files, `%%PHP%%%%WWWDIR%%/php-admin/htdocs/logs.php` and `.../texts.php`. Verified empirically — `bmake fake && bmake makeplist`, then set-compared `gen-plist` against `pkg-plist`. FreeBSD's 2.1.0 plist is *also* missing these; their PHP option is off by default so it went unnoticed. All 273 `text.skel`/man/bin/docs entries carried over unchanged.

## Verification

makesum/patch/build/fake/package all OK → `mlmmj-2.1.0.mport`. **distinfo SHA256 matches FreeBSD's exactly.** LICENSE unchanged — upstream `LICENSE` reads "The MIT License"; mports `mit` is correct. Dependencies unchanged; the MidnightBSD-only `kyua` `TEST_DEPENDS` is preserved.

`bmake test` not run — `WITH_TESTING` is undefined so `--disable-tests` is passed. amd64 only.

## Adjacent, not fixed

`makeplist` emits `@dir %%DOCSDIR%%`, `@dir %%DATADIR%%`, `@dir %%DATADIR%%/text.skel` and 11 per-language `@dir` lines that `pkg-plist` lacks. Pre-existing (1.5.0 had none) and `bmake package` succeeds without them, so left alone under minimal-change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the mlmmj port to version 2.1.0 and adapt the build and packaging to the new upstream build system and headers.

Enhancements:
- Adjust MASTER_SITES substitution to match upstream release naming for mlmmj 2.1.0.
- Switch from GNU_CONFIGURE to HAS_CONFIGURE and pass an explicit mandir to accommodate the new bbuild-based configure script.

Build:
- Add a MidnightBSD-specific patch to reorder LOCAL_CFLAGS ahead of CFLAGS so in-tree headers are preferred over system includes during compilation.
- Refresh distinfo and pkg-plist for the 2.1.0 release, including new PHP-related installed files.