### PR TITLE
devel/cmake-core: add MidnightBSD linker platform modules

### DIFF
--- a/devel/cmake-core/Makefile
+++ b/devel/cmake-core/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	cmake
 DISTVERSION=	${_CMAKE_VERSION}
-PORTREVISION=	0
+PORTREVISION=	1
 CATEGORIES=	devel
 PKGNAMESUFFIX=	-core
 
@@ -60,6 +60,7 @@ OPTIONS_SUB=		yes
 
 post-patch:
 	@${CP} ${FILESDIR}/MidnightBSD*.cmake ${WRKSRC}/Modules/Platform
+	@${CP} ${FILESDIR}/Linker/MidnightBSD*.cmake ${WRKSRC}/Modules/Platform/Linker
 	@(${FIND} ${WRKSRC}/Modules -name "*.cmake" -print0; \
 		${FIND} ${WRKSRC}/Tests -name "CMakeLists.txt" -print0 ) | \
 		${XARGS} -0 -n 100 ${REINPLACE_CMD} -e 's|/usr/local|${LOCALBASE}|g; \

--- a/devel/cmake-core/files/Linker/MidnightBSD-ASM.cmake
+++ b/devel/cmake-core/files/Linker/MidnightBSD-ASM.cmake
@@ -1,0 +1,7 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# MidnightBSD was forked from FreeBSD and uses the same linkers, so reuse
+# the FreeBSD linker support. Platform/FreeBSD-ASM selects between the
+# GNU and LLD variants itself via Platform/Linker/BSD-Linker-Initialize.
+include(Platform/Linker/FreeBSD-ASM)

--- a/devel/cmake-core/files/Linker/MidnightBSD-C.cmake
+++ b/devel/cmake-core/files/Linker/MidnightBSD-C.cmake
@@ -1,0 +1,7 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# MidnightBSD was forked from FreeBSD and uses the same linkers, so reuse
+# the FreeBSD linker support. Platform/FreeBSD-C selects between the
+# GNU and LLD variants itself via Platform/Linker/BSD-Linker-Initialize.
+include(Platform/Linker/FreeBSD-C)

--- a/devel/cmake-core/files/Linker/MidnightBSD-CXX.cmake
+++ b/devel/cmake-core/files/Linker/MidnightBSD-CXX.cmake
@@ -1,0 +1,7 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# MidnightBSD was forked from FreeBSD and uses the same linkers, so reuse
+# the FreeBSD linker support. Platform/FreeBSD-CXX selects between the
+# GNU and LLD variants itself via Platform/Linker/BSD-Linker-Initialize.
+include(Platform/Linker/FreeBSD-CXX)

--- a/devel/cmake-core/files/Linker/MidnightBSD-Fortran.cmake
+++ b/devel/cmake-core/files/Linker/MidnightBSD-Fortran.cmake
@@ -1,0 +1,7 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+# MidnightBSD was forked from FreeBSD and uses the same linkers, so reuse
+# the FreeBSD linker support. Platform/FreeBSD-Fortran selects between the
+# GNU and LLD variants itself via Platform/Linker/BSD-Linker-Initialize.
+include(Platform/Linker/FreeBSD-Fortran)

--- a/devel/cmake-core/pkg-plist
+++ b/devel/cmake-core/pkg-plist
@@ -3300,6 +3300,10 @@ share/bash-completion/completions/ctest
 %%DATADIR%%/Modules/Platform/Linker/MSYS-LLD-C.cmake
 %%DATADIR%%/Modules/Platform/Linker/MSYS-LLD-CXX.cmake
 %%DATADIR%%/Modules/Platform/Linker/MSYS-LLD-Fortran.cmake
+%%DATADIR%%/Modules/Platform/Linker/MidnightBSD-ASM.cmake
+%%DATADIR%%/Modules/Platform/Linker/MidnightBSD-C.cmake
+%%DATADIR%%/Modules/Platform/Linker/MidnightBSD-CXX.cmake
+%%DATADIR%%/Modules/Platform/Linker/MidnightBSD-Fortran.cmake
 %%DATADIR%%/Modules/Platform/Linker/MirBSD-ASM.cmake
 %%DATADIR%%/Modules/Platform/Linker/MirBSD-C.cmake
 %%DATADIR%%/Modules/Platform/Linker/MirBSD-CXX.cmake


### PR DESCRIPTION
CMake 3.29 moved link-feature handling into per-linker platform modules under
`Modules/Platform/Linker/<OS>-<Linker>-<Lang>.cmake`. Upstream ships
`FreeBSD-GNU-*` and `FreeBSD-LLD-*` but nothing for MidnightBSD, so any feature
declared through the `$<LINK_LIBRARY>` generator expression is undefined here.

`Modules/Platform/MidnightBSD.cmake` already does `include(Platform/FreeBSD)`,
but that predates the `Linker/` split and does not cover it.

## Symptom

Any port using `$<LINK_LIBRARY:WHOLE_ARCHIVE,...>` fails at generate time.
Found while updating `ai/pytorch` to 2.13.0:

```
CMake Error at caffe2/CMakeLists.txt:804 (add_library):
  Feature 'WHOLE_ARCHIVE', specified through generator-expression
  '$<LINK_LIBRARY>' to link target 'torch_cpu', is not supported for the
  'CXX' link language.
```

## Change

Adds `files/Linker/MidnightBSD-{ASM,C,CXX,Fortran}.cmake`, each a one-line
delegation to its FreeBSD counterpart, mirroring what
`Platform/MidnightBSD.cmake` already does for the base platform. The FreeBSD
modules select between the GNU and LLD variants themselves via
`Platform/Linker/BSD-Linker-Initialize`, so no linker detection is duplicated.

Also adds the `post-patch` copy line, the four `pkg-plist` entries, and bumps
`PORTREVISION` to 1.

## Testing

- `bmake build` / `bmake fake` / `bmake package` clean on MidnightBSD 4.2 amd64
- `Created /usr/mports/Packages/amd64/All/cmake-core-3.31.6_1.mport`
- Installed; the four modules land in
  `/usr/local/share/cmake/Modules/Platform/Linker/`
- Confirmed `ai/pytorch` 2.13.0 now reaches `Generating done` instead of
  failing on `WHOLE_ARCHIVE`

This is an upstream CMake gap and is worth reporting there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkHF8bn8Ehit2aSoWjCshm

## Summary by Sourcery

Add MidnightBSD linker modules that reuse FreeBSD linker support in CMake.

New Features:
- Add MidnightBSD linker platform support for ASM, C, C++, and Fortran through the CMake core port.

Bug Fixes:
- Enable CMake link-library generator expressions, including WHOLE_ARCHIVE, for MidnightBSD targets.

Build:
- Install the new MidnightBSD linker platform modules and bump the port revision.

Tests:
- Verify the updated port builds, packages, installs, and supports generating ai/pytorch on MidnightBSD.