### PR TITLE
mail/courier-imap: update to 6.0.4

### DIFF
--- a/mail/courier-imap/Makefile
+++ b/mail/courier-imap/Makefile
@@ -87,7 +87,7 @@ EXTRA_DOCS=	AUTHORS INSTALL NEWS \
 .endif
 
 #
-# Variable avilable for further customization:
+# Variables available for further customization:
 #
 # WITH_SYSLOG_FACILITY:         The syslogfacility to use
 #

--- a/mail/courier-imap/Makefile
+++ b/mail/courier-imap/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	courier-imap
-PORTVERSION=	5.3.2
-PORTREVISION=	2
+PORTVERSION=	6.0.4
 PORTEPOCH=	2
 CATEGORIES=	mail
 MASTER_SITES=	SF/courier/imap/${PORTVERSION}
@@ -12,40 +11,46 @@ WWW=		https://www.courier-mta.org/imap/
 LICENSE=	gpl3
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-RUN_DEPENDS=	${LOCALBASE}/share/sysconftool/sysconftool:devel/sysconftool
 LIB_DEPENDS=	libcourier-unicode.so:devel/courier-unicode \
 		libcourierauth.so:security/courier-authlib-base \
-		libgdbm.so:databases/gdbm \
 		libidn2.so:dns/libidn2 \
 		libpcre2-8.so:devel/pcre2
+RUN_DEPENDS=	${LOCALBASE}/share/sysconftool/sysconftool:devel/sysconftool
 
 USES=		compiler:c++11-lang gmake localbase:ldflags perl5 pkgconfig ssl \
 		tar:bzip2
 USE_RC_SUBR=	courier-imap-imapd courier-imap-imapd-ssl \
 		courier-imap-pop3d courier-imap-pop3d-ssl
 
-CONFLICTS=	courier imap-uw panda-imap
-
 GNU_CONFIGURE=	yes
+GNU_CONFIGURE_MANPREFIX=	${PREFIX}/share
+CONFIGURE_ARGS=	--datadir=${DATADIR} \
+		--disable-root-check \
+		--enable-unicode \
+		--enable-workarounds-for-imap-client-bugs \
+		--libexecdir=${LIBEXECDIR} \
+		--localstatedir="${PREFIX}/var" \
+		--sysconfdir=${CONFDIR} \
+		--with-locking-method=fcntl \
+		--with-notice=unicode
 CONFIGURE_ENV=	REHASH=${SCRIPTDIR}/c_rehash
 CONFIGURE_TARGET=	${ARCH}-portbld-freebsd12.4
 
 MAKE_ENV:=	${CONFIGURE_ENV}
 ALL_TARGET=	all makeimapaccess makedat
 
+CONFLICTS=	courier imap-uw panda-imap
+
 SUB_FILES=	pkg-message
 SUB_LIST=	CONFDIR=${CONFDIR}
 
-#
-# options available:
-#
-# WITH_SYSLOG_FACILITY:         The syslogfacility to use
-#
+PLIST_SUB=	CONFDIR=${CONFDIR:S,^${PREFIX}/,,} \
+		LIBEXECDIR=${LIBEXECDIR:S,^${PREFIX}/,,}
 
 OPTIONS_DEFINE=	GDBM GNUTLS INOTIFY IPV6 TRASHQUOTA
 
-GNUTLS_DESC=	Use GnuTLS instead of OpenSSL (Enables SNI)
-INOTIFY_DESC=	Inotify support for IDLE command
+GNUTLS_DESC=		Use GnuTLS instead of OpenSSL (Enables SNI)
+INOTIFY_DESC=		Inotify support for IDLE command
 TRASHQUOTA_DESC=	Include deleted mails in the quota
 
 .if exists(${.CURDIR}/../../security/courier-authlib/Makefile.opt)
@@ -55,48 +60,16 @@ TRASHQUOTA_DESC=	Include deleted mails in the quota
 CONFDIR?=	${PREFIX}/etc/${PORTNAME}
 USERDB?=	${PREFIX}/etc/userdb
 LIBEXECDIR?=	${PREFIX}/libexec/${PORTNAME}
