### PR TITLE
lang/go125: update to 1.25.13

### DIFF
--- a/lang/go125/Makefile
+++ b/lang/go125/Makefile
@@ -1,4 +1,4 @@
-DISTVERSION=	1.25.9
+DISTVERSION=	1.25.13
 # Always set PORTREVISION explicitly as otherwise they are inherited from lang/go-devel
 PORTREVISION=	0
 MASTER_SITES=	https://go.dev/dl/

--- a/lang/go125/distinfo
+++ b/lang/go125/distinfo
@@ -1,6 +1,6 @@
-TIMESTAMP = 1777569867
-SHA256 (go1.25.9.src.tar.gz) = 0ec9ef8ebcea097aac37decae9f09a7218b451cd96be7d6ed513d8e4bcf909cf
-SIZE (go1.25.9.src.tar.gz) = 31997830
+TIMESTAMP = 1786716911
+SHA256 (go1.25.13.src.tar.gz) = 1d7e2f70b1ee9b93c7df8efcca71f5adcc6a59797a4336c2d10171bd4c174614
+SIZE (go1.25.13.src.tar.gz) = 32023100
 SHA256 (go1.24.13.freebsd-arm64.tar.gz) = 67efe294235fd85fc0fb810275dfd402a459c8522f7bf075f63c7047db474f1b
 SIZE (go1.24.13.freebsd-arm64.tar.gz) = 74600806
 SHA256 (go1.24.13.freebsd-amd64.tar.gz) = 96e3c439befbb365ecde3ae475f9319ef7693d5d66a05992e8f8d29c60a63761


### PR DESCRIPTION
## Summary
- update Go 1.25 from 1.25.9 to the 1.25.13 security release
- retain the Go 1.24.13 bootstrap toolchain
- addresses the ten security issues announced with Go 1.25.13, including CVE-2026-56865 and CVE-2026-56864

## Validation
- `bmake makesum`
- `bmake patch`
- `bmake`
- `bmake fake`
- `bmake package`
- `bmake check-license`
- built tool reports `go version go1.25.13 freebsd/amd64`
- `git diff --check`

The port inherits existing `NO_TEST=yes`. `portlint -C` reports the pre-existing slave-port SHEBANG_FILES ordering error and option warnings.

## Summary by Sourcery

Enhancements:
- Bump the Go 1.25 port from version 1.25.9 to 1.25.13 and refresh distinfo accordingly.