### PR TITLE
www/tomcat-native: update to 1.3.9

### DIFF
--- a/www/tomcat-native/Makefile
+++ b/www/tomcat-native/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	tomcat-native
-DISTVERSION=	1.3.8
+DISTVERSION=	1.3.9
 CATEGORIES=	www java
 MASTER_SITES=	https://archive.apache.org/dist/tomcat/tomcat-connectors/native/${PORTVERSION}/source/
 DISTNAME=	${PORTNAME}-${PORTVERSION}-src

--- a/www/tomcat-native/distinfo
+++ b/www/tomcat-native/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1786124628
-SHA256 (tomcat-native-1.3.8-src.tar.gz) = c482a3d29ab7eadc108e85b62e0d23c8a13663861ef7e4f975f9fe4c3fd31e90
-SIZE (tomcat-native-1.3.8-src.tar.gz) = 355659
+TIMESTAMP = 1788841387
+SHA256 (tomcat-native-1.3.9-src.tar.gz) = 7453c529566bc5c5418117cf1c782e311f63d603003eea92dbf9da8c626f1c7b
+SIZE (tomcat-native-1.3.9-src.tar.gz) = 357674


### PR DESCRIPTION
## Summary
- update Tomcat Native 1.3 from 1.3.8 to 1.3.9

## Validation
- bmake makesum
- bmake clean package
- bmake test
- portlint -C www/tomcat-native (0 fatal errors)
- git diff --check

## Summary by Sourcery

Enhancements:
- Update the Tomcat Native port to version 1.3.9.