### PR TITLE
japanese/wordpress: regenerate distinfo for 7.0.3

### DIFF
--- a/japanese/wordpress/distinfo
+++ b/japanese/wordpress/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782964377
-SHA256 (wordpress-6.9-ja.tar.gz) = f42f989d5ebcfe0403fba97563d83cec03e4b800b442f348ef99b7cdb5c35a0f
-SIZE (wordpress-6.9-ja.tar.gz) = 34361444
+TIMESTAMP = 1787370824
+SHA256 (wordpress-7.0.3-ja.tar.gz) = e167023f8c31dedca20667c8988062912fdd45144dfe85ca5ccc3b4aeed7366b
+SIZE (wordpress-7.0.3-ja.tar.gz) = 36915323


### PR DESCRIPTION
## Problem

Commit `6314d32ee7` updated the master port `www/wordpress` from 6.9 to 7.0.3 and regenerated only `www/wordpress/distinfo`. This Japanese slave still carried the 6.9 checksums, so fetching failed:

```
=> wordpress-7.0.3-ja.tar.gz is not in /usr/mports/japanese/wordpress/distinfo.
=> Either /usr/mports/japanese/wordpress/distinfo is out of date, or
=> wordpress-7.0.3-ja.tar.gz is spelled incorrectly.
```

Reported by Magus run 647.

## Fix

`bmake makesum`.

No `PORTREVISION` bump — the version comes from the master port, which already carries it.

## Testing

`bmake makesum` followed by `bmake checksum`, which passes against the freshly fetched 7.0.3 ja tarball.

## Scope

All five `www/wordpress` slaves are affected by the same commit (`chinese/wordpress-zh_CN`, `chinese/wordpress-zh_TW`, `french/wordpress`, `german/wordpress`, `japanese/wordpress`). Each is fixed on its own branch per the one-port-per-PR convention; this is one of the five.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the Japanese WordPress port checksums for version 7.0.3 so the distribution archive can be fetched and verified.