### PR TITLE
security/openvas: update to 23.50.24

### DIFF
--- a/security/openvas/Makefile
+++ b/security/openvas/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	openvas
-DISTVERSION=	23.16.1
-PORTREVISION=	1
 DISTVERSIONPREFIX=	v
+DISTVERSION=	23.50.24
 CATEGORIES=	security
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -31,6 +30,7 @@ RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}impacket>=0:net/py-impacket@${PY_FLAVOR} \
 
 USES=		bison cmake gnome gssapi:mit pkgconfig python ssl
 USE_GITHUB=	yes
+USE_LDCONFIG=	yes
 GH_ACCOUNT=	greenbone
 GH_PROJECT=	${PORTNAME}-scanner
 USE_GNOME=	glib20
@@ -42,8 +42,8 @@ GROUPS=		${USERS}
 
 .include <bsd.port.pre.mk>
 
-.if ${OPSYS} == FreeBSD
-CFLAGS+=	-Wno-error=strict-prototypes -Wno-error=unused-but-set-variable -Wno-error=invalid-utf8 -Wno-implicit-function-declaration
+.if ${OPSYS} == FreeBSD || ${OPSYS} == MidnightBSD
+CFLAGS+=	-Wno-error=strict-prototypes -Wno-error=sometimes-uninitialized -Wno-error=unused-but-set-variable -Wno-error=invalid-utf8 -Wno-implicit-function-declaration
 .endif
 
 # The struct this error is about is only ever accessed using bcopy() and memset(),

--- a/security/openvas/distinfo
+++ b/security/openvas/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1744680509
-SHA256 (greenbone-openvas-scanner-v23.16.1_GH0.tar.gz) = 6ef32eab6fe19d3b37589705f9b2e4539a0572cd70bc8b16d217078080dad827
-SIZE (greenbone-openvas-scanner-v23.16.1_GH0.tar.gz) = 1550974
+TIMESTAMP = 1788839623
+SHA256 (greenbone-openvas-scanner-v23.50.24_GH0.tar.gz) = af8b1e0175dfc57f38bdecc08607dbac294459e684e2f3e7d69c85101fa13517
+SIZE (greenbone-openvas-scanner-v23.50.24_GH0.tar.gz) = 7131658

--- a/security/openvas/files/patch-nasl_nasl_packet_forgery.c
+++ b/security/openvas/files/patch-nasl_nasl_packet_forgery.c
@@ -1,6 +1,6 @@
 --- nasl/nasl_packet_forgery.c	2022-02-22 05:32:53.000000000 -0500
 +++ nasl/nasl_packet_forgery.c	2022-05-20 22:17:07.796127000 -0500
-@@ -33,6 +33,12 @@
+@@ -23,6 +23,12 @@
  #include "nasl_tree.h"
  #include "nasl_var.h"
  
@@ -28,7 +28,7 @@
 @@ -119,6 +130,7 @@
    struct in6_addr *dst_addr;
    char *data;
-   int data_len;
+   size_t data_len;
 +  struct in_addr tmp_src, tmp_dst;
  
    dst_addr = plug_get_host_ip (script_infos);

--- a/security/openvas/files/patch-src_attack.c
+++ b/security/openvas/files/patch-src_attack.c
@@ -8,21 +8,3 @@
  #include <errno.h> /* for errno() */
  #include <fcntl.h>
  #include <glib.h>
-@@ -1541,13 +1540,13 @@
- 
-   gettimeofday (&now, NULL);
-   if (test_alive_hosts_only)
--    g_message ("Vulnerability scan %s finished in %ld seconds: "
-+    g_message ("Vulnerability scan %s finished in %lld seconds: "
-                "%d alive hosts of %d",
--               globals->scan_id, now.tv_sec - then.tv_sec,
-+               globals->scan_id, (long long)now.tv_sec - then.tv_sec,
-                gvm_hosts_count (alive_hosts_list), gvm_hosts_count (hosts));
-   else
--    g_message ("Vulnerability scan %s finished in %ld seconds: %d hosts",
--               globals->scan_id, now.tv_sec - then.tv_sec,
-+    g_message ("Vulnerability scan %s finished in %lld seconds: %d hosts",
-+               globals->scan_id, (long long)now.tv_sec - then.tv_sec,
-                gvm_hosts_count (hosts));
- 
-   gvm_hosts_free (hosts);

--- a/security/openvas/pkg-plist
+++ b/security/openvas/pkg-plist
@@ -3,10 +3,10 @@ bin/openvas-nasl-lint
 @sample %%ETCDIR%%/openvas_log.conf.sample
 lib/libopenvas_misc.so
 lib/libopenvas_misc.so.23
-lib/libopenvas_misc.so.23.16.1
+lib/libopenvas_misc.so.23.50.24
 lib/libopenvas_nasl.so
 lib/libopenvas_nasl.so.23
-lib/libopenvas_nasl.so.23.16.1
+lib/libopenvas_nasl.so.23.50.24
 sbin/openvas
 share/man/man1/openvas-nasl-lint.1.gz
 share/man/man1/openvas-nasl.1.gz


### PR DESCRIPTION
## Summary
- update OpenVAS Scanner from 23.16.1 to 23.50.24
- refresh shared library package entries and enable ldconfig handling
- preserve MidnightBSD Clang compatibility for upstream warnings treated as errors

## Validation
- bmake makesum
- bmake clean package
- bmake test
- portlint -C security/openvas (0 fatal errors)
- git diff --check

## Summary by Sourcery

Update the OpenVAS Scanner port to 23.50.24 with refreshed packaging and continued MidnightBSD compatibility.

Enhancements:
- Update the OpenVAS Scanner port to release 23.50.24 and refresh its shared-library packaging metadata.
- Preserve MidnightBSD compiler compatibility while accommodating upstream warning changes.