### PR TITLE
ai/claude-code: update to 2.1.243

### DIFF
--- a/ai/claude-code/Makefile
+++ b/ai/claude-code/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	claude-code
-DISTVERSION=	2.1.241
+DISTVERSION=	2.1.243
 CATEGORIES=	ai linux
 MASTER_SITES=	https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/
 DISTNAME=	claude-code-linux-x64-${DISTVERSION}

--- a/ai/claude-code/distinfo
+++ b/ai/claude-code/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1787462351
-SHA256 (claude-code-linux-x64-2.1.241.tgz) = f96dcac778c84318f07beab37056948c076e00412afdc8a3b8d052312a5d8e34
-SIZE (claude-code-linux-x64-2.1.241.tgz) = 102154556
+TIMESTAMP = 1787833384
+SHA256 (claude-code-linux-x64-2.1.243.tgz) = 7acea1730de569f8d28594e5ba50891a07edda1bceb6ad512bda9e182122e54c
+SIZE (claude-code-linux-x64-2.1.243.tgz) = 119883709


### PR DESCRIPTION
## Summary
- update Claude Code from 2.1.241 to 2.1.243
- refresh the distfile checksum and size

Note: npm currently advertises 2.1.247 as latest; this PR intentionally preserves the submitted 2.1.243 update.

## Validation
- `bmake check-license`
- `bmake clean patch`
- `bmake build fake package`
- `git diff --check`
- `portlint -C` (0 fatal errors; 5 pre-existing style warnings)

## Summary by Sourcery

Update the Claude Code port to release 2.1.243.

Enhancements:
- Update the packaged Claude Code release to version 2.1.243.

Chores:
- Refresh the distfile metadata for the updated release.