### PR TITLE
databases/postgresql18-server: fix fake installation

### DIFF
--- a/databases/postgresql18-server/Makefile
+++ b/databases/postgresql18-server/Makefile
@@ -222,28 +222,28 @@ post-patch:
 do-install:
 	for dir in ${INSTALL_DIRS}; do \
 	    cd ${WRKSRC}/$${dir} && \
-		${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${MAKE_CMD} ${MAKE_ARGS} ${INSTALL_TARGET}; \
+		${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${MAKE_CMD} ${MAKE_ARGS} ${FAKE_MAKEARGS} ${INSTALL_TARGET}; \
 	done
 .  if defined(SERVER_ONLY)
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/postgresql/*.so
-	${MKDIR} ${STAGEDIR}${PREFIX}/share/postgresql
-	${MKDIR} ${STAGEDIR}${PREFIX}/etc/periodic/daily
+	${STRIP_CMD} ${PREFIX}/lib/postgresql/*.so
+	${MKDIR} ${PREFIX}/share/postgresql
+	${MKDIR} ${PREFIX}/etc/periodic/daily
 	${INSTALL_SCRIPT} ${WRKDIR}/502.pgsql \
-			${STAGEDIR}${PREFIX}/etc/periodic/daily
+			${PREFIX}/etc/periodic/daily
 .  endif # SERVER_ONLY
 .  if defined(CLIENT_ONLY)
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/bin/* ${STAGEDIR}${PREFIX}/lib/lib*.so
-	cd ${WRKSRC}/src && ${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${MAKE_CMD} ${MAKE_ARGS} install-local
+	${STRIP_CMD} ${PREFIX}/bin/* ${PREFIX}/lib/lib*.so
+	cd ${WRKSRC}/src && ${SETENVI} ${WRK_ENV} ${MAKE_ENV} ${MAKE_CMD} ${MAKE_ARGS} ${FAKE_MAKEARGS} install-local
 .    if ${DISTVERSION:C/([0-9][0-9]).*/\1/g} >= 17
-	cd ${WRKSRC}/doc/src/sgml && ${COPYTREE_SHARE} "man1 man3 man7" ${STAGEDIR}${PREFIX}/share/man
+	cd ${WRKSRC}/doc/src/sgml && ${COPYTREE_SHARE} "man1 man3 man7" ${PREFIX}/share/man
 .    endif
 .  endif
 .  if defined(SLAVE_ONLY)
-	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/postgresql/*.so
+	${STRIP_CMD} ${PREFIX}/lib/postgresql/*.so
 .  endif
 	if [ -r ${PKGMESSAGE} ]; then \
-		${MKDIR} ${STAGEDIR}${DOCSDIR} ;\
-		${INSTALL_DATA} ${PKGMESSAGE} ${STAGEDIR}${DOCSDIR}/README${COMPONENT} ;\
+		${MKDIR} ${DOCSDIR} ;\
+		${INSTALL_DATA} ${PKGMESSAGE} ${DOCSDIR}/README${COMPONENT} ;\
 	fi
 .endif # !NO_BUILD
 


### PR DESCRIPTION
## Summary

- pass the mports fake-install arguments to PostgreSQL install targets
- use fake-adjusted PREFIX and DOCSDIR paths exactly once
- fix the shared staging logic used by PostgreSQL 15 and 16 clients

## Magus failures

- postgresql15-client, ID 2249593, amd64: fake failed when strip received a duplicated fake-root path
- postgresql16-client, ID 2249601, amd64: same failure
- analyzer classification: Partially supported; it identified the duplicated staging path but missed the omitted FAKE_MAKEARGS

## Validation

- postgresql15-client 15.18: build, fake, and package passed
- postgresql16-client 16.14: build, fake, and package passed
- check-license passed for both clients
- client test targets exited successfully; no substantive client tests were defined
- git diff --check passed
- portlint was run and reports pre-existing formatting and plist findings in the shared port

## Summary by Sourcery

Fix PostgreSQL fake-install staging so server and client packages install, strip, and stage files under the correct paths.

Bug Fixes:
- Fix fake installation of PostgreSQL server and client components by propagating fake-install arguments to all relevant install targets.
- Prevent duplicated fake-root paths during stripping and staging of PostgreSQL files.
- Correct shared staging behavior for PostgreSQL 15 and 16 clients.