### PR TITLE
mail/mlmmj-archiver: update to 0.7.1

### DIFF
--- a/mail/mlmmj-archiver/Makefile
+++ b/mail/mlmmj-archiver/Makefile
@@ -1,22 +1,26 @@
 PORTNAME=	mlmmj-archiver
-DISTVERSION=	0.4
+DISTVERSION=	0.7.1
 CATEGORIES=	mail www
-MASTER_SITES=	https://fossil.nours.eu/${PORTNAME}/tarball/?r=${DISTVERSION}&name=./
+MASTER_SITES=	https://codeberg.org/bapt/${PORTNAME}/archive/${DISTVERSIONFULL}${EXTRACT_SUFX}?dummy=/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Simple mailing archiver designed for mlmmj
-WWW=		https://fossil.nours.eu/mlmmj-archiver
+WWW=		https://codeberg.org/bapt/mlmmj-archiver
 
-LICENSE=	bsd2
-BUILD_DEPENDS=	${LOCALBASE}/lib/libneo_cs.a:www/clearsilver
+LICENSE=	mit
 
-USES=		sqlite:3 uidfix pkgconfig
+LIB_DEPENDS=	libucl.so:textproc/libucl
 
-MAKE_ARGS=	MAN= LOCALBASE=${LOCALBASE}
+USES=		sqlite:3 uidfix pkgconfig iconv
 
-PLIST_FILES=	bin/${PORTNAME}
+WRKSRC=		${WRKDIR}/${PORTNAME}
 
-do-install:
-	${INSTALL_PROGRAM}  ${WRKSRC}/${PORTNAME} ${PREFIX}/bin
+HAS_CONFIGURE=	yes
+CONFIGURE_ARGS=	--mandir=${PREFIX}/share/man
+
+PLIST_FILES=	bin/cs2tpl \
+		bin/${PORTNAME} \
+		share/man/man1/cs2tpl.1.gz \
+		share/man/man1/${PORTNAME}.1.gz
 
 .include <bsd.port.mk>

--- a/mail/mlmmj-archiver/distinfo
+++ b/mail/mlmmj-archiver/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1675345313
-SHA256 (mlmmj-archiver-0.4.tar.gz) = 489598e41421ade0830a15d126bfa7a2fe19bf6d2a0132139089676c634d5216
-SIZE (mlmmj-archiver-0.4.tar.gz) = 13897
+TIMESTAMP = 1786280202
+SHA256 (mlmmj-archiver-0.7.1.tar.gz) = b5eaa40bd212271b5923b09013ffdc153fbe3458378f1884c907c44dda318ffb
+SIZE (mlmmj-archiver-0.7.1.tar.gz) = 43519

--- a/mail/mlmmj-archiver/pkg-descr
+++ b/mail/mlmmj-archiver/pkg-descr
@@ -1,4 +1,9 @@
-mlmmj-archiver is a program which will generates HTML archives out of mlmmj archives
-mlmmj-archiver uses the clearsilver templating system in order to allow maximum configurability
-mlmmj-archiver uses SQLite for its database cache
-mlmmj-archiver runs in a capsicum sandbox
+mlmmj-archiver generates HTML archives from mlmmj mailing list archives
+
+Features:
+-  Generates per-mail HTML pages with threading (references/replies)
+-  Monthly indexes by date, author, and threaded subject
+-  Mbox export support
+-  Mustache-style templates (ucltpl) for full layout customization
+-  SQLite database cache for incremental archive updates
+-  Capsicum sandboxing on FreeBSD


### PR DESCRIPTION
Update `mail/mlmmj-archiver` from 0.4 to 0.7.1.

## LICENSE corrected: bsd2 → mit

This is a **genuine relicense**, not an mports-vs-FreeBSD naming difference. Every `.c` in the 0.7.1 tarball carries the MIT permission text under "Copyright (C) 2022 Baptiste Daroussin", and FreeBSD's port says `MIT`. The tarball ships no `LICENSE`/`COPYING` file, so `LICENSE_FILE` can't be set either way.

## Upstream moved and re-architected

fossil.nours.eu → codeberg.org/bapt; clearsilver replaced by libucl templates. The Makefile is rewritten to the 0.7.1 shape: `HAS_CONFIGURE` replaces the raw bmake `MAKE_ARGS`/`do-install`, `WRKSRC=${WRKDIR}/${PORTNAME}`, `USES` gains `iconv`. `pkg-descr` synced — the old text described clearsilver, which is gone.

**Dependency changes:** `-BUILD_DEPENDS www/clearsilver`, `+LIB_DEPENDS libucl.so:textproc/libucl`, `+USES iconv`. `textproc/libucl` exists in mports and is installed (libucl.so.7.2.0).

## PLIST_FILES added — FreeBSD's port has none

FreeBSD's 0.7.1 port has **no `pkg-plist` and no `PLIST_FILES`**, so their package installs untracked files. That looks like an upstream FreeBSD bug. Ours gets a proper 4-entry `PLIST_FILES` derived from the staged tree: `bin/cs2tpl`, `bin/mlmmj-archiver`, and both man pages. **0.7.1 ships a new second binary, `cs2tpl`** (clearsilver→ucltpl template converter).

## Verification

makesum/patch/build/fake/package all OK → `mlmmj-archiver-0.7.1.mport`, rebuilt clean after the license change. MidnightBSD `MAINTAINER` preserved. amd64 only.

## ⚠ Fetch fragility worth knowing

Codeberg's on-demand archive tarballs are **no longer byte-identical to FreeBSD's cached copies** (different gzip container; 43519 vs 43576 bytes). Verified benign: fetching FreeBSD's copy from `distcache.freebsd.org` and running `diff -r` on the extracted trees is identical, and re-fetching from codeberg reproduces our hash exactly.

**Operational consequence:** because our SHA256 differs from FreeBSD's published hash, this port can never fall back to `distcache.freebsd.org`/`MASTER_SITE_BACKUP` — a fetch from there will fail checksum. If codeberg re-gzips, it breaks with no fallback. The same applies to `mail/mlmmj-webview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update mlmmj-archiver port to the 0.7.1 release with new upstream location, licensing, and packaging layout.

New Features:
- Package the new cs2tpl helper binary and its manpage alongside mlmmj-archiver.

Bug Fixes:
- Correct the port license to MIT to match the upstream 0.7.1 relicensing.
- Add an explicit packing list so all installed binaries and manpages are tracked.

Enhancements:
- Switch the port to the new Codeberg-hosted upstream tarball and project URL.
- Adopt the 0.7.1 build system by enabling configure, adjusting WRKSRC, and simplifying installation via HAS_CONFIGURE.
- Replace the clearsilver build dependency with libucl and update uses to include iconv.