### PR TITLE
dns/rubygem-public_suffix: update to 7.0.2

### DIFF
--- a/dns/rubygem-public_suffix/Makefile
+++ b/dns/rubygem-public_suffix/Makefile
@@ -1,11 +1,12 @@
 PORTNAME=	public_suffix
-PORTVERSION=	6.0.2
+PORTVERSION=	7.0.2
 CATEGORIES=	dns rubygems
 MASTER_SITES=	RG
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Ruby domain name parser based on the Public Suffix List
-WWW=		https://github.com/weppos/publicsuffix-ruby
+WWW=		https://simonecarletti.com/code/publicsuffix-ruby/ \
+		https://github.com/weppos/publicsuffix-ruby
 
 LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE.txt

--- a/dns/rubygem-public_suffix/Makefile
+++ b/dns/rubygem-public_suffix/Makefile
@@ -11,6 +11,7 @@ WWW=		https://simonecarletti.com/code/publicsuffix-ruby/ \
 LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 
+BUILD_DEPENDS=	${PATCH_DEPENDS}
 PATCH_DEPENDS=	public_suffix_list>=0:dns/public_suffix_list
 
 USES=		gem

--- a/dns/rubygem-public_suffix/distinfo
+++ b/dns/rubygem-public_suffix/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1747547474
-SHA256 (rubygem/public_suffix-6.0.2.gem) = bfa7cd5108066f8c9602e0d6d4114999a5df5839a63149d3e8b0f9c1d3558394
-SIZE (rubygem/public_suffix-6.0.2.gem) = 104960
+TIMESTAMP = 1768626693
+SHA256 (rubygem/public_suffix-7.0.2.gem) = 9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+SIZE (rubygem/public_suffix-7.0.2.gem) = 108032


### PR DESCRIPTION
Updates rubygem-public_suffix to 7.0.2.

Validation: bmake package, portlint -C, git diff --check.

## Summary by Sourcery

Enhancements:
- Update the Ruby public_suffix package to version 7.0.2 and refresh its project metadata and build dependencies.