-PLIST_SUB=	CONFDIR=${CONFDIR:S,^${PREFIX}/,,} \
-		LIBEXECDIR=${LIBEXECDIR:S,^${PREFIX}/,,}
 
-CONFIGURE_ARGS=	--sysconfdir=${CONFDIR} \
-		--localstatedir="${PREFIX}/var" \
-		--datadir=${DATADIR} \
-		--libexecdir=${LIBEXECDIR} \
-		--enable-workarounds-for-imap-client-bugs \
-		--enable-unicode \
-		--disable-root-check \
-		--with-locking-method=fcntl \
-		--with-notice=unicode
-
-GNUTLS_LIB_DEPENDS=	libgnutls.so:security/gnutls \
-			libgcrypt.so:security/libgcrypt
+GNUTLS_LIB_DEPENDS=	libgcrypt.so:security/libgcrypt \
+			libgnutls.so:security/gnutls
 GNUTLS_CONFIGURE_WITH=	gnutls
-GNUTLS_USES=		pkgconfig
 
 INOTIFY_LIB_DEPENDS=	libinotify.so:devel/libinotify
 
 IPV6_CONFIGURE_OFF=	--without-ipv6
 
-TRASHQUOTA_CONFIGURE_ON=--with-trashquota
-
-.include <bsd.port.pre.mk>
-
-.if exists(${.CURDIR}/../../security/courier-authlib/Makefile.dep)
-.include "${.CURDIR}/../../security/courier-authlib/Makefile.dep"
-.endif
-
-.if ${PORT_OPTIONS:MSYSLOG_FACILITY}
-CONFIGURE_ARGS+=--with-syslog=${WITH_SYSLOG_FACILITY}
-.endif
-
-.if ${PORT_OPTIONS:MAUTH_USERDB}
-.if ${PORT_OPTIONS:MGDBM}
-CONFIGURE_ARGS+=--with-db=gdbm --with-userdb=${USERDB}
-LIB_DEPENDS+=	libgdbm.so:databases/gdbm
-.else
-CONFIGURE_ARGS+=--with-db=db  --with-userdb=${USERDB}
-.endif
-.endif
+TRASHQUOTA_CONFIGURE_ON=	--with-trashquota
 
 EXTRA_DOCS=	AUTHORS INSTALL NEWS \
 		libs/imap/ChangeLog \
@@ -105,7 +78,33 @@ EXTRA_DOCS=	AUTHORS INSTALL NEWS \
 		libs/maildir/README.maildirfilter.html \
 		libs/maildir/README.maildirquota.txt \
 		libs/maildir/README.sharedfolders.txt \
-		libs/tcpd/README.couriertls \
+		libs/tcpd/README.couriertls
+
+.include <bsd.mport.options.mk>
+
+.if exists(${.CURDIR}/../../security/courier-authlib/Makefile.dep)
+.include "${.CURDIR}/../../security/courier-authlib/Makefile.dep"
+.endif
+
+#
+# Variable avilable for further customization:
+#
+# WITH_SYSLOG_FACILITY:         The syslogfacility to use
+#
+.ifdef WITH_SYSLOG_FACILITY
+CONFIGURE_ARGS+=	--with-syslog=${WITH_SYSLOG_FACILITY}
+.endif
+
+.if ${PORT_OPTIONS:MAUTH_USERDB}
+.if ${PORT_OPTIONS:MGDBM}
+CONFIGURE_ARGS+=	--with-db=gdbm \
+			--with-userdb=${USERDB}
+LIB_DEPENDS+=		libgdbm.so:databases/gdbm
+.else
+CONFIGURE_ARGS+=	--with-db=db \
+			--with-userdb=${USERDB}
+.endif
+.endif
 
 post-patch:
 	@${REINPLACE_CMD} -e 's|^case x$$lockmethod in|${TEST} \&\& &|g' \
@@ -114,8 +113,9 @@ post-patch:
 		-e 's|@LN_S@|${RLN}|' \
 		${WRKSRC}/Makefile.in
 
+# MidnightBSD has no native inotify; always link against devel/libinotify.
 post-patch-INOTIFY-on:
