### PR TITLE
security/openssl: update to 3.0.21

### DIFF
--- a/security/openssl/Makefile
+++ b/security/openssl/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	openssl
-DISTVERSION=	3.0.20
-PORTREVISION=	1
+DISTVERSION=	3.0.21
 CATEGORIES=	security devel
 
 MAINTAINER=	ports@MidnightBSD.org

--- a/security/openssl/distinfo
+++ b/security/openssl/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1775584413
-SHA256 (openssl-openssl-3.0.20-openssl-3.0.20_GH0.tar.gz) = ae5ca65c744cc402e49dadd6c2bce599cb6601687898bef79cc783f1ef801ece
-SIZE (openssl-openssl-3.0.20-openssl-3.0.20_GH0.tar.gz) = 15432105
+TIMESTAMP = 1786641916
+SHA256 (openssl-openssl-3.0.21-openssl-3.0.21_GH0.tar.gz) = da110736b34979da4084e8a013365b1d8c24fe6d1a2e7c8b1d8ae951a0f15f5a
+SIZE (openssl-openssl-3.0.21-openssl-3.0.21_GH0.tar.gz) = 15451560


### PR DESCRIPTION
## Summary

Update `security/openssl` from 3.0.20_1 to the 3.0.21 security release.

OpenSSL 3.0.21 fixes multiple vulnerabilities published on June 9, 2026, including a High-severity heap use-after-free in `PKCS7_verify()`.

## Validation

- `BATCH=yes bmake -C security/openssl makesum`
- `BATCH=yes bmake -C security/openssl clean patch`
- `BATCH=yes bmake -C security/openssl`
- `BATCH=yes bmake -C security/openssl fake package`
- `BATCH=yes bmake -C security/openssl test check-license`
- package created: `openssl-3.0.21.mport`
- `git diff --cached --check`

`portlint -C security/openssl` continues to report pre-existing Makefile framework/style findings unrelated to this version-only update.

## Summary by Sourcery

Build:
- Adjust port version metadata for openssl 3.0.21, removing the previous PORTREVISION.