### PR TITLE
mail/roundcube: update to 1.7.3 [security]

### DIFF
--- a/mail/roundcube/Makefile
+++ b/mail/roundcube/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	roundcube
-DISTVERSION=	1.7.2
+DISTVERSION=	1.7.3
 PORTEPOCH=	1
 CATEGORIES?=	mail www
 MASTER_SITES=	https://github.com/roundcube/roundcubemail/releases/download/${DISTVERSION}/

--- a/mail/roundcube/distinfo
+++ b/mail/roundcube/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1786138382
-SHA256 (roundcubemail-1.7.2-complete.tar.gz) = 01bf9ede1665e507db94bab1361ebed20ee353dba04bc628b00fb6eca05af3d1
-SIZE (roundcubemail-1.7.2-complete.tar.gz) = 6380572
+TIMESTAMP = 1786376249
+SHA256 (roundcubemail-1.7.3-complete.tar.gz) = 443cde2ea03b840ce4701fe23c273f01e68702f176d282e60248236bbb5f5f85
+SIZE (roundcubemail-1.7.3-complete.tar.gz) = 6423462


### PR DESCRIPTION
Update `mail/roundcube` from 1.7.2 to 1.7.3 — **security release**, published upstream 2026-08-09.

> **Note:** FreeBSD has not picked up 1.7.3 yet (their tree is still on 1.7.2 as of 2026-08-10), so unlike the 1.7.2 bump there is no reference port to diff against. Everything here was verified directly against the upstream tarball.

## What it fixes

Upstream lists eleven vulnerabilities. The severe ones:

- **RCE** via the `cmd_learn` driver of the markasjunk plugin (reported by nept1337)
- **IMAP command injection** via mail search and LITERAL+ byte-count desynchronization (Zach Hanley, Horizon3.ai)
- **LDAP filter injection** via unescaped `%u`/`%fu`/`%d` substitution into `search_filter` (Milan Hoppe)
- **Arbitrary Sieve script injection** via a filter rule name bypassing `managesieve_disabled_actions` (Milan Hoppe)
- **Stored XSS** in the "Add to address book" action (Paulos Yibelo, pwn.ai)

Plus SSRF filter bypasses via `100.64.0.0/10` and `fe80::/10` addresses (Dmytro Ivanenko) and via nip.io/sslip.io hostname forms evading `is_local_url()` (Milan Hoppe); a remote-content blocking bypass via unclosed `url()` in a FuncIRI attribute; an HTML/CSS sanitization bypass via the SVG `animate` `by` attribute (vectrain); a password modoboa driver leaking an auth token to a user-controlled host (meifukun); and basic validation for content proxied by the css proxy.

## Port changes

`Makefile` (`DISTVERSION`) and `distinfo` only.

```
SHA256 (roundcubemail-1.7.3-complete.tar.gz) = 443cde2ea03b840ce4701fe23c273f01e68702f176d282e60248236bbb5f5f85
SIZE  = 6423462
```

**Patch set unchanged.** Both `patch-config_defaults.inc.php` and `patch-program_lib_Roundcube_rcube_message.php` apply cleanly at their existing anchors with no fuzz and no `.rej`/`.orig`. Verified beyond the exit status by confirming the `+` side of each hunk is present in the extracted tree.

**`RCUBECOMP` re-checked.** Each member was verified to exist in the 1.7.3 tree — this is what bit the 1.7.2 update, where mports still listed a top-level `.htaccess` that upstream had dropped and `COPYTREE_SHARE` would have failed on. No such drift here.

**pkg-plist** needs no change — this port has no static plist; `do-install` generates it by walking `bin` + `RCUBECOMP` into `TMPPLIST`.

## Verification

makesum / patch / build / fake / package all OK → `roundcube-php83-1.7.3,1.mport`.

**CPE confirmed** so `mport audit` will actually match these advisories: `CPE_VENDOR=roundcube` / `CPE_PRODUCT=webmail` resolves to `cpe:2.3:a:roundcube:webmail:1.7.3:::::midnightbsd4:x64:0`, matching NVD's naming for this product.

`PORTEPOCH=1` unchanged; no `PORTREVISION` line exists. LICENSE unchanged (`gpl3+`). The 1.7 breaking-changes `pkg-message` block added in the 1.7.2 update still applies — its `maximum_version: "1.7.0"` means anyone coming from 1.6.x still sees it.

**Not validated:** php83 flavor only, amd64 only. No runtime smoke test — the package was not installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Roundcube webmail port to the 1.7.3 security release.

Bug Fixes:
- Incorporate upstream security fixes for multiple vulnerabilities, including RCE, injection issues, XSS, SSRF filter bypasses, and content sanitization weaknesses by updating to Roundcube 1.7.3.

Enhancements:
- Refresh distfile checksums and related metadata for the new Roundcube 1.7.3 release while keeping existing patches and packaging logic unchanged.