### PR TITLE
german/wordpress: regenerate distinfo for 7.0.3

### DIFF
--- a/german/wordpress/distinfo
+++ b/german/wordpress/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779047974
-SHA256 (wordpress-6.9-de_DE.tar.gz) = 9c341e112aeb63383a49ec16152f06e2f63669c2f5cd4b8e8774cbaef2f1e237
-SIZE (wordpress-6.9-de_DE.tar.gz) = 34368407
+TIMESTAMP = 1787370820
+SHA256 (wordpress-7.0.3-de_DE.tar.gz) = cb0eb50c580e744fa3af9202ad43e24c661a270625592aca62877950d27925d8
+SIZE (wordpress-7.0.3-de_DE.tar.gz) = 36913554


### PR DESCRIPTION
## Problem

Commit `6314d32ee7` updated the master port `www/wordpress` from 6.9 to 7.0.3 and regenerated only `www/wordpress/distinfo`. This German slave still carried the 6.9 checksums, so fetching failed:

```
=> wordpress-7.0.3-de_DE.tar.gz is not in /usr/mports/german/wordpress/distinfo.
=> Either /usr/mports/german/wordpress/distinfo is out of date, or
=> wordpress-7.0.3-de_DE.tar.gz is spelled incorrectly.
```

Reported by Magus run 647.

## Fix

`bmake makesum`.

No `PORTREVISION` bump — the version comes from the master port, which already carries it.

## Testing

`bmake makesum` followed by `bmake checksum`, which passes against the freshly fetched 7.0.3 de_DE tarball.

## Scope

All five `www/wordpress` slaves are affected by the same commit (`chinese/wordpress-zh_CN`, `chinese/wordpress-zh_TW`, `french/wordpress`, `german/wordpress`, `japanese/wordpress`). Each is fixed on its own branch per the one-port-per-PR convention; this is one of the five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the German WordPress distribution checksums to support fetching and verifying version 7.0.3.