### PR TITLE
devel/wasi-compiler-rt22: add LLVM 22 runtime

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -2723,6 +2723,7 @@
     SUBDIR += wasi-compiler-rt19
     SUBDIR += wasi-compiler-rt20
     SUBDIR += wasi-compiler-rt21
+    SUBDIR += wasi-compiler-rt22
     SUBDIR += wasi-libc
     SUBDIR += wasi-libcxx
     SUBDIR += wasi-libcxx17

--- a/devel/wasi-compiler-rt22/Makefile
+++ b/devel/wasi-compiler-rt22/Makefile
@@ -1,0 +1,6 @@
+# must sync with devel/llvm22
+DISTVERSION=	22.1.8
+
+MASTERDIR=	${.CURDIR}/../wasi-compiler-rt
+
+.include "${MASTERDIR}/Makefile"


### PR DESCRIPTION
## Summary
- add the LLVM 22.1.8 WebAssembly compiler runtime master-port stub
- register the new origin in devel/Makefile
- satisfy the wasi-libc@22 dependency that currently prevents INDEX-4 generation

## Validation
- bmake makesum
- bmake check-license
- bmake patch
- bmake build
- bmake fake
- bmake package
- bmake test

Portlint reports its known MASTERDIR-stub parsing false positive; the existing versioned WASI runtime ports use the same layout.

## Summary by Sourcery

Add a new versioned WASI compiler runtime port aligned with LLVM 22 and register it in the devel ports category.

New Features:
- Introduce the wasi-compiler-rt22 port tracking LLVM 22.1.8 WebAssembly compiler runtime.

Enhancements:
- Reuse the existing wasi-compiler-rt master port infrastructure for the new LLVM 22 runtime variant.