### PR TITLE
lang/ghc: run bootstrap bindist install with a clean environment

### DIFF
--- a/lang/ghc/Makefile
+++ b/lang/ghc/Makefile
@@ -219,7 +219,7 @@ pre-configure:
 # If we are using bootstrap compiler, configure and install it into ${BOOT_DIR}
 .if empty(PORT_OPTIONS:MBOOT)
 	cd ${BOOT_DIR} && ${CONFIGURE_ENV} ${CONFIGURE_ENV_BOOTSTRAP} ${CONFIGURE_CMD} --prefix=${BOOT_INSTALL_DIR} --build=${CONFIGURE_TARGET} --host=${CONFIGURE_TARGET} --target=${CONFIGURE_TARGET}
-	cd ${BOOT_DIR} && PACKAGES='' ${MAKE_CMD} install
+	cd ${BOOT_DIR} && ${SETENVI} ${WRK_ENV} ${MAKE_CMD} PACKAGES='' install
 .endif
 .ifdef USE_HADRIAN
 # Compile Hadrian


### PR DESCRIPTION
Fixes #857.

When `lang/ghc` is built as a dependency, `do-depends.sh` invokes bmake with `-DINSTALLS_DEPENDS`, and bmake exports `-D INSTALLS_DEPENDS` in the `MAKEFLAGS` environment variable. gmake 4.4.1 parses `MAKEFLAGS` as options and rejects `-D`, so the bootstrap bindist's `gmake install` in `pre-configure` failed with `: invalid option -- D`. Building the port directly worked because `MAKEFLAGS` was empty.

The existing `Mk/extensions/gmake.mk` guard (`MAKE_ENV+= MAKEFLAGS=`) only covers framework-driven make invocations. This direct call now uses `${SETENVI} ${WRK_ENV}`, matching the `binary-dist` targets later in the file and FreeBSD's port.

Verification: `bmake -DINSTALLS_DEPENDS -DBATCH configure` completes, and the bootstrap install lands `work/ghc-boot-install/bin/ghc-9.6.7`. portlint: 0 fatal errors, warnings pre-existing.

Note: about 30 other ports call `${MAKE_CMD}` or `${GMAKE}` bare inside their own targets and carry the same latent bug when built as dependencies (e.g. textproc/uim, japanese/uim-anthy, www/chromium, www/py-django42, emulators/qemu7, ftp/proftpd). Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqhJwxeUv8hz3u16y8tpUz

## Summary by Sourcery

Bug Fixes:
- Ensure the GHC bootstrap bindist installation runs with a clean environment when the port is built as a dependency, preventing inherited MAKEFLAGS from breaking gmake.