### PR TITLE
textproc/php-pspell: add community extension

### DIFF
--- a/Mk/extensions/php.mk
+++ b/Mk/extensions/php.mk
@@ -432,7 +432,11 @@ pdo_sqlite_DEPENDS=	databases/php${PHP_VER}-pdo_sqlite
 pgsql_DEPENDS=	databases/php${PHP_VER}-pgsql
 phar_DEPENDS=	archivers/php${PHP_VER}-phar
 posix_DEPENDS=	sysutils/php${PHP_VER}-posix
+.    if ${PHP_VER} <= 83
 pspell_DEPENDS=	textproc/php${PHP_VER}-pspell
+.    else
+pspell_DEPENDS=	textproc/php-pspell@${PHP_FLAVOR}
+.    endif
 radius_DEPENDS=	net/pecl-radius@${PHP_FLAVOR}
 readline_DEPENDS=	devel/php${PHP_VER}-readline
 redis_DEPENDS=	databases/pecl-redis@${PHP_FLAVOR}

--- a/textproc/Makefile
+++ b/textproc/Makefile
@@ -289,6 +289,7 @@
     SUBDIR += pear-Horde_Text_Flowed
     SUBDIR += pear-Horde_Xml_Element
     SUBDIR += pear-Horde_Xml_Wbxml
+    SUBDIR += php-pspell
     SUBDIR += php82-ctype
     SUBDIR += php82-dom
     SUBDIR += php82-enchant

--- a/textproc/php-pspell/Makefile
+++ b/textproc/php-pspell/Makefile
@@ -1,0 +1,36 @@
+PORTNAME=	pspell
+DISTVERSION=	1.0.1
+CATEGORIES=	textproc
+PKGNAMEPREFIX=	${PHP_PKGNAMEPREFIX}
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Shared community extension for pspell
+WWW=		https://github.com/php/pecl-text-pspell
+
+LICENSE=	PHP301
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+LIB_DEPENDS=	libaspell.so:textproc/aspell
+
+USES=		php:ext
+USE_GITHUB=	yes
+GH_ACCOUNT=	php
+GH_PROJECT=	pecl-text-pspell
+IGNORE_WITH_PHP=	82 83
+
+TEST_TARGET=	test
+
+.include <bsd.port.pre.mk>
+
+.if ${OSVERSION} <= 300000
+CONFIGURE_TARGET=	${ARCH}-portbld-freebsd12.4
+.else
+CONFIGURE_TARGET=	${ARCH}-portbld-freebsd13.4
+.endif
+
+.if ${PHP_VER} >= 86
+post-patch:
+	@${REINPLACE_CMD} -e 's|XtOffsetOf|offsetof|' ${WRKSRC}/pspell.c
+.endif
+
+.include <bsd.port.post.mk>

--- a/textproc/php-pspell/distinfo
+++ b/textproc/php-pspell/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1783265235
+SHA256 (php-pecl-text-pspell-1.0.1_GH0.tar.gz) = c98cbfe35039ff2daa51370a4a1515258435d22b73a22cb3f45ed741dd45662a
+SIZE (php-pecl-text-pspell-1.0.1_GH0.tar.gz) = 10933

--- a/textproc/php-pspell/pkg-descr
+++ b/textproc/php-pspell/pkg-descr
@@ -1,0 +1,2 @@
+This extension allows you to check the spelling of a word and offer
+suggestions using aspell.


### PR DESCRIPTION
## Summary

- add the community pspell extension for PHP 8.4 and 8.5
- preserve bundled pspell dependencies for PHP 8.2 and 8.3
- route newer `USE_PHP=pspell` consumers to the matching port flavor
- use the FreeBSD-compatible configure target required on MidnightBSD

## Validation

- `bmake makesum`
- `bmake check-license`
- `bmake patch`
- `bmake build` (`FLAVOR=php85`, isolated PHP 8.5 SDK)
- `bmake fake` (`FLAVOR=php85`)
- `bmake package` (`FLAVOR=php85`)
- `bmake test` (`FLAVOR=php85`; 5 skipped because no English aspell dictionary is installed, 0 failed)
- `portlint -AC` (0 fatal errors, maintainer-mode warning only)
- `portfmt -D Makefile`
- `bmake index` (completed; existing glib dependency-cycle notices only)

## Summary by Sourcery

Add a new community-based PHP pspell extension port and wire it into the PHP extensions framework while retaining existing pspell handling for older PHP versions.

New Features:
- Introduce a new textproc/php-pspell port providing the community pspell extension for supported PHP versions.
- Route USE_PHP=pspell for PHP 8.4+ to the new php-pspell flavor-based port instead of versioned ports.

Enhancements:
- Keep existing versioned pspell ports in use for PHP 8.2 and 8.3 to preserve bundled dependencies.
- Add OS-version-specific configure targets and a PHP 8.6+ compatibility patch hook for building the new php-pspell port.