### PR TITLE
www/foreign-cdm: new port, Linuxulator CDM agent for Chromium

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -42,6 +42,7 @@
     SUBDIR += firefox
     SUBDIR += firefox-esr
     SUBDIR += firefox-freebsd
+    SUBDIR += foreign-cdm
     SUBDIR += furl
     SUBDIR += gitea
     SUBDIR += gitlab

--- a/www/foreign-cdm/Makefile
+++ b/www/foreign-cdm/Makefile
@@ -1,0 +1,73 @@
+PORTNAME=	foreign-cdm
+DISTVERSION=	20250224
+CATEGORIES=	www multimedia linux
+MASTER_SITES=	https://arrowd.name/:cdm
+DISTFILES=	cdm-${CDM_INT_HASH}.tar.gz:cdm
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	CDM agent for Chromium
+WWW=		https://github.com/shkhln/foreign-cdm
+
+LICENSE=	mit
+
+ONLY_FOR_ARCHS=	aarch64 amd64
+
+BUILD_DEPENDS=	cmake:devel/cmake-core
+
+USES=		linux:rl9
+
+USE_GITHUB=	yes
+USE_LDCONFIG=	yes
+USE_LINUX=	base:build,run devtools:build
+
+GH_ACCOUNT=	shkhln
+GH_PROJECT=	foreign-cdm
+GH_TUPLE=	capnproto:capnproto:928c8390d4d562bd32dc79a42eb64e9bdba572d8:capnproto/third_party/capnproto
+
+MAKE_ENV=	MAKE_JOBS_NUMBER=${MAKE_JOBS_NUMBER}
+
+SUB_FILES=	fcdm-setup-env
+
+PLIST_FILES=	libexec/fcdm-jail \
+		libexec/fcdm-worker \
+		lib/foreign-cdm/fcdm-fbsd.so \
+		share/chromium/WidevineCdm/_platform_specific/linux_${LINUX_ARCH}/libwidevinecdm.so \
+		share/chromium/WidevineCdm/manifest.json \
+		share/foreign-cdm/fcdm-setup-env
+
+CDM_INT_HASH=	06395a2863cb1ebdb47617a995b73f95c14fe120
+
+LINUX_ARCH=	${ARCH:S/amd64/x64/:S/aarch64/arm64/}
+
+.include <bsd.port.pre.mk>
+
+# mports has no devel/linux-c7-devtoolset, so unlike FreeBSD this port is
+# Rocky Linux 9 only (USES=linux:rl9 above).
+MAKE_ENV+=	LINUX_CC=/compat/linux/usr/bin/${ARCH:S/amd64/x86_64/}-redhat-linux-g++
+
+post-extract:
+	${MV} ${WRKDIR}/*.h ${WRKSRC}/third_party/cdm/
+
+post-patch:
+	${REINPLACE_CMD} -e 's|chmod a+srX|chmod a+rX|' ${WRKSRC}/Makefile
+
+do-install:
+	${MKDIR} ${PREFIX}/libexec
+	${INSTALL_PROGRAM} ${WRKSRC}/build/fcdm-jail ${PREFIX}/libexec/
+	${CHMOD} u+s ${PREFIX}/libexec/fcdm-jail
+	${INSTALL_PROGRAM} ${WRKSRC}/build/fcdm-worker ${PREFIX}/libexec/
+
+	${MKDIR} ${DATADIR}
+	${INSTALL_DATA} ${WRKDIR}/fcdm-setup-env ${DATADIR}
+
+	${MKDIR} ${PREFIX}/lib/foreign-cdm
+	${CP} ${WRKSRC}/build/fcdm-fbsd.so ${PREFIX}/lib/foreign-cdm/
+	${STRIP_CMD} ${PREFIX}/lib/foreign-cdm/fcdm-fbsd.so
+
+	${MKDIR} ${PREFIX}/share/chromium/WidevineCdm/_platform_specific/linux_${LINUX_ARCH}
+	# TRUE_PREFIX, not PREFIX: the link targets are runtime paths, while the
+	# links themselves land in the staging tree.
+	${LN} -s ${TRUE_PREFIX}/lib/foreign-cdm/fcdm-fbsd.so ${PREFIX}/share/chromium/WidevineCdm/_platform_specific/linux_${LINUX_ARCH}/libwidevinecdm.so
+	${LN} -s ${TRUE_PREFIX}/lib/WidevineCdm/manifest.json ${PREFIX}/share/chromium/WidevineCdm/manifest.json
+
+.include <bsd.port.post.mk>

--- a/www/foreign-cdm/distinfo
+++ b/www/foreign-cdm/distinfo
@@ -1,0 +1,7 @@
+TIMESTAMP = 1741067231
+SHA256 (cdm-06395a2863cb1ebdb47617a995b73f95c14fe120.tar.gz) = 6b64bae344abc37c4d5db0fa83766224a4520ddfcc6eaffb87668bd6165672ef
+SIZE (cdm-06395a2863cb1ebdb47617a995b73f95c14fe120.tar.gz) = 14936
+SHA256 (shkhln-foreign-cdm-20250224_GH0.tar.gz) = 090c4fc7ccbb3c9076de4b9c856950f079a1338c465c9ab7399b7841b08f1ea1
+SIZE (shkhln-foreign-cdm-20250224_GH0.tar.gz) = 17679
+SHA256 (capnproto-capnproto-928c8390d4d562bd32dc79a42eb64e9bdba572d8_GH0.tar.gz) = 5c867f4758d7a3e2e0213e732e2b9a5ad70d1193a4d615bbab41df1d4051de37
+SIZE (capnproto-capnproto-928c8390d4d562bd32dc79a42eb64e9bdba572d8_GH0.tar.gz) = 2413835

--- a/www/foreign-cdm/files/fcdm-setup-env.in
+++ b/www/foreign-cdm/files/fcdm-setup-env.in
@@ -1,0 +1,2 @@
+export FCDM_CDM_SO_PATH=%%PREFIX%%/lib/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
+export FCDM_BINDIR_PATH=%%PREFIX%%/libexec

--- a/www/foreign-cdm/pkg-descr
+++ b/www/foreign-cdm/pkg-descr
@@ -1,0 +1,2 @@
+Linuxulator-based CDM agent for the Chromium browser making it possible to
+to play DRM content with native Chromium.

--- a/www/foreign-cdm/pkg-message
+++ b/www/foreign-cdm/pkg-message
@@ -1,0 +1,8 @@
+[
+{ type: install
+  message: <<EOM
+This package requires Google's CDM library which can be installed by compiling the
+www/linux-widevine-cdm port.
+EOM
+}
+]


### PR DESCRIPTION
New port: `www/foreign-cdm`, imported from FreeBSD.

`foreign-cdm` runs Google's Linux Widevine CDM under the Linuxulator and proxies it to a native Chromium over Cap'n Proto. This is what makes `www/chromium`'s `WIDEVINE` option satisfiable — until now that option referenced a port mports did not have (see #842).

### MidnightBSD changes versus FreeBSD's port

- `ports@MidnightBSD.org`, lowercase `mit` license id
- `USES=linux:rl9` rather than plain `linux`. FreeBSD picks the Linux base from `LINUX_DEFAULT` and falls back to `devel/linux-c7-devtoolset` for the CentOS 7 case; mports has no such port, so this pins to Rocky Linux 9 and drops the branch.
- mports staging semantics in `do-install`, using `${TRUE_PREFIX}` for the two symlink *targets* — those are runtime paths, while the links themselves belong in the staging tree
- explicitly create `${PREFIX}/libexec` before installing into it

### Testing (amd64, MidnightBSD 4.1)

`bmake build`, `bmake fake` and `bmake package` all clean. Both the native `fcdm-fbsd.so`/`fcdm-jail` side and the Linux-side `fcdm-linux.so`/`fcdm-worker` (built with the rl9 `x86_64-redhat-linux-g++`) compile.

`bmake check-fake` warns that the two `WidevineCdm` symlinks are dangling. That is expected: `libwidevinecdm.so` resolves once the package is installed, and `manifest.json` needs `www/linux-widevine-cdm`, which is not yet in mports — `pkg-message` points users at it.

### Not verified

DRM playback itself was not exercised; that needs `www/linux-widevine-cdm` and a browser session. The port was built and packaged but not installed here (`fcdm-jail` is installed setuid root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Add foreign-cdm support so Chromium can use Google's Linux Widevine CDM through a native MidnightBSD integration.

New Features:
- Add the foreign-cdm port to provide a Linuxulator-based Widevine CDM agent for native Chromium on supported architectures.

Enhancements:
- Integrate Rocky Linux 9 runtime/build support and install the native and Linux CDM components with Chromium-compatible Widevine paths.

Documentation:
- Document the external Widevine CDM dependency and setup requirements.