### PR TITLE
devel/qt5-designer: stop leaving Qt5Designer.pc.bak in the stage dir

### DIFF
--- a/devel/qt5-designer/Makefile
+++ b/devel/qt5-designer/Makefile
@@ -32,7 +32,7 @@ post-install:
 	${INSTALL_DATA} ${WRKSRC}/src/${PORTNAME}/src/designer/images/designer.png \
 		${PREFIX}/share/pixmaps/designer-qt5.png
 	# The generated .pc file refers to a nonexistent other .pc file
-	${REINPLACE_CMD} -e '/^Requires/s/Qt5UiPlugin//' \
+	${SED} -i '' -e '/^Requires/s/Qt5UiPlugin//' \
 		${PREFIX}/libdata/pkgconfig/Qt5Designer.pc
 	${SED} -i '' 's|/../../../../|/../../../|g' \
 		${PREFIX}/lib/cmake/Qt5Designer/Qt5DesignerConfig.cmake


### PR DESCRIPTION
Follow-up to #838, which missed one.

## Problem

That PR's sweep matched only the cmake-rewrite line, so it did not catch the *other* staged `REINPLACE_CMD` in this port's `post-install`, which fixes up the generated pkg-config file:

```make
${REINPLACE_CMD} -e '/^Requires/s/Qt5UiPlugin//' \
	${PREFIX}/libdata/pkgconfig/Qt5Designer.pc
```

`REINPLACE_CMD` is `sed -i.bak`, and during `fake` `${PREFIX}` already includes `${FAKE_DESTDIR}`, so this left `Qt5Designer.pc.bak` in the staging directory and one more missing-from-plist line in `bmake check-fake`.

## Fix

`${SED} -i ''`, matching the line directly below it.

## Rescan

Rather than grep for the same text pattern again, I rescanned every qt5 port for `REINPLACE_CMD` invocations whose target is under `${PREFIX}`, `${FAKE_DESTDIR}` or `${STAGEDIR}`, joining line continuations first so multi-line commands are matched. This was the only remaining one.

The `post-patch` `REINPLACE_CMD` in this port operates on `${WRKSRC}` and is deliberately left alone — backup files there are normal and never staged.

## No PORTREVISION bump

The `.bak` was never in `pkg-plist`, so it was never packaged, and the package is otherwise unchanged.

## Validation (amd64)

- no `.bak` anywhere in the stage dir
- the `Requires:` line still has `Qt5UiPlugin` removed: `Requires: Qt5Core Qt5Gui Qt5Widgets Qt5Xml`
- resulting `Qt5Designer.pc` and `Qt5DesignerConfig.cmake` diffed against the ones the `REINPLACE_CMD` version produced — byte-identical
- `check-fake` now completely clean for this port (no orphans, no warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Bug Fixes:
- Prevent creation of the staged Qt5Designer.pc.bak file during post-install processing.