### PR TITLE
chinese/wordpress-zh_CN: regenerate distinfo for 7.0.3

### DIFF
--- a/chinese/wordpress-zh_CN/distinfo
+++ b/chinese/wordpress-zh_CN/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779042573
-SHA256 (wordpress-6.9-zh_CN.tar.gz) = 14ac3bc5c970fb5381e2c5e477f8d0aeb0158455df16f6b13915616e4c7f53a8
-SIZE (wordpress-6.9-zh_CN.tar.gz) = 34322298
+TIMESTAMP = 1787370809
+SHA256 (wordpress-7.0.3-zh_CN.tar.gz) = e3795f01d24c5a24de15544691bd8bfed3eb550ee7d43ff49bf0582307f0c754
+SIZE (wordpress-7.0.3-zh_CN.tar.gz) = 36877403


### PR DESCRIPTION
## Problem

Commit `6314d32ee7` updated the master port `www/wordpress` from 6.9 to 7.0.3 and regenerated only `www/wordpress/distinfo`. This Simplified Chinese slave still carried the 6.9 checksums, so fetching failed:

```
=> wordpress-7.0.3-zh_CN.tar.gz is not in /usr/mports/chinese/wordpress-zh_CN/distinfo.
=> Either /usr/mports/chinese/wordpress-zh_CN/distinfo is out of date, or
=> wordpress-7.0.3-zh_CN.tar.gz is spelled incorrectly.
```

Reported by Magus run 647.

## Fix

`bmake makesum`.

No `PORTREVISION` bump — the version comes from the master port, which already carries it.

## Testing

`bmake makesum` followed by `bmake checksum`, which passes against the freshly fetched 7.0.3 zh_CN tarball.

## Scope

All five `www/wordpress` slaves are affected by the same commit (`chinese/wordpress-zh_CN`, `chinese/wordpress-zh_TW`, `french/wordpress`, `german/wordpress`, `japanese/wordpress`). Each is fixed on its own branch per the one-port-per-PR convention; this is one of the five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the Simplified Chinese WordPress distinfo checksums to support fetching and verifying version 7.0.3.