### PR TITLE
x11-toolkits/qt5-gamepad: make the SDL2 backend an option

### DIFF
--- a/x11-toolkits/qt5-gamepad/Makefile
+++ b/x11-toolkits/qt5-gamepad/Makefile
@@ -12,6 +12,18 @@ USES=		compiler:c++11-lang perl5 qmake:norecursive qt-dist:5,gamepad
 USE_PERL5=	build
 USE_QT=		core declarative gui buildtools:build
 
+# The sdl2 backend is auto-detected via pkg-config, so without an explicit
+# switch the plugin is built only when sdl2 happens to be installed on the
+# builder, and it is not in the packing list either way.  Pin the feature to
+# the option so the package is reproducible.
+OPTIONS_DEFINE=		SDL2
+OPTIONS_SUB=		yes
+
+SDL2_DESC=		SDL2 gamepad backend
+SDL2_LIB_DEPENDS=	libSDL2.so:devel/sdl20
+SDL2_VARS=		QMAKE_CONFIGURE_ARGS+=--feature-sdl2
+SDL2_VARS_OFF=		QMAKE_CONFIGURE_ARGS+=--no-feature-sdl2
+
 post-install:
 	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake

--- a/x11-toolkits/qt5-gamepad/pkg-plist
+++ b/x11-toolkits/qt5-gamepad/pkg-plist
@@ -17,6 +17,7 @@
 %%QT_CMAKEDIR%%/Qt5Gamepad/Qt5GamepadConfig.cmake
 %%QT_CMAKEDIR%%/Qt5Gamepad/Qt5GamepadConfigVersion.cmake
 %%QT_CMAKEDIR%%/Qt5Gamepad/Qt5Gamepad_QEvdevGamepadBackendPlugin.cmake
+%%SDL2%%%%QT_CMAKEDIR%%/Qt5Gamepad/Qt5Gamepad_QSdl2GamepadBackendPlugin.cmake
 %%QT_LIBDIR%%/libQt5Gamepad.prl
 %%QT_LIBDIR%%/libQt5Gamepad.so
 %%QT_LIBDIR%%/libQt5Gamepad.so.5
@@ -27,6 +28,8 @@
 %%QT_MKSPECDIR%%/modules/qt_lib_gamepad_private.pri
 %%QT_PLUGINDIR%%/gamepads/libevdevgamepad.so
 %%DEBUG%%%%QT_PLUGINDIR%%/gamepads/libevdevgamepad.so.debug
+%%SDL2%%%%QT_PLUGINDIR%%/gamepads/libsdl2gamepad.so
+%%SDL2%%%%DEBUG%%%%QT_PLUGINDIR%%/gamepads/libsdl2gamepad.so.debug
 %%QT_QMLDIR%%/QtGamepad/libdeclarative_gamepad.so
 %%DEBUG%%%%QT_QMLDIR%%/QtGamepad/libdeclarative_gamepad.so.debug
 %%QT_QMLDIR%%/QtGamepad/plugins.qmltypes


### PR DESCRIPTION
## Problem

qtgamepad auto-detects sdl2 through pkg-config (`src/gamepad/configure.json` defines the `sdl2` feature with `"condition": "libs.sdl2"`), so `src/plugins/gamepads/gamepads.pro` builds the sdl2 backend whenever sdl2 happens to be installed on the builder and skips it otherwise.

The plugin was never listed in `pkg-plist`, so it was built and then thrown away. On any host with sdl2 installed, `bmake check-fake` reported:

```
/usr/local/lib/qt5/plugins/gamepads/libsdl2gamepad.so is missing from the plist
/usr/local/lib/cmake/Qt5Gamepad/Qt5Gamepad_QSdl2GamepadBackendPlugin.cmake is missing from the plist
```

FreeBSD's port has the same shape, which is why this has gone unnoticed — clean poudriere/Magus builders don't have sdl2 installed, so the plugin never gets built there.

## Fix

Add an `SDL2` option, **off by default**, that pins the feature explicitly instead of leaving it to detection, and list the two files under `%%SDL2%%`. This follows the backend-option pattern already used by `accessibility/qt5-speech`.

Off by default keeps parity with what Magus and FreeBSD actually ship today (evdev only), while letting users who want SDL2 gamepad support opt in and get a correct package.

## No PORTREVISION bump

The default package is unchanged. A builder without sdl2 never built the plugin; a builder with sdl2 built it but left it out of the package. Packaged contents were evdev-only either way.

## Validation (amd64, on a host that **does** have sdl2 installed)

| Build | Result |
|---|---|
| default | only `libevdevgamepad.so` staged; no sdl2 plugin, no Sdl2 cmake file; package has **0** sdl2 entries |
| `OPTIONS_SET=SDL2` | both plugins staged; `LIB_DEPENDS` picks up `libSDL2.so:devel/sdl20`; both sdl2 files land in the package |
| `check-fake`, both | no missing-from-plist entries |

`PLIST_SUB` was checked to flip `SDL2=` between `@comment ` and `""` in the two configurations.

The one remaining `check-fake` orphan, `Qt5GamepadConfig.cmake.bak`, is a separate pre-existing issue across the qt5 ports, addressed in #838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Make the Qt5 Gamepad SDL2 backend an explicit, disabled-by-default option with correct conditional packaging.

New Features:
- Add an opt-in SDL2 gamepad backend for Qt5 Gamepad.

Bug Fixes:
- Prevent the SDL2 backend from being built nondeterministically and omitted from packages when SDL2 is present.

Enhancements:
- Keep SDL2 backend packaging synchronized with the build option while preserving the default evdev-only package.