### PR TITLE
archivers/zipmix: update to 20160430

### DIFF
--- a/archivers/zipmix/Makefile
+++ b/archivers/zipmix/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	zipmix
-DISTVERSION=	20070221
+DISTVERSION=	20160430
 CATEGORIES=	archivers
 MASTER_SITES=	http://www.advsys.net/ken/util/ \
 		https://BSDforge.com/projects/source/archivers/zipmix/

--- a/archivers/zipmix/distinfo
+++ b/archivers/zipmix/distinfo
@@ -1,2 +1,3 @@
-SHA256 (zipmix_src.zip) = 34f049928f691be4ba3decd559654a052877b2cc377ebe78255398b532592b99
-SIZE (zipmix_src.zip) = 4759
+TIMESTAMP = 1787372820
+SHA256 (zipmix_src.zip) = f036730a83fa74fde469bfc7576249bc81713a2c7e8d9bdb59011ae554eddc9e
+SIZE (zipmix_src.zip) = 5232


### PR DESCRIPTION
## Problem

The port pinned the **2007-02-21** distfile, but upstream (`advsys.net`) replaced `zipmix_src.zip` **in place** with a **2016-04-30** build years ago. The two `MASTER_SITES` now serve different content under the same filename:

| Site | Size | Date | Matches distinfo |
|---|---|---|---|
| `advsys.net` (primary) | 5232 | 2016-04-30 | ✗ |
| `BSDforge.com` (mirror) | 4759 | 2007-02-21 | ✓ |

So every fetch failed its size check on the primary and fell through to the mirror:

```
fetch: http://www.advsys.net/ken/util/zipmix_src.zip: size mismatch: expected 4759, actual 5232
```

That left the port depending on a single third-party mirror for a file upstream no longer publishes — one mirror outage away from being unfetchable. Following upstream is the durable fix.

## Upstream changes between the two builds

- Guard the byte-swap helpers with `__POWERPC__` rather than `__APPLE__` — the old guard misfired on non-PPC Apple hardware
- Add `getday()` and `isdatetimewithin1sec()`, so files whose ZIP timestamps differ by a second still match

`files/patch-zipmix.c` still applies (hunk 2 shifts by 22 lines).

## Testing

`bmake makesum`, `patch`, `build`, `fake`, `package` all succeed; `portlint` reports *"looks fine"*. The built binary runs and prints its usage banner.

## Pre-existing bug found while testing — not introduced here

The resulting binary **hangs** when actually asked to mix two archives (`zipmix A.zip B.zip out.zip`), producing a 0-byte output and never terminating. It is not an interactive prompt — it hangs the same way with input fed to stdin.

I built the patched **2007** and **2016** sources side by side and they hang **identically**, so this is pre-existing and orthogonal to this update. Flagging it rather than folding it in; it deserves its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Update the zipmix port to the upstream 2016-04-30 distfile so fetches use the current primary source instead of relying on the outdated mirror.