### PR TITLE
benchmarks: add p5-Benchmark-Forking and p5-Benchmark-Stopwatch

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -25,6 +25,8 @@
     SUBDIR += netperf
     SUBDIR += netpipe
     SUBDIR += nttcp
+    SUBDIR += p5-Benchmark-Forking
+    SUBDIR += p5-Benchmark-Stopwatch
     SUBDIR += p5-Dumbbench
     SUBDIR += pathrate
     SUBDIR += perftest

--- a/benchmarks/p5-Benchmark-Forking/Makefile
+++ b/benchmarks/p5-Benchmark-Forking/Makefile
@@ -1,0 +1,17 @@
+PORTNAME=	Benchmark-Forking
+PORTVERSION=	1.01
+CATEGORIES=	benchmarks perl5
+MASTER_SITES=	CPAN
+PKGNAMEPREFIX=	p5-
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Run benchmarks in separate processes
+WWW=		https://metacpan.org/release/Benchmark-Forking
+
+LICENSE=	artistic gpl+
+LICENSE_COMB=	dual
+
+USES=		perl5
+USE_PERL5=	configure
+
+.include <bsd.port.mk>

--- a/benchmarks/p5-Benchmark-Forking/distinfo
+++ b/benchmarks/p5-Benchmark-Forking/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1787463074
+SHA256 (Benchmark-Forking-1.01.tar.gz) = d0c2f68fb3187826553017ea1f98f9ef2cc01aa131ee6c5ba9fdc248bbcebf95
+SIZE (Benchmark-Forking-1.01.tar.gz) = 6251

--- a/benchmarks/p5-Benchmark-Forking/pkg-descr
+++ b/benchmarks/p5-Benchmark-Forking/pkg-descr
@@ -1,0 +1,12 @@
+The Benchmark::Forking module changes the behavior of the standard
+Benchmark module, running each piece of code to be timed in a separate
+forked process. Because each child exits after running its timing loop,
+the computations it performs can't propogate back to affect subsequent
+test cases.
+
+This can make benchmark comparisons more accurate, because the
+separate test cases are mostly isolated from side-effects caused by
+the others. Benchmark scripts typically don't depend on those
+side-effects, so in most cases you can simply use or require this
+module at the top of your existing code without having to change
+anything else.

--- a/benchmarks/p5-Benchmark-Forking/pkg-plist
+++ b/benchmarks/p5-Benchmark-Forking/pkg-plist
@@ -1,0 +1,2 @@
+%%SITE_PERL%%/Benchmark/Forking.pm
+%%PERL5_MAN3%%/Benchmark::Forking.3.gz

--- a/benchmarks/p5-Benchmark-Stopwatch/Makefile
+++ b/benchmarks/p5-Benchmark-Stopwatch/Makefile
@@ -1,0 +1,22 @@
+PORTNAME=	Benchmark-Stopwatch
+PORTVERSION=	0.05
+CATEGORIES=	benchmarks perl5
+MASTER_SITES=	CPAN
+PKGNAMEPREFIX=	p5-
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Simple timing of stages of your code
+WWW=		https://metacpan.org/release/Benchmark-Stopwatch
+
+LICENSE=	artistic gpl+
+LICENSE_COMB=	dual
+
+BUILD_DEPENDS=	${RUN_DEPENDS} \
+		p5-Test-LongString>=0:devel/p5-Test-LongString
+RUN_DEPENDS=	p5-Clone>=0:devel/p5-Clone
+
+USES=		perl5
+USE_PERL5=	configure
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/benchmarks/p5-Benchmark-Stopwatch/distinfo
+++ b/benchmarks/p5-Benchmark-Stopwatch/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1787463314
+SHA256 (Benchmark-Stopwatch-0.05.tar.gz) = 6009a70e47cb8bec43e1cb960992948bab24d5433323f78a68bd4c638ea97942
+SIZE (Benchmark-Stopwatch-0.05.tar.gz) = 5050

--- a/benchmarks/p5-Benchmark-Stopwatch/pkg-descr
+++ b/benchmarks/p5-Benchmark-Stopwatch/pkg-descr
@@ -1,0 +1,16 @@
+The other benchmark modules provide excellent timing for specific
+parts of your code. This module aims to allow you to easily time the
+progression of your code.
+
+The stopwatch analogy is that at some point you get a new stopwatch
+and start timing. Then you note certain events using lap. Finally you
+stop the watch and then print out a summary.
+
+The summary shows all the events in order, what time they occurred at,
+how long since the last lap and the percentage of the total time.
+Hopefully this will give you a good idea of where your code is
+spending most of its time.
+
+The times are all wallclock times in fractional seconds.
+
+That's it.

--- a/benchmarks/p5-Benchmark-Stopwatch/pkg-plist
+++ b/benchmarks/p5-Benchmark-Stopwatch/pkg-plist
@@ -1,0 +1,3 @@
+%%SITE_PERL%%/Benchmark/Stopwatch.pm
+%%SITE_PERL%%/Benchmark/example.pl
+%%PERL5_MAN3%%/Benchmark::Stopwatch.3.gz


### PR DESCRIPTION
Adds two related Perl benchmarking modules, imported from FreeBSD ports and adapted for mports.

- **benchmarks/p5-Benchmark-Forking** 1.01 — runs each timed code block in a forked child so side-effects cannot leak between test cases.
- **benchmarks/p5-Benchmark-Stopwatch** 0.05 — times the progression of a script via lap marks, printing elapsed time and percentage of total per event.

Kept as one PR since the two are companion benchmarking modules and share the same `benchmarks/Makefile` SUBDIR change.

## mports adaptation

The imported Makefiles carried FreeBSD-only license identifiers (`ART10 GPLv1+`), which mports does not recognize — `check-license` aborted before fetch:

```
===>  License not correctly defined: for unknown licenses, defining LICENSE_PERMS_ART10 is mandatory
```

Changes applied to both ports:

- `LICENSE= ART10 GPLv1+` → `artistic gpl+`
- `MAINTAINER` → `ports@MidnightBSD.org`
- Dropped the `PORTREVISION` values carried over from FreeBSD
- `bmake makesum` added the missing `TIMESTAMP` lines (SHA256/SIZE were already correct)
- Registered both directories in `benchmarks/Makefile`

## Dependencies

No new ports required. `devel/p5-Clone` and `devel/p5-Test-LongString` (Stopwatch) already exist and are registered; Forking has no non-core prerequisites.

## Validation

|  | Forking | Stopwatch |
|---|---|---|
| `bmake check-license` | pass | pass |
| `bmake build` / `fake` / `package` | pass | pass |
| `pkg-plist` vs staged tree | matches | matches |
| `bmake test` | 4/4 pass | 22/22 pass |
| `portlint` | looks fine | looks fine |

Built on amd64. The tree's `lang/perl5.40` is at 5.40.5 while the build host had perl5-5.40.4 installed, so builds were run with `NO_DEPENDS=yes PERL_VERSION=5.40.4` to avoid an unrelated perl upgrade. Both ports are pure perl with no arch-specific components, but they have not been built against 5.40.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add two CPAN benchmarking modules for isolated forked benchmarks and stopwatch-style timing to the benchmarks collection.

New Features:
- Add the Benchmark-Forking and Benchmark-Stopwatch Perl benchmarking ports.
- Register both benchmarking modules in the benchmarks port collection.

Enhancements:
- Adapt both ports to mports licensing and packaging conventions.