-	@${REINPLACE_CMD} -e 's|LIBS = @LIBS@|& ${LOCALBASE}/lib/libinotify.a /usr/lib/libpthread.a|' \
+	@${REINPLACE_CMD} -e 's|LIBS = @LIBS@|& -L${LOCALBASE}/lib -linotify -lpthread|' \
 		${WRKSRC}/libs/maildir/Makefile.in \
 		${WRKSRC}/libs/imap/Makefile.in
 
@@ -123,6 +123,8 @@ post-configure-INOTIFY-on:
 	@${ECHO_CMD} '#define HAVE_INOTIFY_INIT 1' >>${WRKSRC}/libs/maildir/config.h
 	@${ECHO_CMD} '#define HAVE_INOTIFY_INIT1 1' >>${WRKSRC}/libs/maildir/config.h
 
+# NB: mports prepends FAKE_DESTDIR to PREFIX during install, so ${STAGEDIR}
+# must not be used here (it would double the staging prefix).
 post-install:
 	${INSTALL_SCRIPT} ${WRKSRC}/makeimapaccess ${PREFIX}/bin/
 	${INSTALL_SCRIPT} ${WRKSRC}/makedat ${PREFIX}/bin/
@@ -134,4 +136,4 @@ post-install:
 	${INSTALL_DATA} ${WRKSRC}/${a} ${DOCSDIR}
 .endfor
 
-.include <bsd.port.post.mk>
+.include <bsd.port.mk>

--- a/mail/courier-imap/distinfo
+++ b/mail/courier-imap/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779061610
-SHA256 (courier-imap-5.3.2.tar.bz2) = 64451cb30705754a0cab3a3f72558154c82dad4ff25c432f2e0f46b03430f68a
-SIZE (courier-imap-5.3.2.tar.bz2) = 3741883
+TIMESTAMP = 1786280308
+SHA256 (courier-imap-6.0.4.tar.bz2) = 0d69342c6c1b4100f51f41cf347b85547e2d59569b8bf901a3a58570da19074d
+SIZE (courier-imap-6.0.4.tar.bz2) = 3494787

--- a/mail/courier-imap/files/pkg-message.in
+++ b/mail/courier-imap/files/pkg-message.in
@@ -12,6 +12,12 @@ You will have to run %%DATADIR%%/mkimapdcert to create
 a self-signed certificate if you want to use imapd-ssl.
 And you will have to copy and edit the *.dist files to *
 in %%CONFDIR%%.
+
+If you have maildirs with a lot of messages
+(indicatively > 120000), imapd could exhaust memory while
+scanning them.
+If you see the imapd process crash with SIGABRT try
+incrasing the ULIMIT setting in imapd configuration file.
 EOM
 }
 ]

--- a/mail/courier-imap/files/pkg-message.in
+++ b/mail/courier-imap/files/pkg-message.in
@@ -17,7 +17,7 @@ If you have maildirs with a lot of messages
 (indicatively > 120000), imapd could exhaust memory while
 scanning them.
 If you see the imapd process crash with SIGABRT try
-incrasing the ULIMIT setting in imapd configuration file.
+increasing the ULIMIT setting in the imapd configuration file.
 EOM
 }
 ]


### PR DESCRIPTION
Update `mail/courier-imap` from 5.3.2_2 to 6.0.4. `PORTEPOCH=2` kept.

## Ordering note

**No dependency on `mail/courier`** — the two `CONFLICTS` each other, so there's no ordering constraint between that PR and this one. Shared deps are `devel/courier-unicode` (2.6.0, already aligned with FreeBSD) and `security/courier-authlib-base`. mports `security/courier-authlib` is **0.72.1** vs FreeBSD's 0.73.1, but 6.0.4's `LIB_DEPENDS` on `libcourierauth.so` is unversioned; 0.72.1 satisfies it and the port compiles and links against it cleanly, so no authlib update was needed.

## Deliberate divergences from FreeBSD

