### PR TITLE
devel/jenkins: update to 2.580

### DIFF
--- a/devel/jenkins/Makefile
+++ b/devel/jenkins/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	jenkins
-PORTVERSION=	2.570
+PORTVERSION=	2.580
 CATEGORIES=	devel java
 MASTER_SITES=	https://get.jenkins.io/war/${PORTVERSION}/
 DISTNAME=	jenkins

--- a/devel/jenkins/distinfo
+++ b/devel/jenkins/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782391729
-SHA256 (jenkins/2.570/jenkins.war) = 64404d9b406dba0f6276791393748dddff6944c2d8d82afaef3a86d9667eeceb
-SIZE (jenkins/2.570/jenkins.war) = 101117615
+TIMESTAMP = 1788474380
+SHA256 (jenkins/2.580/jenkins.war) = 2b4f2ce66f0db92b9e65a96d02c34f1ad31ee0a9ae809334894e946d34c73a09
+SIZE (jenkins/2.580/jenkins.war) = 53729873


### PR DESCRIPTION
## Summary

Updates the Jenkins weekly line from 2.570 to 2.580.

## Upstream packaging change

Jenkins stopped bundling detached plugins in the war. 2.570 shipped 48 `.hpi` files under `WEB-INF/detached-plugins/`; 2.580 ships none — the directory is gone entirely. That accounts for the distfile shrinking from 101MB to 53MB, which is a real upstream change rather than a truncated download (verified against upstream's published `jenkins.war.sha256`).

Practical effect: existing installs keep the plugins already present in `JENKINS_HOME` and are unaffected. A **fresh** install now pulls those plugins from the Jenkins update center on first run, so a new setup needs network access to reach a usable state.

`JAVA_VERSION=21+` is unchanged and still correct.

## Validation

- `bmake makesum` — SHA256 `2b4f2ce6…` matches upstream's published `jenkins.war.sha256` byte-for-byte
- `bmake package` — `jenkins-2.580.mport` built, fake-qa passed, pkg-plist unchanged and still correct
- staged war smoke-tested: `java -jar .../jenkins.war --version` under `openjdk21` reports `2.580`
- war manifest confirms `Jenkins-Version: 2.580`
- `portlint -AC`: 0 fatal errors (5 pre-existing warnings)

AI-Assisted-by: Claude Opus 5 <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Update the Jenkins weekly package to version 2.580 and its upstream distribution metadata.