### PR TITLE
sysutils/zellij: avoid staged path in binary

### DIFF
--- a/sysutils/zellij/Makefile
+++ b/sysutils/zellij/Makefile
@@ -13,8 +13,6 @@ LICENSE_FILE=	${WRKSRC}/LICENSE.md
 ONLY_FOR_ARCHS=	aarch64 amd64
 ONLY_FOR_ARCHS_REASON=	wasmer-vm crate currently only supports aarch64 and amd64
 
-SKIP_FAKE_ALL=  yes
-
 LIB_DEPENDS=	libcurl.so:ftp/curl \
 		libzstd.so:archivers/zstd
 
@@ -526,5 +524,9 @@ CARGO_CRATES=	addr2line-0.17.0 \
 		zstd-0.13.1 \
 		zstd-safe-7.1.0 \
 		zstd-sys-2.0.10+zstd.1.5.6
+
+do-install:
+	${INSTALL_PROGRAM} ${CARGO_TARGET_DIR}/${CARGO_BUILD_TARGET}/release/zellij \
+		${PREFIX}/bin/zellij
 
 .include <bsd.port.mk>


### PR DESCRIPTION
## Summary
- install the release artifact built with the real prefix
- avoid rebuilding Zellij during fake install with the staging prefix
- remove the ineffective SKIP_FAKE_ALL workaround

This fixes the fake-QA failure from Magus port 2257920, where bin/zellij contained the fake installation path.

## Validation
- BATCH=yes bmake clean patch
- BATCH=yes bmake build
- BATCH=yes bmake fake package
- staged binary contains no fake installation path
- staged zellij --version reports 0.42.2
- BATCH=yes bmake test (0 failed; 38 ignored upstream end-to-end tests)
- portlint -C sysutils/zellij (0 fatal errors; maintainer-mode warning only)
- git diff --check

## Summary by Sourcery

Install Zellij without rebuilding it under the staging prefix to prevent staged binaries from containing fake paths.

Bug Fixes:
- Install the release-built Zellij binary directly so staged packages no longer embed the fake installation prefix.

Enhancements:
- Remove the ineffective SKIP_FAKE_ALL workaround.