### PR TITLE
mail/py-mail-parser: update to 4.4.0

### DIFF
--- a/mail/py-mail-parser/Makefile
+++ b/mail/py-mail-parser/Makefile
@@ -1,9 +1,9 @@
 PORTNAME=	mail-parser
-PORTVERSION=	3.15.0
-PORTREVISION=	1
+PORTVERSION=	4.4.0
 CATEGORIES=	mail python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+DISTNAME=	${PORTNAME:S/-/_/}-${PORTVERSION}
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Wrapper for email standard library
@@ -11,12 +11,11 @@ WWW=		https://github.com/SpamScope/mail-parser
 
 LICENSE=	Apache-2.0
 
-RUN_DEPENDS=	msgconvert:mail/p5-Email-Outlook-Message \
-		${PYTHON_PKGNAMEPREFIX}simplejson>=3.17.0:devel/py-simplejson@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}six>=1.14.0:devel/py-six@${PY_FLAVOR}
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hatchling>=0:devel/py-hatchling@${PY_FLAVOR}
+RUN_DEPENDS=	msgconvert:mail/p5-Email-Outlook-Message
 
 USES=		python
-USE_PYTHON=	autoplist concurrent distutils
+USE_PYTHON=	autoplist concurrent pep517
 
 NO_ARCH=	yes
 

--- a/mail/py-mail-parser/distinfo
+++ b/mail/py-mail-parser/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1620357433
-SHA256 (mail-parser-3.15.0.tar.gz) = d66638acf0633dfd8a718e1e3646a6d58f8e9d75080c94638c7b267b4b0d6c86
-SIZE (mail-parser-3.15.0.tar.gz) = 18001
+TIMESTAMP = 1786284107
+SHA256 (mail_parser-4.4.0.tar.gz) = 82d2c0fa98a138620feaa87a378af2a2643b2941b2e125d7abfc65dd21094b33
+SIZE (mail_parser-4.4.0.tar.gz) = 2852896


### PR DESCRIPTION
Update `mail/py-mail-parser` from 3.15.0 to 4.4.0 — a major version jump.

## User-visible breaking changes

Verified by fetching the 3.15.0 sdist and diffing it against the extracted 4.4.0 tree, not inferred from release notes:

- **Console script renamed**: `mailparser` → `mail-parser` (`setup.py:71` old vs `[project.scripts]` new). The plist now installs `bin/mail-parser` plus the concurrent alias `bin/mail-parser-3.12`.
- **Module layout moved**: `mailparser/mailparser.py` → `src/mailparser/core.py`. The import package name `mailparser` is preserved, but `from mailparser.mailparser import ...` breaks.

**No in-tree consumers** — `grep -rl` over all Makefiles hits only the `mail/Makefile` SUBDIR list, so nothing needs a dependent bump.

## Build backend: setuptools → hatchling

`setup.py`/distutils is gone; `[build-system]` now requires `hatchling` with backend `hatchling.build`. `USE_PYTHON= autoplist concurrent distutils` → `autoplist concurrent pep517`.

**`${PY_SETUPTOOLS}` deliberately NOT added.** That workaround is needed only when the pep517 backend *is* setuptools; here it's hatchling, which doesn't need it. `hatchling` is the sole entry in `[build-system] requires` (no hatch-vcs), so `BUILD_DEPENDS` is complete. Confirmed mports' pep517 branch auto-injects the frontends: `bmake -V BUILD_DEPENDS` expands to `py312-hatchling py312-build py312-installer` plus python312.

`DISTNAME` added for the PEP 625 underscore sdist name.

## Dependencies

- **Removed** `py-simplejson`, `py-six` — upstream declares `dependencies = []`; 3.x needed both.
- **Added** `devel/py-hatchling` (exists at 1.27.0).
- **Kept** `msgconvert:mail/p5-Email-Outlook-Message` — still genuinely used at `src/mailparser/utils.py:381`. Upstream now marks that backend deprecated in favour of an optional `extract-msg` extra; FreeBSD doesn't wire the extra and neither does this.

No missing mports dependencies.

## Verification

makesum/patch/build/fake/package all OK → `py312-mail-parser-4.4.0.mport`. distinfo matches FreeBSD exactly. `requires-python = ">=3.9,<3.15"` and `PYTHON_VER` is 3.12, so no `USES=python:X.Y+` floor was needed. portlint: 0 fatal, 1 pre-existing warning (hyphen in PORTNAME, same as FreeBSD).

**The sdist grew 18KB → 2.85MB** (it now ships `tests/`, `docs/`, `uv.lock`). Confirmed none of it lands in the package — the wheel target is `packages = ["src/mailparser"]`, and the plist is clean.

LICENSE unchanged — `pyproject.toml` declares `Apache-2.0`, matching the existing field.

**Not run:** `bmake test` is a no-op here (`TEST_TARGET` empty, `pytest` not in `USE_PYTHON`) — that is not a passing suite. Upstream ships a pytest suite with `--cov`-heavy `addopts`; wiring it up would diverge from FreeBSD and expand scope. amd64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the py-mail-parser port to version 4.4.0 and switch it to a modern PEP 517-based build.

New Features:
- Track upstream mail-parser 4.4.0, including its new console script name and source layout.

Enhancements:
- Adopt pep517-based Python build using hatchling instead of distutils/setuptools for this port.
- Align distfile naming with the upstream PEP 625 underscore convention and refresh distinfo accordingly.

Build:
- Add a build dependency on devel/py-hatchling and adjust USE_PYTHON to use pep517.
- Drop now-unneeded runtime dependencies on py-simplejson and py-six in line with upstream’s declared dependencies.