### PR TITLE
french/wordpress: regenerate distinfo for 7.0.3

### DIFF
--- a/french/wordpress/distinfo
+++ b/french/wordpress/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1764823733
-SHA256 (wordpress-6.9-fr_FR.tar.gz) = 36b777f147462d64fceec63f0d4eb3d19333033f6d170ffcd939439bd9ee0312
-SIZE (wordpress-6.9-fr_FR.tar.gz) = 34356018
+TIMESTAMP = 1787370816
+SHA256 (wordpress-7.0.3-fr_FR.tar.gz) = 4a7e3621de00bbc9d6b886526e17f5eae1d83c11f4036367ed81c5bf34d5959a
+SIZE (wordpress-7.0.3-fr_FR.tar.gz) = 36903343


### PR DESCRIPTION
## Problem

Commit `6314d32ee7` updated the master port `www/wordpress` from 6.9 to 7.0.3 and regenerated only `www/wordpress/distinfo`. This French slave still carried the 6.9 checksums, so fetching failed:

```
=> wordpress-7.0.3-fr_FR.tar.gz is not in /usr/mports/french/wordpress/distinfo.
=> Either /usr/mports/french/wordpress/distinfo is out of date, or
=> wordpress-7.0.3-fr_FR.tar.gz is spelled incorrectly.
```

Reported by Magus run 647.

## Fix

`bmake makesum`.

No `PORTREVISION` bump — the version comes from the master port, which already carries it.

## Testing

`bmake makesum` followed by `bmake checksum`, which passes against the freshly fetched 7.0.3 fr_FR tarball.

## Scope

All five `www/wordpress` slaves are affected by the same commit (`chinese/wordpress-zh_CN`, `chinese/wordpress-zh_TW`, `french/wordpress`, `german/wordpress`, `japanese/wordpress`). Each is fixed on its own branch per the one-port-per-PR convention; this is one of the five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Regenerate the French WordPress 7.0.3 distribution checksums so the localized slave can fetch and verify its source archive.