### PR TITLE
chinese/wordpress-zh_TW: regenerate distinfo for 7.0.3

### DIFF
--- a/chinese/wordpress-zh_TW/distinfo
+++ b/chinese/wordpress-zh_TW/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1766963044
-SHA256 (wordpress-6.9-zh_TW.tar.gz) = 1fcd14767cfff687c531907e65e096af9f41c2ec415f5d529f699393228c5ca4
-SIZE (wordpress-6.9-zh_TW.tar.gz) = 34320400
+TIMESTAMP = 1787370813
+SHA256 (wordpress-7.0.3-zh_TW.tar.gz) = f4f36ff04cea3f6bfca13f87fa2c824cff7b432940d34e55a8383d72eb62f2e7
+SIZE (wordpress-7.0.3-zh_TW.tar.gz) = 36863159


### PR DESCRIPTION
## Problem

Commit `6314d32ee7` updated the master port `www/wordpress` from 6.9 to 7.0.3 and regenerated only `www/wordpress/distinfo`. This Traditional Chinese slave still carried the 6.9 checksums, so fetching failed:

```
=> wordpress-7.0.3-zh_TW.tar.gz is not in /usr/mports/chinese/wordpress-zh_TW/distinfo.
=> Either /usr/mports/chinese/wordpress-zh_TW/distinfo is out of date, or
=> wordpress-7.0.3-zh_TW.tar.gz is spelled incorrectly.
```

Reported by Magus run 647.

## Fix

`bmake makesum`.

No `PORTREVISION` bump — the version comes from the master port, which already carries it.

## Testing

`bmake makesum` followed by `bmake checksum`, which passes against the freshly fetched 7.0.3 zh_TW tarball.

## Scope

All five `www/wordpress` slaves are affected by the same commit (`chinese/wordpress-zh_CN`, `chinese/wordpress-zh_TW`, `french/wordpress`, `german/wordpress`, `japanese/wordpress`). Each is fixed on its own branch per the one-port-per-PR convention; this is one of the five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the Traditional Chinese WordPress port checksums so version 7.0.3 can be fetched and verified successfully.