### PR TITLE
dns/unbound: update to 1.26.0

### DIFF
--- a/dns/unbound/Makefile
+++ b/dns/unbound/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	unbound
-DISTVERSION=	1.24.2
+DISTVERSION=	1.26.0
 CATEGORIES=	dns
 MASTER_SITES=	https://www.nlnetlabs.nl/downloads/unbound/
 

--- a/dns/unbound/distinfo
+++ b/dns/unbound/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1764226214
-SHA256 (unbound-1.24.2.tar.gz) = 44e7b53e008a6dcaec03032769a212b46ab5c23c105284aa05a4f3af78e59cdb
-SIZE (unbound-1.24.2.tar.gz) = 6905018
+TIMESTAMP = 1785831269
+SHA256 (unbound-1.26.0.tar.gz) = 77458a7156e275c0b7b17fabcb357cb12445d95cfcb26fb9bb7d5ecba45e0b63
+SIZE (unbound-1.26.0.tar.gz) = 6945614

--- a/dns/unbound/pkg-plist
+++ b/dns/unbound/pkg-plist
@@ -5,7 +5,7 @@ libdata/pkgconfig/libunbound.pc
 lib/libunbound.a
 lib/libunbound.so
 lib/libunbound.so.8
-lib/libunbound.so.8.1.34
+lib/libunbound.so.8.1.39
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/_unbound.so
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/unbound.py
 %%PYTHON%%%%PYTHON_SITELIBDIR%%/unboundmodule.py


### PR DESCRIPTION
Updates Unbound to 1.26.0 and refreshes its shared-library plist entry.

Validation: bmake package, portlint -C, git diff --check.

## Summary by Sourcery

Enhancements:
- Update Unbound to version 1.26.0 and refresh its shared-library package manifest entry.