### PR TITLE
qt5: stop leaving .bak files in the stage dir

### DIFF
--- a/accessibility/qt5-speech/Makefile
+++ b/accessibility/qt5-speech/Makefile
@@ -38,7 +38,7 @@ ALSA_VARS=		QMAKE_CONFIGURE_ARGS+=--feature-flite_alsa
 ALSA_VARS_OFF=		QMAKE_CONFIGURE_ARGS+=--no-feature-flite_alsa
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
                 ${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/comms/qt5-sensors/Makefile
+++ b/comms/qt5-sensors/Makefile
@@ -12,7 +12,7 @@ USE_QT=		core declarative buildtools:build
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 

--- a/devel/qt5-core/Makefile
+++ b/devel/qt5-core/Makefile
@@ -69,7 +69,7 @@ post-install:
 # Cleanup qconfig.h and remove stray '#define QT_NO_FOO'
 	${REINPLACE_CMD} "/#define QT_NO_/d" ${WRKDIR}/qconfig.h
 	${MV} ${WRKDIR}/qconfig.h ${PREFIX}/${QT_INCDIR_REL}/QtCore/qconfig.h
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 

--- a/devel/qt5-dbus/Makefile
+++ b/devel/qt5-dbus/Makefile
@@ -43,7 +43,7 @@ post-install:
 		${SETENV} ${MAKE_ENV} ${MAKE} ${MAKE_FLAGS} ${FAKE_MAKEFLAGS} ${MAKEFILE} \
 		${MAKE_ARGS} ${FAKE_MAKEARGS} ${INSTALL_TARGET}
 .endfor
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5DBus/Qt5DBusConfig.cmake
 
 .include <bsd.port.mk>

--- a/devel/qt5-designer/Makefile
+++ b/devel/qt5-designer/Makefile
@@ -34,7 +34,7 @@ post-install:
 	# The generated .pc file refers to a nonexistent other .pc file
 	${REINPLACE_CMD} -e '/^Requires/s/Qt5UiPlugin//' \
 		${PREFIX}/libdata/pkgconfig/Qt5Designer.pc
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5Designer/Qt5DesignerConfig.cmake
 
 .include <bsd.port.mk>

--- a/devel/qt5-linguist/Makefile
+++ b/devel/qt5-linguist/Makefile
@@ -22,7 +22,7 @@ INSTALL_WRKSRC=	${WRKSRC}/src/${PORTNAME}/${PORTNAME}
 QT_BINARIES=	yes
 
 post-install:
-	-${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	-${SED} -i '' 's|/../../../../|/../../../|g' \
                 ${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 	${INSTALL_DATA} ${BUILD_WRKSRC}/images/icons/linguist-128-32.png \
 		${PREFIX}/share/pixmaps/linguist-qt5.png

--- a/devel/qt5-linguisttools/Makefile
+++ b/devel/qt5-linguisttools/Makefile
@@ -19,7 +19,7 @@ post-patch:
 		${WRKSRC}/src/linguist/linguist.pro
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
                 ${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 .for f in lrelease lupdate
 	${INSTALL_MAN} ${WRKSRC}/src/linguist/${f}/${f}.1 \

--- a/devel/qt5-location/Makefile
+++ b/devel/qt5-location/Makefile
@@ -14,7 +14,7 @@ USE_QT=		concurrent core dbus declarative gui network serialport \
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
                 ${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/devel/qt5-uitools/Makefile
+++ b/devel/qt5-uitools/Makefile
@@ -14,7 +14,7 @@ BUILD_WRKSRC=	${WRKSRC}/src/designer/src/${PORTNAME}
 INSTALL_WRKSRC=	${WRKSRC}/src/designer/src/${PORTNAME}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5UiTools/Qt5UiToolsConfig.cmake
 
 .include <bsd.port.mk>

--- a/graphics/qt5-svg/Makefile
+++ b/graphics/qt5-svg/Makefile
@@ -12,7 +12,7 @@ USE_QT=		core gui widgets buildtools:build
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 

--- a/graphics/qt5-wayland/Makefile
+++ b/graphics/qt5-wayland/Makefile
@@ -25,7 +25,7 @@ USE_XORG=	x11 xcomposite
 QT_BINARIES=	yes
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/multimedia/qt5-multimedia/Makefile
+++ b/multimedia/qt5-multimedia/Makefile
@@ -61,7 +61,7 @@ PULSEAUDIO_VARS_OFF=	QT_CONFIG+=-pulseaudio \
 			QMAKE_CONFIGURE_ARGS+=-no-pulseaudio
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/net/qt5-network/Makefile
+++ b/net/qt5-network/Makefile
@@ -47,7 +47,7 @@ post-install:
 	@cd ${WRKSRC}/src/plugins/bearer/generic && \
 		${SETENV} ${MAKE_ENV} ${MAKE} ${MAKE_FLAGS} ${FAKE_MAKEFLAGS} ${MAKEFILE} \
 		${MAKE_ARGS} ${FAKE_MAKEARGS} ${INSTALL_TARGET}
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 

--- a/net/qt5-networkauth/Makefile
+++ b/net/qt5-networkauth/Makefile
@@ -13,7 +13,7 @@ USE_QT=		core network \
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/textproc/qt5-xmlpatterns/Makefile
+++ b/textproc/qt5-xmlpatterns/Makefile
@@ -14,7 +14,7 @@ USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 QT_BINARIES=	yes
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5XmlPatterns/Qt5XmlPatternsConfig.cmake
 
 .include <bsd.port.mk>

--- a/www/qt5-webchannel/Makefile
+++ b/www/qt5-webchannel/Makefile
@@ -17,7 +17,7 @@ USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 EXTRACT_AFTER_ARGS=	--no-same-owner --no-same-permissions
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -182,7 +182,7 @@ post-install:
 	do \
 		${BRANDELF} -t FreeBSD $$lib ; \
 	done
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/www/qt5-websockets/Makefile
+++ b/www/qt5-websockets/Makefile
@@ -12,7 +12,7 @@ USE_QT=		buildtools:build core network
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-charts/Makefile
+++ b/x11-toolkits/qt5-charts/Makefile
@@ -13,7 +13,7 @@ USE_QT=		core declarative network gui widgets designer \
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-datavis3d/Makefile
+++ b/x11-toolkits/qt5-datavis3d/Makefile
@@ -13,7 +13,7 @@ USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 USES=		compiler:c++11-lang perl5 qmake qt-dist:5,datavis3d
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-declarative-test/Makefile
+++ b/x11-toolkits/qt5-declarative-test/Makefile
@@ -30,7 +30,7 @@ post-patch:
 		${WRKSRC}/src/3rdparty/masm/masm.pri
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-declarative/Makefile
+++ b/x11-toolkits/qt5-declarative/Makefile
@@ -33,7 +33,7 @@ post-patch:
 		${WRKSRC}/src/3rdparty/masm/masm.pri
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 

--- a/x11-toolkits/qt5-gamepad/Makefile
+++ b/x11-toolkits/qt5-gamepad/Makefile
@@ -13,7 +13,7 @@ USE_PERL5=	build
 USE_QT=		core declarative gui buildtools:build
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-quick3d/Makefile
+++ b/x11-toolkits/qt5-quick3d/Makefile
@@ -18,7 +18,7 @@ USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 QT_BINARIES=	yes
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-quickcontrols/Makefile
+++ b/x11-toolkits/qt5-quickcontrols/Makefile
@@ -15,7 +15,7 @@ USE_QT=		core declarative gui widgets \
 USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 
 post-install:
-	-${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	-${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-quickcontrols2/Makefile
+++ b/x11-toolkits/qt5-quickcontrols2/Makefile
@@ -17,7 +17,7 @@ USE_LDCONFIG=	${PREFIX}/${QT_LIBDIR_REL}
 QT_DIST=	${PORTNAME}
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-uiplugin/Makefile
+++ b/x11-toolkits/qt5-uiplugin/Makefile
@@ -17,7 +17,7 @@ INSTALL_WRKSRC=	${WRKSRC}/src/designer/src/${PORTNAME}
 NO_ARCH=	yes
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
                 ${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-virtualkeyboard/Makefile
+++ b/x11-toolkits/qt5-virtualkeyboard/Makefile
@@ -18,7 +18,7 @@ USE_XORG=	xcb
 QMAKE_ARGS=	CONFIG+=disable-layouts
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11-toolkits/qt5-widgets/Makefile
+++ b/x11-toolkits/qt5-widgets/Makefile
@@ -69,7 +69,7 @@ post-install:
 	${INSTALL_DATA} ${BUILD_WRKSRC}/dialogs/images/qtlogo-64.png \
 		${PREFIX}/share/pixmaps/qt5logo.png
 	${RLN} ${QT_BINDIR}/uic ${PREFIX}/bin/uic-qt5
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
 
 .include <bsd.port.mk>

--- a/x11/qt5-x11extras/Makefile
+++ b/x11/qt5-x11extras/Makefile
@@ -12,7 +12,7 @@ USE_QT=		core gui \
 		buildtools:build # syncqt
 
 post-install:
-	${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
+	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5X11Extras/Qt5X11ExtrasConfig.cmake
 
 .include <bsd.port.mk>


### PR DESCRIPTION
## Problem

Thirty qt5 ports rewrite the cmake config files they install, in `post-install`:

```make
${REINPLACE_CMD} 's|/../../../../|/../../../|g' \
	${PREFIX}/lib/cmake/Qt5*/Qt5*Config.cmake
```

`REINPLACE_CMD` is `sed -i.bak`, and during `fake` `${PREFIX}` already includes `${FAKE_DESTDIR}`, so each of these left a `Qt5*Config.cmake.bak` next to the file it edited — inside the staging directory.

The `.bak` files are not in `pkg-plist`, so they were never packaged. The real cost is that `bmake check-fake` printed a missing-from-plist line for every one. Across the tree that is roughly forty lines of noise, which is enough to bury a genuine packing-list error — it is exactly what hid the missing sdl2 backend plugin in `x11-toolkits/qt5-gamepad` (#837).

This block is a MidnightBSD-local addition; FreeBSD's qt5 ports have no equivalent.

## Fix

Use `${SED} -i ''`, already used in ~39 other mports Makefiles. The rewrite itself is unchanged. 30 files, one line each.

Two of the thirty carry a leading `-` to ignore errors; that prefix is preserved.

## No PORTREVISION bumps

The packages are byte-identical. For `graphics/qt5-svg`, the resulting `Qt5SvgConfig.cmake` was diffed against the file produced by the `REINPLACE_CMD` version (still installed from a prior build) and is the same file. Only the `.bak` side effect is gone.

## Validation (amd64)

Built across the three shapes this line takes in the tree:

| Port | Shape | Result |
|---|---|---|
| `graphics/qt5-svg` | glob target | no `.bak` staged; 0 `/../../../../` left in output; `check-fake` completely clean; output byte-identical to before |
| `x11/qt5-x11extras` | explicit single file | same |
| `x11-toolkits/qt5-quickcontrols` | leading `-` | this port installs no cmake config files at all, so `sed` still fails and the `-` still swallows it; build exits 0 as before |

## Note on merge order

This touches `x11-toolkits/qt5-gamepad/Makefile` a couple of lines away from #837. Whichever merges second may need a trivial rebase; the two changes are on different lines and don't conflict semantically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Bug Fixes:
- Prevent Qt5 port post-install rewrites from leaving untracked .bak files in staging directories and producing misleading check-fake packing-list warnings.