### PR TITLE
mail/mlmmj-archive-mid: update to 0.3

### DIFF
--- a/mail/mlmmj-archive-mid/Makefile
+++ b/mail/mlmmj-archive-mid/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	mlmmj-archive-mid
-DISTVERSION=	0.2
+DISTVERSION=	0.3
 CATEGORIES=	mail www
 MASTER_SITES=	https://fossil.nours.eu/${PORTNAME}/tarball/?r=${DISTVERSION}&name=./
 
@@ -15,9 +15,12 @@ USES=		sqlite:3 uidfix pkgconfig
 
 MAKE_ARGS=	MAN= LOCALBASE=${LOCALBASE}
 
-PLIST_FILES=	bin/${PORTNAME}
+PLIST_FILES=	bin/${PORTNAME} \
+		share/man/man1/${PORTNAME}.1.gz
 
 do-install:
 	${INSTALL_PROGRAM}  ${WRKSRC}/${PORTNAME} ${PREFIX}/bin
+	@${MKDIR} ${PREFIX}/share/man/man1
+	${INSTALL_DATA} ${WRKSRC}/${PORTNAME}.1 ${PREFIX}/share/man/man1
 
 .include <bsd.port.mk>

--- a/mail/mlmmj-archive-mid/distinfo
+++ b/mail/mlmmj-archive-mid/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1675411338
-SHA256 (mlmmj-archive-mid-0.2.tar.gz) = d14f6bdc3934c6f7221a0cd81af2ba0086075b4944605c0159bcb368d60fe760
-SIZE (mlmmj-archive-mid-0.2.tar.gz) = 2863
+TIMESTAMP = 1786280385
+SHA256 (mlmmj-archive-mid-0.3.tar.gz) = a38d3a35ddfc072feb51072d051d6f87890847554d912ab8e66a6fb7abba7292
+SIZE (mlmmj-archive-mid-0.3.tar.gz) = 4072


### PR DESCRIPTION
Update `mail/mlmmj-archive-mid` from 0.2 to 0.3.

**New man page.** 0.3 ships `mlmmj-archive-mid.1`, so `do-install` gains a man-page install and `PLIST_FILES` gains `share/man/man1/mlmmj-archive-mid.1.gz`. An `@${MKDIR} ${PREFIX}/share/man/man1` was added since the staging directory won't pre-exist.

Kept the mports `${PREFIX}` form rather than FreeBSD's `${STAGEDIR}${PREFIX}` — `do-install` gets `FAKE_DESTDIR` prepended automatically in mports, so the FreeBSD form would double-prefix and break `bmake fake`. Upstream's `Makefile` still sets `MAN=` (suppressed by our `MAKE_ARGS`), so the manual install is the right approach.

**Dependencies unchanged** (`www/kcgi`, `sqlite:3`); both exist in mports.

**Verification:** makesum/patch/build/fake/package all OK → `mlmmj-archive-mid-0.3.mport`. **distinfo SHA256 matches FreeBSD's exactly.**

This port initially couldn't be built because `www/kcgi` was not installed on this host; kcgi 1.0.1 was built and installed, after which it builds and packages cleanly.

LICENSE unchanged — source header is BSD-2-Clause, `bsd2` correct. amd64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the mlmmj-archive-mid port to version 0.3 and account for its new installed files.

New Features:
- Install the mlmmj-archive-mid 1-manpage provided by upstream as part of the port.

Enhancements:
- Adjust packing list and install target to include the new manpage directory and file.