### PR TITLE
cad/cura: fix invalid LICENSE, set to lgpl3

### DIFF
--- a/cad/cura/Makefile
+++ b/cad/cura/Makefile
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Slicing application for 3D printers
 WWW=		https://github.com/Ultimaker/Cura/wiki
 
-LICENSE=	apgl
+LICENSE=	lgpl3
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	Uranium>0,1:cad/uranium


### PR DESCRIPTION
## Problem

`LICENSE= apgl` is not a recognized identifier. The framework treats an unknown token as a *custom* license and aborts before doing any work:

```
===>  License not correctly defined: for unknown licenses, defining
      LICENSE_PERMS is mandatory (otherwise use a known LICENSE)
```

Magus run 647 recorded this as a **fetch failure**, because the license check runs inside the fetch target — but nothing was ever fetched. (The trailing `make: exec(exit) failed (No such file or directory)` in that log is framework noise masking the real error on the line above.)

## Why lgpl3 and not agpl

`apgl` reads like a transposition of `agpl`, and FreeBSD's `cad/cura` does use `AGPLv3` — but that is **not what this port builds**.

Cura relicensed at 4.0. This port is `DISTVERSION= 4.13.1`, `GH_ACCOUNT= Ultimaker`, and the `LICENSE` file at that tag — the very file `LICENSE_FILE= ${WRKSRC}/LICENSE` points at — is:

```console
$ fetch -qo - https://raw.githubusercontent.com/Ultimaker/Cura/4.13.1/LICENSE | head -2
    GNU LESSER GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
```

So `lgpl3` is the value that matches the shipped source. Taking the obvious typo fix would have recorded a license the source does not carry, and left `LICENSE_FILE` contradicting `LICENSE`.

FreeBSD's port looks stale on this point.

## Fix

`LICENSE= apgl` → `LICENSE= lgpl3`

No `PORTREVISION` bump — the port could not build at all, so there is no package whose metadata changes.

## Testing

`bmake check-license` → `===>  License lgpl3 accepted by the user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct the Cura port license identifier from the invalid `apgl` value to `lgpl3`, allowing license checks and builds to proceed.