### PR TITLE
japanese/p5-WWW-MobileCarrierJP: fix misspelled LICENSE identifier

### DIFF
--- a/japanese/p5-WWW-MobileCarrierJP/Makefile
+++ b/japanese/p5-WWW-MobileCarrierJP/Makefile
@@ -7,7 +7,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Scrape Japanese mobile carrier information
 WWW=		https://metacpan.org/release/WWW-MobileCarrierJP
 
-LICENSE=	artitistic gpl+
+LICENSE=	artistic gpl+
 LICENSE_COMB=	dual
 LICENSE_FILE=	${WRKSRC}/LICENSE
 


### PR DESCRIPTION
## Problem

`LICENSE= artitistic gpl+` — `artitistic` is not a recognized identifier, so the framework treated it as a *custom* license and aborted before doing any work:

```
===>  License not correctly defined: for unknown licenses, defining
      LICENSE_PERMS_artitistic is mandatory (otherwise use a known LICENSE)
```

Magus run 647 recorded this as a **fetch failure**, because the license check runs inside the fetch target — but nothing was ever fetched. (The trailing `make: exec(exit) failed (No such file or directory)` in that log is framework noise masking the real error on the line above.)

## Fix

`artitistic` → `artistic`.

With `LICENSE_COMB=dual` this is the standard Perl dual license, spelled `artistic gpl+` by every other `p5-*` port in the tree (`archivers/p5-Archive-Extract`, `archivers/p5-IO-Compress`, and ~20 more).

No `PORTREVISION` bump — the port could not build at all, so there is no package whose metadata changes.

## Testing

`bmake check-license` → `===>  License artistic gpl+ accepted by the user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct the misspelled Artistic license identifier so the port passes license validation and can build.