### PR TITLE
mail/dovecot24: select Python for installed helper

### DIFF
--- a/mail/dovecot24/Makefile
+++ b/mail/dovecot24/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	dovecot24
 PORTVERSION=	2.4.4
-PORTREVISION=	2
+PORTREVISION=	3
 CATEGORIES=	mail
 MASTER_SITES=	https://dovecot.org/releases/2.4/
 DISTNAME=	dovecot-${PORTVERSION}
@@ -28,7 +28,7 @@ pgsql_PKGNAMESUFFIX=	-pgsql
 
 LIB_DEPENDS=	libzstd.so:archivers/zstd
 
-USES=		cpe iconv libtool pkgconfig shebangfix ssl
+USES=		cpe iconv libtool pkgconfig python:run shebangfix ssl
 CPE_PRODUCT=	dovecot
 SHEBANG_FILES=	src/lib-settings/settings-history.py
 USE_RC_SUBR=	dovecot


### PR DESCRIPTION
## Summary

- add the Python runtime extension so shebangfix selects the versioned interpreter
- bump PORTREVISION to rebuild all Dovecot 2.4 flavors
- fix fake-qa failures for Magus IDs 2255253, 2255254, and 2255255

## Root cause

The existing shebangfix declaration rewrote the upstream python3 shebang to /usr/local/bin/python because no Python version was selected. Magus rejects that unversioned interpreter during fake QA. With python:run, the staged helper uses /usr/local/bin/python3.12 and records the lang/python312 runtime dependency.

The analyzer was partially supported: it identified the shebang area but recommended shebangfix, which was already present, and missed the missing Python runtime selection.

## Validation

- default flavor: clean, patch, build, fake, package passed
- mysql flavor: clean, patch, build, fake, package passed
- pgsql flavor: clean, patch, build, fake, package passed
- all three packages contain #!/usr/local/bin/python3.12 in settings-history.py
- check-license passed
- test target exited successfully; no substantive test commands were defined
- portlint: 0 fatal errors, 7 pre-existing warnings
- git diff --check passed

## Summary by Sourcery

Select the versioned Python runtime for Dovecot's installed helper script.

Bug Fixes:
- Ensure the Dovecot settings-history helper uses a versioned Python interpreter and declares the corresponding runtime dependency, fixing fake-QA failures.

Build:
- Bump PORTREVISION to rebuild all Dovecot 2.4 flavors.