### PR TITLE
lang/rust-bootstrap: build the cargo bootstrap tarball

### DIFF
--- a/lang/rust-bootstrap/Makefile
+++ b/lang/rust-bootstrap/Makefile
@@ -75,7 +75,10 @@ do-configure:
 	@${ECHO_CMD} '[build]' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'build-dir="${WRKDIR}/_build"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'vendor=true' >> ${WRKSRC}/config.toml
-	@${ECHO_CMD} 'extended=false' >> ${WRKSRC}/config.toml
+# lang/rust bootstraps from rustc, rust-std and cargo, so cargo has to be
+# part of the dist run.
+	@${ECHO_CMD} 'tools=["cargo"]' >> ${WRKSRC}/config.toml
+	@${ECHO_CMD} 'extended=true' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'python="${PYTHON_CMD}"' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'docs=false' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'verbose=2' >> ${WRKSRC}/config.toml
@@ -125,6 +128,8 @@ do-configure:
 #	@${ECHO_CMD} 'linker="${CC}"' >> ${WRKSRC}/config.toml
 #.endif
 	@${ECHO_CMD} '[dist]' >> ${WRKSRC}/config.toml
+# Only the xz tarballs are installed, so do not spend time on gzip ones.
+	@${ECHO_CMD} 'compression-formats=["xz"]' >> ${WRKSRC}/config.toml
 	@${ECHO_CMD} 'src-tarball=false' >> ${WRKSRC}/config.toml
 
 do-build:
@@ -135,6 +140,9 @@ do-install:
 	@${MKDIR} ${PREFIX}/rust-bootstrap/${FLAVOR}
 	${INSTALL_DATA} ${WRKDIR}/_build/dist/*-${_RUST_ARCH_${FLAVOR}:U${FLAVOR}}-unknown-${OPSYS:tl}${EXTRACT_SUFX} \
 		${PREFIX}/rust-bootstrap/${FLAVOR}
+# we only need rustc, std and cargo
+	${RM} ${PREFIX}/rust-bootstrap/${FLAVOR}/rust-${PORTVERSION}-* \
+		${PREFIX}/rust-bootstrap/${FLAVOR}/rust*dev*
 	@cd ${PREFIX} && \
 		${FIND} rust-bootstrap -type f >> ${TMPPLIST}
 


### PR DESCRIPTION
Follow-up to #755, fixing the gap noted there: `lang/rust` bootstraps from **three** distfiles — `rustc`, `rust-std` and `cargo` — but this port ran `x.py dist` with `extended=false` and no `tools` list, so it never produced a cargo tarball. The bootstraps it shipped were not enough to bump `lang/rust` on their own; cargo still had to come from the FreeBSD mirror.

## Changes

- `tools=["cargo"]` and `extended=true` so cargo is built and packaged with the other two
- `do-install` drops the combined `rust-${PORTVERSION}` installer (a side effect of `extended=true`) plus the `rust-dev` / `rustc-dev` tarballs, which `lang/rust` never fetches — same set FreeBSD keeps
- `[dist] compression-formats=["xz"]`, since only the xz tarballs are installed and building gzip copies of everything was pure overhead

The package now carries exactly `cargo`, `rustc` and `rust-std`, and shrinks from **469M to 75M**.

## Validation (amd64 flavor)

| Step | Result |
|---|---|
| `bmake configure` | expected `config.toml` |
| `bmake` | Build completed successfully in 0:43:45 |
| `bmake fake` | stages exactly cargo + rustc + rust-std |
| `bmake package` | `amd64-rust-bootstrap-1.95.0.mport`, 75M |
| `portlint` | 15 warnings, all pre-existing and unrelated |

### Bootstrap functional test

The produced tarballs were exercised the way `lang/rust`'s `do-configure` uses them — each extracted and run through its own `install.sh --prefix=<scratch>` — and then used as a real toolchain:

```
$ cargo-1.95.0-x86_64-unknown-freebsd/install.sh --prefix=<scratch>   # cargo installed.
$ rust-std-1.95.0-x86_64-unknown-freebsd/install.sh --prefix=<scratch> # rust std installed.
$ rustc-1.95.0-x86_64-unknown-freebsd/install.sh --prefix=<scratch>    # rustc installed.

$ <scratch>/bin/rustc --version
rustc 1.95.0 (59807616e 2026-04-14) (built from a source tarball)
$ <scratch>/bin/cargo --version
cargo 1.95.0 (f2d3ce0bd 2026-03-21) (built from a source tarball)

$ <scratch>/bin/cargo init --name bstest && cargo build --offline && ./target/debug/bstest
Hello, world!
```

So the bootstrap set installs cleanly and cargo drives rustc to compile and run a crate.

The i386 flavor was not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build a complete, slimmer Rust bootstrap tarball set containing only the cargo, rustc, and rust-std artifacts required by lang/rust.

New Features:
- Build and package Cargo alongside rustc and rust-std for Rust bootstrap consumers.

Bug Fixes:
- Ensure the bootstrap package contains the complete set of distfiles required to independently update lang/rust.

Enhancements:
- Limit generated and installed bootstrap artifacts to the required xz-compressed cargo, rustc, and rust-std tarballs.