### PR TITLE
dns/public_suffix_list: update to 20260819

### DIFF
--- a/dns/public_suffix_list/Makefile
+++ b/dns/public_suffix_list/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	public_suffix_list
-PORTVERSION=	20230728
+PORTVERSION=	20260819
 CATEGORIES=	dns
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -20,11 +20,11 @@ PORTDATA=	public_suffix_list.dat \
 
 GH_ACCOUNT=	publicsuffix
 GH_PROJECT=	list
-GH_TAGNAME=	4e6c53c
+GH_TAGNAME=	e8c9a2b
 USE_GITHUB=	yes
 
 do-install:
-	${MKDIR} ${DATADIR}/
-	${INSTALL_DATA} ${WRKSRC}/public_suffix_list.dat ${WRKSRC}/tests/test_psl.txt ${DATADIR}/
+	${MKDIR} ${DATADIR}
+	${INSTALL_DATA} ${WRKSRC}/public_suffix_list.dat ${WRKSRC}/tests/test_psl.txt ${DATADIR}
 
 .include <bsd.port.mk>

--- a/dns/public_suffix_list/distinfo
+++ b/dns/public_suffix_list/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1690822929
-SHA256 (publicsuffix-list-20230728-4e6c53c_GH0.tar.gz) = 2dfa699778a3c44dc43839c531f1c2fa0917dd60236a5fd269b4ea60bac3c312
-SIZE (publicsuffix-list-20230728-4e6c53c_GH0.tar.gz) = 110915
+TIMESTAMP = 1787267932
+SHA256 (publicsuffix-list-20260819-e8c9a2b_GH0.tar.gz) = 96bc3441d1a1748034f5b7c89cb63d3cfe4ee5d54da66254c5b9cf7a494764f4
+SIZE (publicsuffix-list-20260819-e8c9a2b_GH0.tar.gz) = 306143


### PR DESCRIPTION
Updates the Public Suffix List snapshot to 20260819.

Validation: bmake package, portlint -C, git diff --check.

## Summary by Sourcery

Update the public_suffix_list port to the 20260819 Public Suffix List snapshot.

Enhancements:
- Update the bundled Public Suffix List snapshot to the 20260819 release.

Chores:
- Refresh the package checksums and align installation commands with current port conventions.