### PR TITLE
dns/bind920: remove obsolete helper header

### DIFF
--- a/dns/bind920/pkg-plist
+++ b/dns/bind920/pkg-plist
@@ -140,7 +140,6 @@ include/isc/getaddresses.h
 include/isc/hash.h
 include/isc/hashmap.h
 include/isc/heap.h
-include/isc/helper.h
 include/isc/hex.h
 include/isc/histo.h
 include/isc/hmac.h


### PR DESCRIPTION
## Summary

- remove `include/isc/helper.h` from `pkg-plist`
- align the plist with BIND 9.20.26, which no longer installs that header
- restore package creation

## Validation

- `BATCH=yes bmake makesum`
- clean `BATCH=yes bmake patch`
- clean `BATCH=yes bmake`
- clean `BATCH=yes bmake fake`
- clean `BATCH=yes bmake package`
- `BATCH=yes bmake test` (target exited successfully without substantive test output)
- `BATCH=yes bmake check-license`
- `portlint -AC dns/bind920`

Package created successfully as `bind920-9.20.26.mport`. Existing fake-qa stripping, dependency, and ineffective `REINPLACE_CMD` warnings are unchanged and outside this plist-only fix.

## Summary by Sourcery

Bug Fixes:
- Remove the obsolete BIND helper header from the package plist so bind920 packages can be created successfully with BIND 9.20.26.