### PR TITLE
textproc/py-textual: update to 8.2.8

### DIFF
--- a/textproc/py-textual/Makefile
+++ b/textproc/py-textual/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	textual
-PORTVERSION=	6.12.0
-PORTREVISION=	1
+PORTVERSION=	8.2.8
 CATEGORIES=	textproc python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -13,9 +12,10 @@ LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}poetry-core>=1.2.0:devel/py-poetry-core@${PY_FLAVOR}
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}markdown-it-py>=2.1.0:textproc/py-markdown-it-py@${PY_FLAVOR} \
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}linkify-it-py>=1<3:textproc/py-linkify-it-py@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}markdown-it-py>=2.1.0:textproc/py-markdown-it-py@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}mdit-py-plugins>=0:textproc/py-mdit-py-plugins@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}platformdirs>=4.2.2<5:devel/py-platformdirs@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}platformdirs>=3.6.0<5:devel/py-platformdirs@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}pygments>=2.19.2<3:textproc/py-pygments@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}rich>=14.2.0:textproc/py-rich@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}typing-extensions>=4.4.0<5:devel/py-typing-extensions@${PY_FLAVOR}
@@ -24,11 +24,5 @@ USES=		python
 USE_PYTHON=	allflavors autoplist concurrent pep517
 
 NO_ARCH=	yes
-
-OPTIONS_DEFINE=	SYNTAX
-SYNTAX_DESC=	Syntax support
-
-SYNTAX_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}tree-sitter>=0.20.1<0.21:devel/py-tree-sitter@${PY_FLAVOR} \
-			${PYTHON_PKGNAMEPREFIX}tree-sitter-languages>=1.10.2<1.10.2.99:devel/py-tree-sitter-languages@${PY_FLAVOR}
 
 .include <bsd.port.mk>

--- a/textproc/py-textual/distinfo
+++ b/textproc/py-textual/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1768625753
-SHA256 (textual-6.12.0.tar.gz) = a32e8edbf6abdb0c42d486e96bdf419eb3aa378edb1b1271b84637f3dbd64c73
-SIZE (textual-6.12.0.tar.gz) = 1584182
+TIMESTAMP = 1788591728
+SHA256 (textual-8.2.8.tar.gz) = 3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b
+SIZE (textual-8.2.8.tar.gz) = 1860502


### PR DESCRIPTION
Update textual from 6.12.0 to 8.2.8.

- platformdirs floor lowered 4.2.2 -> 3.6.0 to match upstream.
- py-linkify-it-py added to RUN_DEPENDS: upstream declares
  markdown-it-py[linkify], and textproc/py-markdown-it-py does not pull
  it in itself.
- SYNTAX option removed. It depended on devel/py-tree-sitter-languages,
  which does not exist in the tree at all, so the option was already
  broken. Textual 8 replaces that with 16 separate tree-sitter grammar
  packages, of which only py-tree-sitter and py-tree-sitter-bash exist
  here.

ai/py-mistral-vibe is the only consumer of this port, and it targets
the textual 8 API; its textual-6.12 compatibility patch is removed in
the corresponding mistral-vibe update.

Validated on MidnightBSD 4.0.6/amd64: makesum, patch, build, fake,
package, portlint (0 fatal). Upstream test suite not run; it needs
pytest-textual-snapshot, which is not in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2ugt5KT9NMJdaWjhe2PUu

## Summary by Sourcery

Update py-textual to the 8.2.8 release and align its dependencies and supported configuration with the available ports.

Enhancements:
- Update the Textual port to version 8.2.8 and align its runtime dependencies with the upstream release.
- Remove the unavailable, broken optional syntax-support configuration.