### PR TITLE
games/devilutionX: fix build on MidnightBSD (isascii undeclared)

### DIFF
--- a/games/devilutionX/Makefile
+++ b/games/devilutionX/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	devilutionX
 DISTVERSION=	1.5.4
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	games
 MASTER_SITES=	https://github.com/diasurgical/devilutionx-assets/releases/download/${DATA_VERSION}/:data
 DISTFILES=	devilutionx.mpq?tag=${DATA_VERSION}:data
@@ -20,7 +20,7 @@ BUILD_DEPENDS=	${LOCALBASE}/include/SimpleIni.h:devel/simpleini
 LIB_DEPENDS=	libfmt.so:devel/libfmt
 
 USES=		cmake compiler:c++11-lang dos2unix gettext-tools pkgconfig sdl
-DOS2UNIX_GLOB=	*.cpp *.h CMakeLists.txt Dependencies.cmake
+DOS2UNIX_GLOB=	*.cpp *.h *.cmake CMakeLists.txt
 USE_GITHUB=	yes
 GH_ACCOUNT=	diasurgical
 GH_PROJECT=	DevilutionX

--- a/games/devilutionX/files/patch-CMake_Platforms.cmake
+++ b/games/devilutionX/files/patch-CMake_Platforms.cmake
@@ -1,0 +1,11 @@
+--- CMake/Platforms.cmake.orig	2024-10-13 00:00:00 UTC
++++ CMake/Platforms.cmake
+@@ -2,7 +2,7 @@
+   include(platforms/haiku)
+ endif()
+ 
+-if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|OpenBSD|DragonFly|NetBSD")
++if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD|MidnightBSD|OpenBSD|DragonFly|NetBSD")
+   if(CMAKE_SYSTEM_NAME MATCHES "NetBSD")
+     add_definitions(-D_NETBSD_SOURCE)
+   else()

--- a/games/devilutionX/files/patch-CMake_functions_devilutionx__library.cmake
+++ b/games/devilutionX/files/patch-CMake_functions_devilutionx__library.cmake
@@ -1,0 +1,11 @@
+--- CMake/functions/devilutionx_library.cmake.orig	2024-10-13 00:00:00 UTC
++++ CMake/functions/devilutionx_library.cmake
+@@ -45,7 +45,7 @@
+     target_compile_options(${NAME} PUBLIC -Wall -Wextra -Wno-unused-parameter)
+   endif()
+ 
+-  if(NOT WIN32 AND NOT APPLE AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL FreeBSD)
++  if(NOT WIN32 AND NOT APPLE AND NOT CMAKE_SYSTEM_NAME MATCHES "FreeBSD|MidnightBSD")
+     # Enable POSIX extensions such as `readlink` and `ftruncate`.
+     add_definitions(-D_POSIX_C_SOURCE=200809L)
+   endif()


### PR DESCRIPTION
Fixes #858.

## Root cause

Not a base-system header bug. Upstream's `CMake/functions/devilutionx_library.cmake` adds `-D_POSIX_C_SOURCE=200809L` on every non-Windows, non-Apple system except FreeBSD. MidnightBSD reports its own `CMAKE_SYSTEM_NAME`, so the define was applied. On BSD libc, defining `_POSIX_C_SOURCE` selects a strict POSIX namespace in `sys/cdefs.h` and sets `__XSI_VISIBLE` to 0, which hides `isascii()` from `<ctype.h>`. libc++'s `<__locale>` then fails on any TU that reaches it via `<vector>` under `-std=c++20`.

## Fix

- `patch-CMake_functions_devilutionx__library.cmake`: skip the `_POSIX_C_SOURCE` define on MidnightBSD as well as FreeBSD.
- `patch-CMake_Platforms.cmake`: include MidnightBSD in the BSD platform branch so `_BSD_SOURCE` and the `stat64`/`off64_t` shims are set (the `file_util.cpp` POSIX code paths key off `_BSD_SOURCE`).
- Add `*.cmake` to `DOS2UNIX_GLOB` so the new patches are free of CRLF.
- Bump `PORTREVISION` to 2.

## Validation

On MidnightBSD 4.0.6 amd64 from a clean work dir: `bmake patch`, `bmake`, `bmake fake`, `bmake package` all succeed. `compile_commands.json` no longer contains `_POSIX_C_SOURCE`. `portlint` reports 0 fatal errors; the two remaining warnings (NLS knob, `file` in the ZEROTIER_BROKEN message) are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QppyajU21HE92jbfdUgLSv

## Summary by Sourcery

Restore DevilutionX compatibility with MidnightBSD builds.

Bug Fixes:
- Fix the DevilutionX build on MidnightBSD by preventing incompatible POSIX namespace restrictions and enabling the required BSD compatibility paths.

Build:
- Normalize CMake patch files during the port build and bump the port revision.