### PR TITLE
dns/py-tldextract: update to 5.3.0

### DIFF
--- a/dns/py-tldextract/Makefile
+++ b/dns/py-tldextract/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	tldextract
-PORTVERSION=	3.3.1
-PORTREVISION=	1
+PORTVERSION=	5.3.0
 CATEGORIES=	dns python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -10,15 +9,17 @@ COMMENT=	Separate the TLD from the registered domain and subdomains of a URL
 WWW=		https://github.com/john-kurkowski/tldextract
 
 LICENSE=	bsd3
+LICENSE_FILE=	${WRKSRC}/LICENSE
 
-BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}setuptools-scm>0:devel/py-setuptools-scm@${PY_FLAVOR}
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}idna>=2.0:dns/py-idna@${PY_FLAVOR} \
-	        ${PYTHON_PKGNAMEPREFIX}requests>=2.1.0:www/py-requests@${PY_FLAVOR} \
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}setuptools-scm>0:devel/py-setuptools-scm@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}wheel>=0:devel/py-wheel@${PY_FLAVOR}
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}filelock>=3.0.8:sysutils/py-filelock@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}idna>=2.0:dns/py-idna@${PY_FLAVOR} \
 		${PYTHON_PKGNAMEPREFIX}requests-file>=1.4:www/py-requests-file@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}filelock>0:sysutils/py-filelock@${PY_FLAVOR}
+		${PYTHON_PKGNAMEPREFIX}requests>=2.1.0:www/py-requests@${PY_FLAVOR}
 
-USES=	python
-USE_PYTHON=	autoplist concurrent distutils
+USES=		python
+USE_PYTHON=	autoplist concurrent pep517
 
 NO_ARCH=	yes
 

--- a/dns/py-tldextract/distinfo
+++ b/dns/py-tldextract/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1657409469
-SHA256 (tldextract-3.3.1.tar.gz) = fe15ac3205e5a25b61689369f98cb45c7778a8f2af113d7c11559ece5195f2d6
-SIZE (tldextract-3.3.1.tar.gz) = 110819
+TIMESTAMP = 1754163797
+SHA256 (tldextract-5.3.0.tar.gz) = b3d2b70a1594a0ecfa6967d57251527d58e00bb5a91a74387baa0d87a0678609
+SIZE (tldextract-5.3.0.tar.gz) = 128502


### PR DESCRIPTION
Updates py-tldextract to 5.3.0 and refreshes Python dependencies.

Validation: bmake package, portlint -C, git diff --check.

## Summary by Sourcery

Update the tldextract port to the 5.3.0 release and align its packaging metadata and dependencies.

Enhancements:
- Update the tldextract Python package to version 5.3.0 with refreshed runtime dependencies and modern PEP 517 packaging support.
- Add the package license file and wheel as build requirements.