### PR TITLE
magus: clear file flags before resetting slave chroot directories

### DIFF
--- a/Tools/lib/Magus/Chroot.pm
+++ b/Tools/lib/Magus/Chroot.pm
@@ -191,7 +191,12 @@ sub _create_reference_dir {
   }
     
   if (-e $self->{refdir}) {
-    rmtree($self->{refdir}) || die "Couldn't delete $self->{refdir} $!\n";
+    # The bootstrap tarball carries schg/uchg files (libc, ld-elf.so, init,
+    # su, ...).  Without clearing the flags first rmtree() and the following
+    # tar both fail with EPERM and we end up extracting over a stale tree.
+    $self->_clear_flags_path($self->{refdir});
+    rmtree($self->{refdir});
+    die "Couldn't delete $self->{refdir}: $!\n" if -e $self->{refdir};
   }
   
   mkpath($self->{refdir});
@@ -610,9 +615,11 @@ sub _clean {
   return $self->_clean_zfs if $self->{zfs};
 
   $self->_unmount_loopbacks;
-  
-  #$self->_clear_flags("/");
-  
+
+  # cpdup cannot replace schg/uchg files left behind by a build, so drop the
+  # flags before re-syncing the reference dir over this chroot.
+  $self->_clear_flags("/");
+
   $self->_sync_reference_dir;
   $self->_mount_loopbacks;
 }
@@ -621,7 +628,16 @@ sub _clean {
 sub _clear_flags {
   my ($self, $dir) = @_;
 
-  $self->_run_command('/bin/chflags', '-R', '0', "$self->{root}$dir")
+  $self->_clear_flags_path("$self->{root}$dir");
+}
+
+
+sub _clear_flags_path {
+  my ($self, $path) = @_;
+
+  return unless -e $path;
+
+  $self->_run_command('/bin/chflags', '-R', '0', $path)
     or die "/bin/chflags returned non-zero: $?\n";
 }
   

--- a/Tools/lib/Magus/Chroot.pm
+++ b/Tools/lib/Magus/Chroot.pm
@@ -614,7 +614,9 @@ sub _clean {
 
   return $self->_clean_zfs if $self->{zfs};
 
-  $self->_unmount_loopbacks;
+  # Strict: the recursive chflags below must not descend into a loopback that
+  # failed to unmount, and cpdup must not sync over one either.
+  $self->_unmount_loopbacks(1);
 
   # cpdup cannot replace schg/uchg files left behind by a build, so drop the
   # flags before re-syncing the reference dir over this chroot.


### PR DESCRIPTION
## Problem

On slave startup, `Magus::Chroot::_create_reference_dir` fails to reset the `reference` directory. The bootstrap tarball carries `schg`/`uchg` files (`libc.so.7`, `ld-elf.so.1`, `init`, `su`, `usr/lib32/*`, ...), so `rmtree` cannot unlink them:

```
cannot unlink file for /usr/magus/slave-data/chroots/4.0.7/reference/usr/lib32/libcrypt.so.5: Operation not permitted at .../Magus/Chroot.pm line 194.
cannot remove directory for /usr/magus/slave-data/chroots/4.0.7/reference: Directory not empty at .../Magus/Chroot.pm line 194.
lib/libc.so.7: Can't unlink already-existing object: Operation not permitted
tar: Error exit delayed from previous errors
Couldn't untar root tarball: 256
```

`rmtree()` returns the count of entries it *did* remove, so the existing `rmtree(...) || die` never fired on a partial removal. Startup fell through to `tar`, which extracted over the stale tree and failed with the second wave of errors.

## Changes

- `_create_reference_dir`: clear file flags before `rmtree`, and verify the directory is actually gone rather than relying on `rmtree`'s return value.
- `_clean`: restore the `_clear_flags("/")` call that was commented out. `cpdup` in `_sync_reference_dir` hits the same `EPERM` on any flagged file a build left in the worker chroot (the `1` directory). Loopbacks are unmounted first, so the recursive `chflags` does not walk into `/usr/mports` or `/usr/src`.
- New `_clear_flags_path` helper taking an absolute path; `_clear_flags` delegates to it. No-ops when the path is absent.

`chflags -R 0` matches the existing convention in this file (already used by `delete`) and clears the whole set, including `uchg`, `sunlnk`, and `uunlnk`, which block unlink just as `schg` does.

## Testing

`perl -c Tools/lib/Magus/Chroot.pm` passes. Not exercised against a live magus slave.

Note: `chflags` cannot clear `schg` at `kern.securelevel >= 1`. On such a machine this still fails, but with a clear `/bin/chflags returned non-zero` instead of the confusing `rmtree`/`tar` cascade.

## Summary by Sourcery

Clear filesystem flags before resetting Magus chroot directories so reference extraction and worker synchronization complete reliably.

Bug Fixes:
- Ensure flagged files and directories can be removed when resetting reference and worker chroots, preventing stale trees from causing startup and synchronization failures.

Enhancements:
- Verify reference directory removal succeeded instead of relying on the number of entries removed by recursive deletion.
- Centralize recursive file-flag clearing with support for absent paths.