### PR TITLE
mail/thunderbird: update to 155.0

### DIFF
--- a/mail/thunderbird/Makefile
+++ b/mail/thunderbird/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	thunderbird
-DISTVERSION=	154.0
+DISTVERSION=	155.0
 PORTREVISION=	0
 CATEGORIES=	mail news net-im wayland
 MASTER_SITES=	MOZILLA/${PORTNAME}/releases/${DISTVERSION}${DISTVERSIONSUFFIX}/source \
@@ -15,7 +15,7 @@ LICENSE=	MPL20
 CONFLICTS_INSTALL=	thunderbird-esr
 
 BUILD_DEPENDS=	nspr>=4.32:devel/nspr \
-		nss>=3.126:security/nss \
+		nss>=3.127:security/nss \
 		libevent>=2.1.8:devel/libevent \
 		harfbuzz>=10.1.0:print/harfbuzz \
 		graphite2>=1.3.14:graphics/graphite2 \
@@ -29,7 +29,7 @@ BUILD_DEPENDS=	nspr>=4.32:devel/nspr \
 		zip:archivers/zip \
 		clang19:devel/llvm19 \
 		cargo:lang/rust \
-		rust-cbindgen>=0.29.1:devel/rust-cbindgen
+		rust-cbindgen>=0.29.4:devel/rust-cbindgen
 
 LIB_DEPENDS+=	libvpx.so:multimedia/libvpx \
 		libevent.so:devel/libevent \

--- a/mail/thunderbird/distinfo
+++ b/mail/thunderbird/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1787716889
-SHA256 (thunderbird-154.0.source.tar.xz) = d22a5f24549a95ca1e729fbff3e24376b1d2e7eca4a66ba46e20e4e54c54b894
-SIZE (thunderbird-154.0.source.tar.xz) = 950250240
+TIMESTAMP = 1788476214
+SHA256 (thunderbird-155.0.source.tar.xz) = 116a5eff70f3405f62247960ac6ca7c781ae99f313c5fc499c9c93b21f28b242
+SIZE (thunderbird-155.0.source.tar.xz) = 948065880

--- a/mail/thunderbird/pkg-plist
+++ b/mail/thunderbird/pkg-plist
@@ -2,7 +2,7 @@ bin/thunderbird
 share/pixmaps/thunderbird.png
 share/applications/thunderbird.desktop
 lib/thunderbird/rnp-cli
-lib/thunderbird/vaapitest
+lib/thunderbird/gfxtest
 lib/thunderbird/librnp.so
 lib/thunderbird/dependentlibs.list
 lib/thunderbird/defaults/messenger/mailViews.dat
@@ -19,7 +19,6 @@ lib/thunderbird/isp/SpamAssassin.sfd
 lib/thunderbird/isp/SpamPal.sfd
 lib/thunderbird/isp/Bogofilter.sfd
 lib/thunderbird/isp/POPFile.sfd
-lib/thunderbird/glxtest
 lib/thunderbird/libmozwayland.so
 lib/thunderbird/chrome/icons/default/msgcomposeWindow16.png
 lib/thunderbird/chrome/icons/default/default32.png


### PR DESCRIPTION
Update Thunderbird from 154.0 to 155.0 (current release channel; 154.0 was superseded directly, with no 154.0.x point release).

## Changes

- `DISTVERSION` 154.0 → 155.0; `distinfo` regenerated. The SHA256 matches Mozilla's published `SHA256SUMS` for `thunderbird-155.0.source.tar.xz`.
- `nss` floor 3.126 → 3.127. 155.0 bundles `NSS_3_127_RTM`, and `build/moz.configure/nss.configure` derives the `--with-system-nss` pkg-config floor from that tag.
- `rust-cbindgen` floor 0.29.1 → 0.29.4, per `build/moz.configure/bindgen.configure`.
- `pkg-plist`: upstream merged `glxtest` and `vaapitest` into a single `gfxtest` binary (`toolkit/xre/moz.build`), so those two entries are replaced by one.

Rust (min 1.90, tree has 1.95), node (min 12.22), and the harfbuzz/png/dav1d floors were checked against the 155.0 source and needed no change.

## Testing

- All 31 patches in `files/` apply without fuzz — no refreshes needed.
- `bmake makesum`, `bmake patch`, `bmake`, `bmake fake`, `bmake package` all succeed on amd64.
- Staged binary reports `Mozilla Thunderbird 155.0`.
- `portlint -AC`: only pre-existing warnings on untouched patch files, plus the leftover `work/` directory.

The port has `--disable-tests`, so there is no upstream test suite to run.

## Summary by Sourcery

Update the Thunderbird port to version 155.0 and align its dependencies and packaged files with the new release.

Enhancements:
- Update Thunderbird to the 155.0 release with the corresponding dependency requirements.
- Align the package contents with upstream’s consolidated graphics test binary.

Chores:
- Regenerate the source archive checksum for Thunderbird 155.0.