### PR TITLE
ai/claude-code: update to 2.1.228

### DIFF
--- a/ai/claude-code/Makefile
+++ b/ai/claude-code/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	claude-code
-DISTVERSION=	2.1.223
+DISTVERSION=	2.1.228
 CATEGORIES=	ai linux
 MASTER_SITES=	https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/
 DISTNAME=	claude-code-linux-x64-${DISTVERSION}

--- a/ai/claude-code/distinfo
+++ b/ai/claude-code/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1786022080
-SHA256 (claude-code-linux-x64-2.1.223.tgz) = fb335c7c5b44fe9c5b48d15d41ca7903e1d0ed2a1ea932da0e8f5b09f34a1a86
-SIZE (claude-code-linux-x64-2.1.223.tgz) = 88909065
+TIMESTAMP = 1786487141
+SHA256 (claude-code-linux-x64-2.1.228.tgz) = 0c304edad9753e2efeb88ddb76c5a13c06160d67c980b9d849ad65bfadde3fd8
+SIZE (claude-code-linux-x64-2.1.228.tgz) = 93656712


### PR DESCRIPTION
Update ai/claude-code from 2.1.223 to 2.1.228 (latest upstream npm release of
@anthropic-ai/claude-code-linux-x64).

## Validation
- `bmake makesum`, `bmake fake`, `bmake package` — all clean, pkg-plist unchanged
- ELF sanity under linuxulator: `e_phoff` = 64 (well under PAGE_SIZE), NEEDED
  libs unchanged (librt, libc, ld-linux, libpthread, libdl, libm) — all provided
  by the existing `USE_LINUX` set
- Staged binary executed: `claude --version` → `2.1.228 (Claude Code)`

Tested on MidnightBSD 4.x/amd64. The installed copy was not replaced during
testing because an instance was running; the staged binary was run in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the claude-code port to the latest upstream 2.1.228 release.

New Features:
- Expose the latest Claude Code 2.1.228 Linux x64 binary via the port.

Enhancements:
- Refresh distversion and distinfo to track the new upstream npm release of @anthropic-ai/claude-code-linux-x64.