### PR TITLE
devel/libsoup3: update to 3.7.1

### DIFF
--- a/devel/libsoup3/Makefile
+++ b/devel/libsoup3/Makefile
@@ -1,13 +1,13 @@
 PORTNAME=	libsoup
-PORTVERSION=	3.6.6
-PORTREVISION=	2
+PORTVERSION=	3.7.1
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
-DIST_SUBDIR=	gnome
 PKGNAMESUFFIX=	3
+DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	HTTP client/server library for GNOME
+WWW=		https://gitlab.gnome.org/GNOME/libsoup
 
 LICENSE=	lgpl
 LICENSE_FILE=	${WRKSRC}/COPYING
@@ -23,8 +23,9 @@ BUILD_DEPENDS=	glib-networking>0:net/glib-networking \
 		${PYTHON_PKGNAMEPREFIX}typogrify>0:textproc/py-typogrify@${PY_FLAVOR}
 
 LIB_DEPENDS=	libbrotlidec.so:archivers/brotli \
-		libnghttp2.so:www/libnghttp2 \
-		libpsl.so:dns/libpsl
+	libnghttp2.so:www/libnghttp2 \
+	libpsl.so:dns/libpsl \
+	libzstd.so:archivers/zstd
 
 RUN_DEPENDS=	glib-networking>0:net/glib-networking
 
@@ -34,20 +35,20 @@ USE_GNOME=	glib20 intlhack introspection:build libxml2
 USE_LDCONFIG=	yes
 CPE_VENDOR=	gnome
 
+OPTIONS_DEFINE=			VAPI
+OPTIONS_DEFAULT=		GSSAPI_${${SSL_DEFAULT} == base :?BASE :NONE} VAPI
 OPTIONS_SINGLE=			GSSAPI
 OPTIONS_SINGLE_GSSAPI=		GSSAPI_BASE GSSAPI_HEIMDAL GSSAPI_MIT GSSAPI_NONE
-OPTIONS_DEFAULT=		GSSAPI_${${SSL_DEFAULT} == base :?BASE :NONE}
+OPTIONS_SUB=			yes
 
-MESON_ARGS=	-Dtests=false \
-		-Ddocs=disabled \
-		-Dinstalled_tests=false \
+MESON_ARGS=	-Ddocs=disabled \
 		-Dsysprof=disabled \
 		-Dpkcs11_tests=disabled \
 		-Dfuzzing=disabled \
 		-Dautobahn=disabled \
-		-Dtls_check=true \
-		-Dvapi=disabled \
 		-Dntlm=disabled
+
+TESTING_UNSAFE=	Two tests fail due to getting a different error code than the test expects
 
 GSSAPI_BASE_USES=		gssapi
 GSSAPI_BASE_MESON_ON=		-Dgssapi=enabled
@@ -59,6 +60,9 @@ GSSAPI_MIT_USES=		gssapi:mit
 GSSAPI_MIT_MESON_ON=		-Dgssapi=enabled
 
 GSSAPI_NONE_MESON_DISABLED=	gssapi
+
+VAPI_USES=			vala:build
+VAPI_MESON_ENABLED=		vapi
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}
 

--- a/devel/libsoup3/distinfo
+++ b/devel/libsoup3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779061452
-SHA256 (gnome/libsoup-3.6.6.tar.xz) = 51ed0ae06f9d5a40f401ff459e2e5f652f9a510b7730e1359ee66d14d4872740
-SIZE (gnome/libsoup-3.6.6.tar.xz) = 1572004
+TIMESTAMP = 1779822140
+SHA256 (gnome/libsoup-3.7.1.tar.xz) = 9c96e11bb91641fe21948013499ca716393c9e9336562f9ff849c41d4edab80e
+SIZE (gnome/libsoup-3.7.1.tar.xz) = 1586280

--- a/devel/libsoup3/pkg-plist
+++ b/devel/libsoup3/pkg-plist
@@ -43,7 +43,7 @@ include/libsoup-3.0/libsoup/soup.h
 lib/girepository-1.0/Soup-3.0.typelib
 lib/libsoup-3.0.so
 lib/libsoup-3.0.so.0
-lib/libsoup-3.0.so.0.7.4
+lib/libsoup-3.0.so.0.7.3
 libdata/pkgconfig/libsoup-3.0.pc
 share/gir-1.0/Soup-3.0.gir
 share/locale/ab/LC_MESSAGES/libsoup-3.0.mo
@@ -118,3 +118,5 @@ share/locale/vi/LC_MESSAGES/libsoup-3.0.mo
 share/locale/zh_CN/LC_MESSAGES/libsoup-3.0.mo
 share/locale/zh_HK/LC_MESSAGES/libsoup-3.0.mo
 share/locale/zh_TW/LC_MESSAGES/libsoup-3.0.mo
+%%VAPI%%share/vala/vapi/libsoup-3.0.deps
+%%VAPI%%share/vala/vapi/libsoup-3.0.vapi


### PR DESCRIPTION
Updates libsoup3 to 3.7.1 from the FreeBSD ports reference.

Validation: makesum, patch, build, fake, package, test, portlint -C, and git diff --check.

## Summary by Sourcery

Update the libsoup3 port to the 3.7.1 release and align its packaging options and dependencies with the current upstream port reference.

Enhancements:
- Update the libsoup3 port to version 3.7.1 with refreshed dependencies, metadata, packaging, and configurable Vala API support.

Tests:
- Enable the port's test suite and document the known unsafe test failures caused by differing expected error codes.