### PR TITLE
devel/libayatana-appindicator: disable gtk-doc build

### DIFF
--- a/devel/libayatana-appindicator/Makefile
+++ b/devel/libayatana-appindicator/Makefile
@@ -4,6 +4,7 @@ CATEGORIES=	devel
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Ayatana Application Indicators Shared Library
+WWW=		https://github.com/AyatanaIndicators/libayatana-appindicator
 
 LICENSE=	lgpl3
 
@@ -19,8 +20,9 @@ LIB_DEPENDS=	libharfbuzz.so:print/harfbuzz \
 
 USE_GNOME=	introspection gtk30 glib20 pango atk cairo gdkpixbuf
 CMAKE_OFF=	ENABLE_BINDINGS_MONO \
-		FLAVOUR_GTK2 \
-		ENABLE_BINDINGS_VALA
+		ENABLE_BINDINGS_VALA \
+		ENABLE_GTKDOC \
+		FLAVOUR_GTK2
 
 USE_LDCONFIG=	yes
 

--- a/devel/libayatana-appindicator/pkg-descr
+++ b/devel/libayatana-appindicator/pkg-descr
@@ -7,5 +7,3 @@ fallback to generic Systray support if none of those are available.
 This code project was originally started by Canonical Ltd. and has been
 adapted by various authors with the purpose of making this Application
 Indicators available on Ubuntu and non-Ubuntu systems alike.
-
-WWW: https://github.com/AyatanaIndicators/libayatana-appindicator


### PR DESCRIPTION
Fixes #855.

The gtk-doc `scangobj.sh` generated by CMake builds its `LDFLAGS` from library names only, with no `-L/usr/local/lib`, so `gtkdoc-scangobj` cannot link against ports libraries and the build fails at 85%. The port does not install the generated docs (nothing in `pkg-plist`), so `ENABLE_GTKDOC` is now in `CMAKE_OFF`, matching FreeBSD.

Also moves `WWW` from `pkg-descr` into the Makefile per portlint.

Verified on amd64: `bmake package` succeeds, no `scangobj` step runs, `portlint` reports "looks fine", `bmake test` passes. Package contents unchanged, so no `PORTREVISION` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QppyajU21HE92jbfdUgLSv

## Summary by Sourcery

Disable uninstalled GTK-Doc generation and update the port metadata location to ensure reliable packaging.

Bug Fixes:
- Disable the failing GTK-Doc build so the port can package successfully when ports libraries are not discoverable by the generated linker flags.

Enhancements:
- Move the project website metadata into the Makefile to satisfy port formatting standards.