### PR TITLE
www/linux-widevine-cdm: new port, Google's Widevine CDM plugin

### DIFF
--- a/www/Makefile
+++ b/www/Makefile
@@ -88,6 +88,7 @@
     SUBDIR += linux-rl9-libnghttp2
     SUBDIR += linux-rl9-qt5-qtwebchannel
     SUBDIR += linux-rl9-qt5-qtwebsockets
+    SUBDIR += linux-widevine-cdm
     SUBDIR += llhttp
     SUBDIR += lynx
     SUBDIR += man2web

--- a/www/linux-widevine-cdm/Makefile
+++ b/www/linux-widevine-cdm/Makefile
@@ -1,0 +1,44 @@
+# The information for PORTVERSION and CHROME_VERSION is borrowed from
+# https://aur.archlinux.org/cgit/aur.git/?h=vivaldi-widevine
+# PORTVERSION can also be obtained from the plugin's manifest.json file
+
+PORTNAME=	widevine-cdm
+PORTVERSION=	4.10.3057.0
+CATEGORIES=	www multimedia linux
+MASTER_SITES=	https://dl.google.com/linux/deb/pool/main/g/google-chrome-stable/
+PKGNAMEPREFIX=	linux-
+DISTNAME=	google-chrome-stable_${CHROME_VERSION}_${ARCH:S/aarch64/arm64/}
+EXTRACT_SUFX=	.deb
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Widevine CDM plugin as provided by Google
+WWW=		https://www.widevine.com
+
+LICENSE=	WIDEVINE
+LICENSE_NAME=	Google proprietary license
+LICENSE_FILE=	${WRKDIR}/opt/google/chrome/WidevineCdm/LICENSE
+LICENSE_PERMS=	no-dist-sell no-pkg-sell no-dist-mirror no-pkg-mirror
+
+ONLY_FOR_ARCHS=	aarch64 amd64
+
+NO_BUILD=	yes
+PLIST_FILES=	lib/WidevineCdm/_platform_specific/linux_${LINUX_ARCH}/libwidevinecdm.so \
+		lib/WidevineCdm/manifest.json
+
+LINUX_ARCH=	${ARCH:S/amd64/x64/:S/aarch64/arm64/}
+CHROME_VERSION=	152.0.7977.75-1
+
+.if make(makesum)
+.  for arch in ${ONLY_FOR_ARCHS}
+DISTFILES+=	google-chrome-stable_${CHROME_VERSION}_${arch:S/aarch64/arm64/}${EXTRACT_SUFX}
+.  endfor
+.endif
+
+post-extract:
+	cd ${WRKDIR} && ${EXTRACT_CMD} ${EXTRACT_BEFORE_ARGS} data.tar.xz ${EXTRACT_AFTER_ARGS}
+
+do-install:
+	cd ${WRKDIR}/opt/google/chrome/ && ${COPYTREE_SHARE} WidevineCdm ${PREFIX}/lib
+	${RM} ${PREFIX}/lib/WidevineCdm/LICENSE
+
+.include <bsd.port.mk>

--- a/www/linux-widevine-cdm/distinfo
+++ b/www/linux-widevine-cdm/distinfo
@@ -1,0 +1,5 @@
+TIMESTAMP = 1788351654
+SHA256 (google-chrome-stable_152.0.7977.75-1_arm64.deb) = 3854b6525037f8d29704812a2681849c4ecdf69797750da3742381403f37e1d2
+SIZE (google-chrome-stable_152.0.7977.75-1_arm64.deb) = 133049792
+SHA256 (google-chrome-stable_152.0.7977.75-1_amd64.deb) = a0b7a64f768ffc0ff5ccc9260ad9ebb53fd16f7a131e2e36994da58b82d913df
+SIZE (google-chrome-stable_152.0.7977.75-1_amd64.deb) = 140834800

--- a/www/linux-widevine-cdm/pkg-descr
+++ b/www/linux-widevine-cdm/pkg-descr
@@ -1,0 +1,3 @@
+A browser plugin designed for the viewing of premium video content. This
+software is distibuted as a compiled Linux binary and is intended to be
+consumed either by a Linux-native browser or via www/foreign-cdm port.

--- a/www/linux-widevine-cdm/pkg-descr
+++ b/www/linux-widevine-cdm/pkg-descr
@@ -1,3 +1,3 @@
-A browser plugin designed for the viewing of premium video content. This
-software is distibuted as a compiled Linux binary and is intended to be
-consumed either by a Linux-native browser or via www/foreign-cdm port.
+A browser plugin designed for viewing premium video content. This
+software is distributed as a compiled Linux binary and is intended to be
+consumed either by a Linux-native browser or via the www/foreign-cdm port.


### PR DESCRIPTION
New port: `www/linux-widevine-cdm`, imported from FreeBSD.

`www/foreign-cdm` (#843) needs Google's Linux CDM library to proxy, and its `pkg-message` points users at this port. Without it, foreign-cdm ships a dangling `WidevineCdm/manifest.json` symlink and cannot play DRM content.

The distfile is the Linux `google-chrome-stable` `.deb`, from which only `WidevineCdm` is extracted. `CHROME_VERSION` is `152.0.7977.75-1`, matching the `www/chromium` in #842.

### MidnightBSD changes versus FreeBSD's port

- `ports@MidnightBSD.org`
- `LICENSE=WIDEVINE` with `LICENSE_NAME`/`LICENSE_PERMS`/`LICENSE_FILE`, since mports has no `Proprietary` license id. Permissions are unchanged from FreeBSD's — `no-dist-sell no-pkg-sell no-dist-mirror no-pkg-mirror` — and acceptance is deliberately left interactive rather than `auto-accept`, so nobody silently agrees to a Google proprietary licence. Build with `LICENSES_ACCEPTED=WIDEVINE` in batch contexts.
- mports staging semantics in `do-install`

### Testing (amd64, MidnightBSD 4.1)

`bmake build`, `bmake fake`, `bmake check-fake` and `bmake package` all clean. `check-fake` reports no missing files.

portlint emits two warnings, both inherited from FreeBSD's port and both false positives here: `USE_LDCONFIG` (the `.so` is a browser plugin, not a linkable library) and the hyphen in `PORTNAME` (`PKGNAMEPREFIX=linux-` is already in use).

### Not verified

DRM playback was not exercised — that needs foreign-cdm installed and a browser session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Add the Google Widevine CDM plugin as a Linux port for use by DRM proxy consumers.

New Features:
- Add a Linux Widevine CDM port that packages Google's browser DRM plugin for amd64 and aarch64 systems.
- Register the new port in the www ports collection.

Enhancements:
- Define MidnightBSD-specific handling for the proprietary Widevine license and staged installation.