### PR TITLE
dns/rubygem-google-apis-dns_v1: update to 0.55.0

### DIFF
--- a/dns/rubygem-google-apis-dns_v1/Makefile
+++ b/dns/rubygem-google-apis-dns_v1/Makefile
@@ -11,6 +11,7 @@ WWW=		https://github.com/googleapis/google-api-ruby-client/tree/main/generated/g
 LICENSE=	Apache-2.0
 LICENSE_FILE=	${WRKSRC}/LICENSE.md
 
+BUILD_DEPENDS=	${RUN_DEPENDS}
 RUN_DEPENDS=	rubygem-google-apis-core>=0.15.0<2.0:devel/rubygem-google-apis-core
 
 USES=		gem

--- a/dns/rubygem-google-apis-dns_v1/Makefile
+++ b/dns/rubygem-google-apis-dns_v1/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	google-apis-dns_v1
-PORTVERSION=	0.52.0
+PORTVERSION=	0.55.0
 CATEGORIES=	dns rubygems
 MASTER_SITES=	RG
 
@@ -11,7 +11,6 @@ WWW=		https://github.com/googleapis/google-api-ruby-client/tree/main/generated/g
 LICENSE=	Apache-2.0
 LICENSE_FILE=	${WRKSRC}/LICENSE.md
 
-BUILD_DEPENDS=	${RUN_DEPENDS}
 RUN_DEPENDS=	rubygem-google-apis-core>=0.15.0<2.0:devel/rubygem-google-apis-core
 
 USES=		gem

--- a/dns/rubygem-google-apis-dns_v1/distinfo
+++ b/dns/rubygem-google-apis-dns_v1/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1776864300
-SHA256 (rubygem/google-apis-dns_v1-0.52.0.gem) = 62d5d7076ed13760babefaa993d24c4c968bab76e74908a4acbcaf1efcd7cabe
-SIZE (rubygem/google-apis-dns_v1-0.52.0.gem) = 38912
+TIMESTAMP = 1787588254
+SHA256 (rubygem/google-apis-dns_v1-0.55.0.gem) = ed5103cfdf62fca2e457cba40fcc30ac491bc05db95992fae4f6812537822b1c
+SIZE (rubygem/google-apis-dns_v1-0.55.0.gem) = 40448


### PR DESCRIPTION
Updates rubygem-google-apis-dns_v1 to 0.55.0.

Validation: bmake package, portlint -C, git diff --check.

## Summary by Sourcery

Enhancements:
- Update the Google APIs DNS v1 Ruby gem port to version 0.55.0.