### PR TITLE
textproc/gitlab-elasticsearch-indexer: fix LICENSE case

### DIFF
--- a/textproc/gitlab-elasticsearch-indexer/Makefile
+++ b/textproc/gitlab-elasticsearch-indexer/Makefile
@@ -8,7 +8,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Elasticsearch indexer for GitLab
 WWW=		https://gitlab.com/gitlab-org/gitlab-elasticsearch-indexer
 
-LICENSE=	MIT
+LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE.md
 
 BUILD_DEPENDS=	git>=2.38.1:devel/git \


### PR DESCRIPTION
## Problem

`LICENSE= MIT`. Identifiers are case-sensitive and the recognized one is `mit`, so the framework treats `MIT` as a *custom* license and aborts before doing any work:

```
===>  License not correctly defined: for unknown licenses, defining
      LICENSE_PERMS is mandatory (otherwise use a known LICENSE)
```

Reproduced locally with `bmake check-license`.

## Fix

`MIT` → `mit`.

The license itself is correct — `LICENSE.md` upstream at https://gitlab.com/gitlab-org/gitlab-elasticsearch-indexer is the MIT license text. Only the identifier spelling was wrong.

No `PORTREVISION` bump — the port could not build at all, so there is no package whose metadata changes.

## Context

Magus run 647 has not reached `textproc` yet, but this port will fail the same way `cad/cura` (#766) and `japanese/p5-WWW-MobileCarrierJP` (#767) already did — reported as a *fetch* failure, because the license check runs inside the fetch target.

Found by sweeping the tree for `LICENSE` tokens that are neither in `bmake license-list` nor backed by a `LICENSE_PERMS` definition. That sweep returned exactly four ports; these two and the two above are all of them.

## Testing

`bmake check-license` → `===>  License mit accepted by the user`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Correct the GitLab Elasticsearch indexer port’s license identifier so license validation recognizes the existing MIT license.