### PR TITLE
print/ghostscript10: bump PORTREVISION to rebuild against libidn 1.43

### DIFF
--- a/print/ghostscript10/Makefile
+++ b/print/ghostscript10/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	ghostscript
 DISTVERSION=	10.03.1
+PORTREVISION=	1
 CATEGORIES=	print
 MASTER_SITES=	https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs${DISTVERSION:S/.//g}/
 PKGNAMESUFFIX=	${GS_MAJOR_VERSION}


### PR DESCRIPTION
`dns/libidn` 1.43 ships `libidn.so.12` with **no ELF symbol versioning at all**. A ghostscript built against an earlier libidn therefore carries a requirement nothing can satisfy, and every invocation dies before `main()`:

```
$ gs --version
ld-elf.so.1: /usr/local/lib/libidn.so.12: version LIBIDN_1.0 required by
             /usr/local/lib/libgs.so.10 not defined
```

Ghostscript is effectively broken for anyone who installed it before the libidn update. Nothing in the port needs to change — it just needs rebuilding — so this is a bare `PORTREVISION` bump.

### How it surfaced

`graphics/graphviz` failed to build: it renders its PDF manuals with `ps2pdf`, which is ghostscript. After rebuilding ghostscript, `gs --version` returns `10.03.1` and graphviz builds cleanly.

### Testing

Rebuilt and reinstalled on amd64 (MidnightBSD 4.1); `gs --version` works, `graphics/graphviz` then built, staged and packaged successfully.

### Note

This is one instance of a general pattern: a library dropping symbol versioning silently breaks every already-installed consumer. `textproc/libxml2` 2.15.4 appears to have done the same thing — `graphics/evince` currently fails with `libxml2.so.2: version LIBXML2_2.4.30 required by libevdocument3.so.4 not defined`. That is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfjmwisLNPFuZeaQCUJn4A

## Summary by Sourcery

Bug Fixes:
- Rebuild ghostscript10 against the unversioned libidn 1.43 ABI so existing installations no longer fail at startup due to an unsatisfied LIBIDN_1.0 requirement.