### PR TITLE
lang/rust-bootstrap: update to 1.95.0

### DIFF
--- a/lang/rust-bootstrap/Makefile
+++ b/lang/rust-bootstrap/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	rust
-PORTVERSION=	1.94.0
-PORTREVISION=	1
+PORTVERSION=	1.95.0
 CATEGORIES=	lang
 MASTER_SITES=	https://static.rust-lang.org/dist/
 PKGNAMEPREFIX=	${FLAVOR:S/_/-/g}-

--- a/lang/rust-bootstrap/distinfo
+++ b/lang/rust-bootstrap/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779561990
-SHA256 (rust/rustc-1.94.0-src.tar.xz) = 0b53ae34f5c0c3612cfe1de139f9167a018cd5737bc2205664fd69ba9b25f600
-SIZE (rust/rustc-1.94.0-src.tar.xz) = 273916448
+TIMESTAMP = 1777287990
+SHA256 (rust/rustc-1.95.0-src.tar.xz) = 62b67230754da642a264ca0cb9fc08820c54e2ed7b3baba0289876d4cdb48c08
+SIZE (rust/rustc-1.95.0-src.tar.xz) = 238952004

--- a/lang/rust-bootstrap/files/patch-AddLLVM.cmake
+++ b/lang/rust-bootstrap/files/patch-AddLLVM.cmake
@@ -1,11 +1,11 @@
---- src/llvm-project/llvm/cmake/modules/AddLLVM.cmake.orig	2025-11-28 15:50:47.187034000 -0500
-+++ src/llvm-project/llvm/cmake/modules/AddLLVM.cmake	2025-11-28 15:51:04.988563000 -0500
-@@ -2466,7 +2466,7 @@
+--- src/llvm-project/llvm/cmake/modules/AddLLVM.cmake.orig	2026-04-14 11:23:49 UTC
++++ src/llvm-project/llvm/cmake/modules/AddLLVM.cmake
+@@ -2565,7 +2565,7 @@
    elseif(UNIX)
      set(_build_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}" ${extra_libdir})
      set(_install_rpath "\$ORIGIN/../lib${LLVM_LIBDIR_SUFFIX}")
--    if(${CMAKE_SYSTEM_NAME} MATCHES "(FreeBSD|DragonFly)")
-+    if(${CMAKE_SYSTEM_NAME} MATCHES "(MidnightBSD|FreeBSD|DragonFly)")
+-    if("${CMAKE_SYSTEM_NAME}" MATCHES "(FreeBSD|DragonFly)")
++    if("${CMAKE_SYSTEM_NAME}" MATCHES "(MidnightBSD|FreeBSD|DragonFly)")
        set_property(TARGET ${name} APPEND_STRING PROPERTY
                     LINK_FLAGS " -Wl,-z,origin ")
      endif()

--- a/lang/rust-bootstrap/files/patch-vendor_cc.rs
+++ b/lang/rust-bootstrap/files/patch-vendor_cc.rs
@@ -125,9 +125,9 @@ https://reviews.llvm.org/D77776
                  (false, false, true, _, false) | (_, _, _, _, true) => Ok(ToolFamily::Gnu),
                  (false, false, false, false, false) => {
                      cargo_output.print_warning(&"Compiler family detection failed since it does not define `__clang__`, `__GNUC__`, `__EMSCRIPTEN__` or `__VXWORKS__`, also does not accept cl style flag `-?`, fallback to treating it as GNU");
---- vendor/cc-1.2.50/src/tool.rs.orig	2026-04-22 17:39:24 UTC
-+++ vendor/cc-1.2.50/src/tool.rs
-@@ -158,9 +158,7 @@ impl Tool {
+--- vendor/cc-1.2.55/src/tool.rs.orig	2026-04-14 11:23:49 UTC
++++ vendor/cc-1.2.55/src/tool.rs
+@@ -157,9 +157,7 @@ impl Tool {
 
              match (clang, accepts_cl_style_flags, gcc, emscripten, vxworks) {
                  (clang_cl, true, _, false, false) => Ok(ToolFamily::Msvc { clang_cl }),


### PR DESCRIPTION
Follows #754 by updating `lang/rust-bootstrap` from 1.94.0 to 1.95.0, so the port keeps producing bootstrap tarballs matching the compiler it bootstraps.

## Changes

- `PORTVERSION` 1.94.0 -> 1.95.0, dropped the now stale `PORTREVISION=1`
- `distinfo` updated for `rustc-1.95.0-src.tar.xz`
- `files/patch-AddLLVM.cmake` and `files/patch-vendor_cc.rs` synced from `lang/rust`; both needed retargeting for the 1.95 sources (LLVM now quotes `"${CMAKE_SYSTEM_NAME}"` and the line moved; the vendored cc crate moved 1.2.50 -> 1.2.55)

## Note on the distfile

FreeBSD's rust-bootstrap distinfo for 1.95.0 records a *different* `rustc-1.95.0-src.tar.xz` (`deb399b9…`, 238942468 bytes) than their own lang/rust distinfo (`62b67230…`, 238952004 bytes) — upstream re-rolled the tarball, and they build bootstraps from the pre-release copy. Both ports here share `DIST_SUBDIR=rust`, so this uses the released tarball that `lang/rust` already carries, keeping one checksum per distfile.

## Validation (amd64)

| Step | Result |
|---|---|
| `bmake checksum` | OK |
| `bmake extract` / `bmake patch` | clean, no rejects |
| `bmake configure` | OK, expected `config.toml` generated |
| `portlint` | 15 warnings, all pre-existing on files this PR does not touch |

A full build of the amd64 flavor was still running when this was opened; I will comment with the result. The i386 flavor was not built. Note that the identical sources and patch set built end to end in #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Rust bootstrap port to 1.95.0 while keeping its FreeBSD-specific patches compatible with the new sources.

Enhancements:
- Update the Rust bootstrap port to version 1.95.0 and align its source patches with the newer Rust and LLVM sources.

Chores:
- Refresh the bootstrap source checksum metadata and remove the obsolete port revision.