### PR TITLE
net-im/telegram-desktop: limit build parallelism to fix clang crashes

### DIFF
--- a/net-im/telegram-desktop/Makefile
+++ b/net-im/telegram-desktop/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	telegram-desktop
 DISTVERSION=	6.5.0
-PORTREVISION=	4
+PORTREVISION=	5
 CATEGORIES=	net-im
 MASTER_SITES=	https://github.com/${GH_ACCOUNT}/${GH_PROJECT}/releases/download/v${DISTVERSION}/
 DISTNAME=	tdesktop-${DISTVERSION}-full
@@ -45,6 +45,13 @@ LIB_DEPENDS=	libabsl_base.so:devel/abseil \
 		libsrtp2.so:net/libsrtp2 \
 		libxxhash.so:devel/xxhash \
 		libvpx.so:multimedia/libvpx
+
+# clang runs out of memory building the generated gi/gio bindings when many
+# compiles run at once, dying with SIGBUS partway through a
+# gen/gio/*_impl.hpp parse. Seen with both base clang 19 and devel/llvm21, and
+# which file dies varies between runs. 16 jobs fails on a 32 GB machine, 8 and
+# 2 both succeed; capped conservatively so builders with less memory are safe.
+MAKE_JOBS_NUMBER_LIMIT=	4
 
 USES=		cmake compiler:c++20-lang desktop-file-utils gl gnome jpeg kde:6 localbase \
 		minizip openal pkgconfig python:build qt:6 ssl


### PR DESCRIPTION
Fixes #861.

## Problem

`net-im/telegram-desktop` failed to build, with clang dying partway through
parsing the generated gi/gio bindings:

```
c++: error: clang frontend command failed with exit code 138
...
gen/gio/tlsdatabase_impl.hpp:483:1: parsing function body
  'gi::repository::Gio::impl::internal::TlsDatabaseClassDef::cl...'
```

Exit 138 is SIGBUS.

## This is not a compiler bug

| Configuration | Result |
|---|---|
| base clang 19.1.7, 16 jobs | 5 crashes |
| clang 21.1.8 (`devel/llvm21`), 16 jobs | 3 crashes |
| clang 21.1.8, 16 jobs, stack raised to 512 MB | **7 crashes** |
| base clang 19.1.7, **8 jobs** | builds |
| base clang 19.1.7, **4 jobs** | builds |
| base clang 19.1.7, **2 jobs** | builds |

Both compilers crash at high parallelism and both succeed at low parallelism,
and *which* file dies varies between runs (`tlsdatabase_impl.hpp`,
`tlsinteraction_impl.hpp`, `file_impl.hpp`). That is a resource limit, not a
deterministic frontend bug — and no newer compiler is required.

Stack limit was investigated and ruled out: the soft limit here is 12.2 MB and
SIGBUS is consistent with stack-growth failure, but raising it to 512 MB made
things *worse*.

A representative heavy TU peaks at ~927 MB RSS, so 16 jobs is roughly 15 GB on
a 32 GB machine — and the generated `gen/gio/*_impl.hpp` bindings are large
enough that some units clearly cost considerably more.

mports' own hint on the failure was already pointing here:
*"Try to set MAKE_JOBS_UNSAFE=yes and rebuild"*.

## Fix

`MAKE_JOBS_NUMBER_LIMIT=4`, plus `PORTREVISION` 4 → 5.

4 rather than the 8 that was verified: this machine has 31.7 GB across 16
cores, so roughly 4 GB per job is needed and a 16 GB builder would still fail
at 8. `MAKE_JOBS_NUMBER_LIMIT` only caps, so machines with fewer cores are
unaffected. Precedent: `java/openjdk17` uses 3, `www/qt6-webengine` uses 1.

## Testing

MidnightBSD 4.2 amd64, **base compiler**, limit in place: `bmake build` /
`fake` / `package` all clean, no crashes, no errors —
`telegram-desktop-6.5.0_5.mport` created.

This completes the chain: #859 (tg_owt CMAKE_SYSTEM_NAME) and #860
(microsoft-gsl 4.2.2) are merged, #867 updates tg_owt, and with this the port
builds end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkHF8bn8Ehit2aSoWjCshm

## Summary by Sourcery

Limit telegram-desktop build concurrency to improve reliability on memory-constrained builders.

Bug Fixes:
- Prevent telegram-desktop builds from failing under high parallelism due to compiler resource exhaustion.

Build:
- Cap telegram-desktop build parallelism at four concurrent jobs and increment the port revision.