### PR TITLE
devel/jenkins-lts: update to 2.568.3

### DIFF
--- a/devel/jenkins-lts/Makefile
+++ b/devel/jenkins-lts/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	jenkins
-PORTVERSION=	2.555.3
+PORTVERSION=	2.568.3
 CATEGORIES=	devel java
 MASTER_SITES=	https://get.jenkins.io/war-stable/${PORTVERSION}/
 PKGNAMESUFFIX=	-lts

--- a/devel/jenkins-lts/distinfo
+++ b/devel/jenkins-lts/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1781100795
-SHA256 (jenkins/2.555.3/jenkins.war) = 5d19905e6c0f23aff89ff007de5564b96e0a05c13f4d1a92d0fdcb69b033bb9a
-SIZE (jenkins/2.555.3/jenkins.war) = 99983837
+TIMESTAMP = 1788474496
+SHA256 (jenkins/2.568.3/jenkins.war) = ccdbfdceade83489e34285a4d57c12134ffea0a09ca20062282e580cbfa5f09e
+SIZE (jenkins/2.568.3/jenkins.war) = 101130898


### PR DESCRIPTION
## Summary

Updates the Jenkins LTS line from 2.555.3 to 2.568.3.

Unlike the 2.580 weekly (#816), the LTS war **still bundles** the 48 detached plugins under `WEB-INF/detached-plugins/`, so the distfile stays at ~101MB and a fresh install does not need the update center to reach a usable state. Worth knowing when the two ports are compared side by side.

`JAVA_VERSION=21+` is unchanged and still correct.

## Validation

- `bmake makesum` — SHA256 `ccdbfdce…` matches upstream's published `jenkins.war.sha256` byte-for-byte
- `bmake package` — `jenkins-lts-2.568.3.mport` built, fake-qa passed, pkg-plist unchanged and still correct
- staged war smoke-tested: `java -jar .../jenkins.war --version` under `openjdk21` reports `2.568.3`
- 48 bundled `.hpi` plugins confirmed present in the staged war
- `portlint -AC`: 0 fatal errors (5 pre-existing warnings)

AI-Assisted-by: Claude Opus 5 <noreply@anthropic.com>

## Summary by Sourcery

Enhancements:
- Update the Jenkins LTS port to version 2.568.3 while retaining the existing Java 21+ requirement and bundled plugin behavior.