### PR TITLE
mail/roundcube: fix newsyslog.conf packing list entry

### DIFF
--- a/mail/roundcube/Makefile
+++ b/mail/roundcube/Makefile
@@ -80,12 +80,18 @@ do-install-DOCS-on:
 	${INSTALL_DATA} ${WRKSRC}/docs/INSTALL.md ${FAKE_DESTDIR}${DOCSDIR}/
 	${INSTALL_DATA} ${WRKSRC}/docs/UPGRADING.md ${FAKE_DESTDIR}${DOCSDIR}/
 
+# Lines appended to TMPPLIST below bypass the @-keyword expansion in
+# Mk/scripts/functions.sh, which has already run by this point.  A raw
+# "@sample src target" would therefore survive into the packing list and be
+# treated as a single filename, so emit the expanded form directly instead.
 do-install-EXAMPLES-on:
 	${MKDIR} ${FAKE_DESTDIR}${EXAMPLESDIR}
 	@${INSTALL_DATA} ${WRKDIR}/newsyslog.conf ${FAKE_DESTDIR}${EXAMPLESDIR}
 	@${ECHO_CMD} '@dir etc/newsyslog.conf.d' \
 		>> ${TMPPLIST}
-	@${ECHO_CMD} '@sample ${EXAMPLESDIR}/newsyslog.conf etc/newsyslog.conf.d/roundcube.conf' \
+	@${ECHO_CMD} '@comment ${TRUE_PREFIX}/etc/newsyslog.conf.d/roundcube.conf' \
+		>> ${TMPPLIST}
+	@${ECHO_CMD} '${EXAMPLESDIR}/newsyslog.conf' \
 		>> ${TMPPLIST}
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Fixes the missing-file warning for `newsyslog.conf` in the examples directory.

## Root cause

`do-install-EXAMPLES-on` appends its packing-list lines straight to `${TMPPLIST}`. That happens **after** the `@`-keyword expansion in `Mk/scripts/functions.sh` has already run, so the raw keyword survives into the final packing list.

`functions.sh:87` would normally expand `@sample src target` into a `@comment` for the target plus the plain sample path:

```sh
@sample\ *)
        set -- $line; shift
        sample_file=$1
        target_file=${1%.sample}
        if [ $# -eq 2 ]; then target_file=$2; fi
        ...
        echo "@comment ${target_file}"
        echo "${comment}${sample_file}"
```

Because that never ran, the packing list contained:

```
@sample /usr/local/share/examples/roundcube/newsyslog.conf etc/newsyslog.conf.d/roundcube.conf
```

and mport treated the entire `"src target"` string as a **single filename**, which is the missing file being reported.

## Fix

Emit the expanded form directly. `@dir` is deliberately left alone — mport handles that keyword natively at create time, and it was not part of the failure.

## Verified

Packing list, before → after:

```
- /usr/local/share/examples/roundcube/newsyslog.conf etc/newsyslog.conf.d/roundcube.conf
+ @dir etc/newsyslog.conf.d
+ @comment /usr/local/etc/newsyslog.conf.d/roundcube.conf
+ /usr/local/share/examples/roundcube/newsyslog.conf
```

And the file now genuinely ships, confirmed in the package archive rather than just the plist:

```
$ tar tvzf roundcube-php83-1.7.3,1.mport | grep newsyslog
-rw-r--r--  0 0 0   264 Aug 10 17:00 /usr/local/share/examples/roundcube/newsyslog.conf
```

Full clean `bmake` → `fake` → `package` cycle, exit 0, php83 flavor with `DOCS EXAMPLES PGSQL`.

## Scope

**This bug predates the 1.7.3 update** — 1.7.2 and earlier carry the identical `do-install-EXAMPLES-on` target, so it is not a regression from the security bump. It only shows with the `EXAMPLES` option on, which is the default.

Worth noting for other ports: any `@` keyword appended to `TMPPLIST` from a `do-install`/`post-install` target has the same problem. `@dir`, `@comment` and plain paths pass through fine, but keywords that require expansion (`@sample`, `@info`, `@shell`, `@fc`/`@fontsdir`) will not be processed. A tree-wide check for that pattern may be worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect @sample entry in the examples packing list that caused mport to treat the newsyslog sample path and target as a single missing filename.