### PR TITLE
devel/py-tree-sitter: update to 0.26.0

### DIFF
--- a/devel/py-tree-sitter/Makefile
+++ b/devel/py-tree-sitter/Makefile
@@ -1,9 +1,9 @@
 PORTNAME=	tree-sitter
-PORTVERSION=	0.25.2
-PORTREVISION=	1
+PORTVERSION=	0.26.0
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+DISTNAME=	tree_sitter-${PORTVERSION}
 
 MAINTAINER=	pat@patmaddox.com
 COMMENT=	Python bindings to the Tree-sitter parsing library

--- a/devel/py-tree-sitter/distinfo
+++ b/devel/py-tree-sitter/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782220686
-SHA256 (tree-sitter-0.25.2.tar.gz) = fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20
-SIZE (tree-sitter-0.25.2.tar.gz) = 177961
+TIMESTAMP = 1788591797
+SHA256 (tree_sitter-0.26.0.tar.gz) = b40c219edccc4564530c96f8f1556f6202b37cda964d1cbd7bd2b7e68b40a245
+SIZE (tree_sitter-0.26.0.tar.gz) = 191423


### PR DESCRIPTION
Update tree-sitter from 0.25.2 to 0.26.0.

DISTNAME added: upstream moved to the PEP 625 normalized sdist name
tree_sitter-0.26.0.tar.gz.

No dependency changes; the runtime dependency set is empty in both
versions.

No PORTREVISION bumps needed for consumers. The tree-sitter C core is
vendored and statically linked into the extension (ldd shows only
libc.so.7), so the port exports no shared library for other ports to
link against, and TREE_SITTER_LANGUAGE_VERSION is 15 with
min-compatible 13 in both 0.25.2 and 0.26.0, so already-compiled
grammars such as devel/py-tree-sitter-bash stay loadable.

Required by ai/py-mistral-vibe 2.20.0 and later.

Validated on MidnightBSD 4.0.6/amd64: makesum, build, fake, package,
portlint (0 fatal). Built extension confirmed as an amd64 ELF shared
object. Upstream tests not run; they need five tree-sitter grammar
packages that are not in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2ugt5KT9NMJdaWjhe2PUu

## Summary by Sourcery

Update the py-tree-sitter port to 0.26.0.

Enhancements:
- Update the Python Tree-sitter bindings port to version 0.26.0 while preserving its existing dependency and compatibility characteristics.

Chores:
- Use the normalized PyPI source distribution name for the updated release.