### PR TITLE
mail/mlmmj-webview: update to 0.1.0

### DIFF
--- a/mail/mlmmj-webview/Makefile
+++ b/mail/mlmmj-webview/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	mlmmj-webview
-PORTVERSION=	0.0.6
+PORTVERSION=	0.1.0
 CATEGORIES=	mail www
 MASTER_SITES=	https://codeberg.org/bapt/${PORTNAME}/archive/${DISTVERSIONFULL}${EXTRACT_SUFX}?dummy=/
 
@@ -9,13 +9,12 @@ WWW=		https://codeberg.org/bapt/mlmmj-webview
 
 LICENSE=	bsd2
 
-LIB_DEPENDS=	libkcgi.so:www/kcgi
+LIB_DEPENDS=	libkcgi.so:www/kcgi \
+		libucl.so:textproc/libucl
 
 USES=		pkgconfig
 WRKSRC=		${WRKDIR}/${PORTNAME}
 
 HAS_CONFIGURE=	yes
-
-PLIST_FILES=	bin/${PORTNAME}
 
 .include <bsd.port.mk>

--- a/mail/mlmmj-webview/distinfo
+++ b/mail/mlmmj-webview/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1701681410
-SHA256 (mlmmj-webview-0.0.6.tar.gz) = 7dfde1993e0717596909c48e7acd848902c8b94ebb3ae6f5cb009d80abafae42
-SIZE (mlmmj-webview-0.0.6.tar.gz) = 190156
+TIMESTAMP = 1786280358
+SHA256 (mlmmj-webview-0.1.0.tar.gz) = bcd098172b98768c924579e49ff5beb1b7c852ff364bae8e85e26b41de2d8995
+SIZE (mlmmj-webview-0.1.0.tar.gz) = 195816

--- a/mail/mlmmj-webview/pkg-plist
+++ b/mail/mlmmj-webview/pkg-plist
@@ -1,0 +1,4 @@
+bin/mlmmj-genindex
+bin/mlmmj-webview
+share/man/man1/mlmmj-genindex.1.gz
+share/man/man1/mlmmj-webview.1.gz


### PR DESCRIPTION
Update `mail/mlmmj-webview` from 0.0.6 to 0.1.0.

**New binary.** 0.1.0 ships `mlmmj-genindex` alongside `mlmmj-webview`, plus man pages for both — hence the switch from a single-entry `PLIST_FILES` to a 4-line `pkg-plist` (copied from FreeBSD, and consistent with the `install:` targets in `webview/Makefile.in` and `genindex/Makefile.in`, which install exactly one binary plus one man page each and no `.pc` files).

**Dependency added:** `libucl.so:textproc/libucl`. Confirmed required by reading `auto.def`, which hard-requires `kcgi`, `kcgi-html` and `libucl` via pkg-config. Both dep ports exist in mports.

**Verification:** makesum/patch/build/fake/package all OK → `mlmmj-webview-0.1.0.mport`.

This port initially couldn't be built because `www/kcgi` was not installed on this host (the port exists in mports; it just wasn't present). kcgi 1.0.1 was built and installed, after which webview builds and packages cleanly.

LICENSE unchanged — source headers are BSD-2-Clause, `bsd2` correct. amd64 only.

**⚠ Fetch fragility:** as with `mail/mlmmj-archiver`, codeberg's on-demand tarball is no longer byte-identical to FreeBSD's cached copy (195816 vs 194975 bytes; extracted trees `diff -r` clean). Our SHA256 therefore differs from FreeBSD's published hash, so this port can never fall back to `distcache.freebsd.org`. If codeberg re-gzips, it breaks with no fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the mlmmj-webview port to version 0.1.0 and align its packaging and dependencies with the new upstream release.

Build:
- Refresh distinfo for the 0.1.0 distfile and switch from inline PLIST_FILES to a pkg-plist matching the new installed files.

Chores:
- Add a libucl runtime dependency required by the new upstream release.