- **INOTIFY stays unconditional.** FreeBSD gates `libinotify` behind `${OSVERSION} < 1500500` — a FreeBSD-15 number that is meaningless on MidnightBSD. Converted to a plain `INOTIFY_LIB_DEPENDS` plus an ungated `post-patch-INOTIFY-on`.
- **Dynamic inotify linking.** mports linked `${LOCALBASE}/lib/libinotify.a` and `/usr/lib/libpthread.a` statically; switched to FreeBSD's `-L${LOCALBASE}/lib -linotify -lpthread`, since `/usr/lib/libpthread.a` is not guaranteed present.
- **Dropped dead code:** `.if ${PORT_OPTIONS:MSYSLOG_FACILITY}` — `SYSLOG_FACILITY` was never a defined option, so the block never fired. Replaced with FreeBSD's correct `.ifdef WITH_SYSLOG_FACILITY`. Also dropped a redundant `GNUTLS_USES=pkgconfig` (already in the global `USES`).

## Patch set — no changes

All of `files/` (`patch-Makefile.in`, `patch-libs_maildir_configure`, the four rc scripts) was already byte-identical to FreeBSD's and applies cleanly to 6.0.4. `files/pkg-message.in` gains back the ULIMIT/SIGABRT paragraph — a FreeBSD addition mports had simply not picked up, not a MidnightBSD removal.

## MidnightBSD delta preserved

`MAINTAINER`, `LICENSE= gpl3`, `CONFIGURE_TARGET=${ARCH}-portbld-freebsd12.4` (accepted by 6.0.4's config.sub — verified in the configure log), `.include <bsd.mport.options.mk>` replacing `bsd.port.pre.mk`/`post.mk`, and `${STAGEDIR}` stripped from `post-install`.

**On that last point** — `Mk/components/fake/vars.mk` sets `FAKE_SETUP` to both `PREFIX=${FAKE_DESTDIR}${TRUE_PREFIX}` and `STAGEDIR=${FAKE_DESTDIR}`, so carrying FreeBSD's `${STAGEDIR}${PREFIX}` double-prefixes and kills `fake`:

```
install: work/fake-inst-amd64/usr/mports/mail/courier-imap/work/fake-inst-amd64/usr/local/bin/...
*** Error code 71
```

`bmake -V STAGEDIR` at top level returns empty, which makes this look safe. An explanatory comment now sits above `post-install`.

## Dependencies

`databases/gdbm` moved out of the unconditional `LIB_DEPENDS` into the `AUTH_USERDB`+`GDBM` branch only. No new deps; all exist in mports.

## Verification

makesum/patch/build/fake/package all OK → `courier-imap-6.0.4,2.mport`. distinfo matches FreeBSD exactly. portlint: 0 fatal, 5 warnings (pre-existing `AUTH_*` options inherited from `courier-authlib/Makefile.opt`). Staged tree and plist match with **zero discrepancies in either direction**.

**No shared libraries** — `find` over the staged tree returns zero `*.so*` files; this port installs only executables, rc scripts and `libexec/` content. No dependent `PORTREVISION` bumps needed.

LICENSE unchanged — `COPYING` still GPL v3 with the OpenSSL linking exception.

Default option set, amd64 only. No test target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update courier-imap port to 6.0.4 while aligning with FreeBSD packaging and preserving MidnightBSD-specific behavior.

New Features:
- Install additional upstream documentation files with the port.

Bug Fixes:
- Ensure inotify support is always linked dynamically against devel/libinotify and pthread to work on MidnightBSD.
- Fix syslog facility customization by wiring WITH_SYSLOG_FACILITY into configure instead of a non-functional SYSLOG_FACILITY option.
- Restrict gdbm library dependency to AUTH_USERDB builds that actually use GDBM, avoiding unnecessary linkage.

Enhancements:
- Adopt GNU_CONFIGURE_MANPREFIX and refined configure arguments to standardize installation paths and options.
- Reorder dependency declarations and cleanup unused or redundant Makefile logic for better maintainability.
- Document FAKE_DESTDIR/STAGEDIR interaction in post-install to prevent double-prefix staging issues.

Build:
- Switch the port framework includes to bsd.mport.options.mk/bsd.port.mk and adjust staging logic to match MidnightBSD fake install behavior.

Documentation:
- Adjust pkg-message and installed documentation set in line with upstream and FreeBSD while keeping MidnightBSD differences.