### PR TITLE
Mk/scripts/do-fetch.sh: diagnose duplicated distinfo entries

### DIFF
--- a/Mk/scripts/do-fetch.sh
+++ b/Mk/scripts/do-fetch.sh
@@ -141,6 +141,20 @@ for _file in "${@}"; do
 		args="${early_args:+${early_args} }${site}${file}"
 		_fetch_cmd="${dp_FETCH_CMD} ${dp_FETCH_BEFORE_ARGS}"
 		if [ -z "${dp_DISABLE_SIZE}" -a -n "${CKSIZE}" ]; then
+			# CKSIZE is interpolated unquoted below, so it has to be a
+			# single integer.  distinfo_data prints one line per matching
+			# entry, so a distfile listed twice in distinfo yields two
+			# values here, which would word-split into fetch(1)'s argument
+			# list and be taken as an extra URL.  That fails on every site
+			# with a misleading error, so diagnose it instead.
+			case "${CKSIZE}" in
+			*[!0-9]*)
+				${dp_ECHO_MSG} "=> Invalid SIZE for ${dp_DIST_SUBDIR:+$dp_DIST_SUBDIR/}$file in ${dp_DISTINFO_FILE}."
+				${dp_ECHO_MSG} "=> Expected a single integer, got: $(echo ${CKSIZE})"
+				${dp_ECHO_MSG} "=> The entry is most likely present more than once."
+				exit 1
+				;;
+			esac
 			_fetch_cmd="${_fetch_cmd} -S ${CKSIZE}"
 		fi
 		_fetch_cmd="${_fetch_cmd} ${args} ${dp_FETCH_AFTER_ARGS}"


### PR DESCRIPTION
## Problem

`distinfo_data()` prints one line per matching entry, so a distfile listed twice in `distinfo` makes `CKSIZE` **two** values instead of one:

```sh
CKSIZE=$(distinfo_data SIZE "${full_file}")   # -> "117326728 117326728"
```

`CKSIZE` is interpolated unquoted into `-S ${CKSIZE}`, so it word-splits into `fetch(1)`'s argument list and the second value is taken as an extra URL. Every mirror then fails with an error that points nowhere near the real problem:

```
fetch: 117326728: No such file or directory
fetch: rust/crates/Inflector-0.11.4.crate is not a directory
=> Couldn't fetch it - please try to retrieve this port manually
```

The size comparison further down breaks the same way — `[ "${actual_size}" -eq "${CKSIZE}" ]` gets too many arguments — so even a *completed* download is discarded as a size mismatch.

This cost real debugging time: two ports in Magus run 647 (`ai/codex`, `java/openjdk23`) were reported as fetch failures that looked exactly like mirror outages. Fixed separately in #758 and #759.

## Fix

Validate `CKSIZE` before it reaches the command line, and report the actual cause:

```
=> Invalid SIZE for zipmix_src.zip in .../distinfo.
=> Expected a single integer, got: 4759 4759
=> The entry is most likely present more than once.
```

The check sits inside the existing `-z "${dp_DISABLE_SIZE}"` guard, so **`makesum` is unaffected** — it runs with `DISABLE_SIZE=yes NO_CHECKSUM=yes` and remains usable to regenerate a duplicated distinfo. That matters: a check placed outside the guard would break the very command you'd use to recover.

## Deliberately not changed

- `checksum.sh` iterates `for chksum in $CKSUM` on purpose, to allow several recorded checksums — duplicates are harmless there.
- The `_sha256sum` lookup at line 60 is only tested for emptiness.

Neither is affected, so the `-S` path is the only genuinely broken call site.

## Testing

With `archivers/zipmix` against a scratch `DISTDIR`:

| Case | Result |
|---|---|
| Clean distinfo | fetches normally, exit 0 (unchanged) |
| Duplicated distinfo, **without** this patch | `=> Couldn't fetch it - please try to retrieve this port manually` |
| Duplicated distinfo, **with** this patch | the diagnostic above |
| `makesum` on a duplicated distinfo | still regenerates a clean distinfo |

Also `sh -n` clean, and the `*[!0-9]*` pattern verified against single-integer, empty, two-value, and non-numeric input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Detect duplicated or otherwise invalid distinfo SIZE values before fetching, replacing misleading fetch failures with a clear diagnostic.