### PR TITLE
ai/claude-code: update to 2.1.248

### DIFF
--- a/ai/claude-code/Makefile
+++ b/ai/claude-code/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	claude-code
-DISTVERSION=	2.1.243
+DISTVERSION=	2.1.248
 CATEGORIES=	ai linux
 MASTER_SITES=	https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/
 DISTNAME=	claude-code-linux-x64-${DISTVERSION}

--- a/ai/claude-code/distinfo
+++ b/ai/claude-code/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1787833384
-SHA256 (claude-code-linux-x64-2.1.243.tgz) = 7acea1730de569f8d28594e5ba50891a07edda1bceb6ad512bda9e182122e54c
-SIZE (claude-code-linux-x64-2.1.243.tgz) = 119883709
+TIMESTAMP = 1787931243
+SHA256 (claude-code-linux-x64-2.1.248.tgz) = 9477cc891be320ee6648ca2fcf9f1083b0b42d89e7387394e8aa9bd9e9d089d0
+SIZE (claude-code-linux-x64-2.1.248.tgz) = 95519947


### PR DESCRIPTION
## Summary
- update Claude Code from 2.1.243 to 2.1.248
- refresh the npm tarball checksum and size

## Validation
- BATCH=yes bmake makesum
- BATCH=yes bmake clean patch
- BATCH=yes bmake
- BATCH=yes bmake fake package
- BATCH=yes bmake test
- staged binary: 2.1.248 (Claude Code)
- xz -t Packages/amd64/All/claude-code-2.1.248.mport
- BATCH=yes bmake check-license
- portlint -C ai/claude-code (0 fatal errors; 5 pre-existing warnings)
- git diff --check

## Summary by Sourcery

Update the Claude Code port to the 2.1.248 release.

Enhancements:
- Update the packaged Claude Code release to version 2.1.248.

Chores:
- Refresh the npm distribution metadata for the updated release.