### PR TITLE
devel/dconf: update to 0.49.0

### DIFF
--- a/devel/dconf/Makefile
+++ b/devel/dconf/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	dconf
-PORTVERSION=	0.40.0
-PORTREVISION=	5
+PORTVERSION=	0.49.0
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 DISTNAME=	dconf-${PORTVERSION}
@@ -8,7 +7,7 @@ DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Configuration database system for GNOME
-WWW=		https://wiki.gnome.org/Projects/dconf
+WWW=		https://gitlab.gnome.org/GNOME/dconf
 
 LICENSE=	lgpl2.1
 LICENSE_FILE=	${WRKSRC}/COPYING
@@ -20,7 +19,8 @@ LIB_DEPENDS=	libdbus-1.so:devel/dbus
 
 PORTSCOUT=	limitw:1,even
 
-USES=		gettext gnome localbase meson pkgconfig python:build tar:xz vala:build
+USES=		gettext gnome localbase meson pkgconfig python:build \
+		shebangfix tar:xz vala:build
 USE_CSTD=	c99
 USE_GNOME=	glib20 libxslt:build
 USE_LDCONFIG=	yes
@@ -29,10 +29,7 @@ USE_BINUTILS=	yes
 LDFLAGS+=	-B${LOCALBASE}/bin
 .endif
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
-
-MESON_ARGS=	-Dman=true \
-		-Dgtk_doc=false \
-		-Dvapi=true
+SHEBANG_FILES=	tests/test-dconf.py
 
 # magus
 NO_TEST=	yes

--- a/devel/dconf/distinfo
+++ b/devel/dconf/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1657827330
-SHA256 (gnome/dconf-0.40.0.tar.xz) = cf7f22a4c9200421d8d3325c5c1b8b93a36843650c9f95d6451e20f0bcb24533
-SIZE (gnome/dconf-0.40.0.tar.xz) = 117764
+TIMESTAMP = 1758011519
+SHA256 (gnome/dconf-0.49.0.tar.xz) = 16a47e49a58156dbb96578e1708325299e4c19eea9be128d5bd12fd0963d6c36
+SIZE (gnome/dconf-0.49.0.tar.xz) = 123832

--- a/devel/dconf/files/patch-client_meson.build
+++ b/devel/dconf/files/patch-client_meson.build
@@ -1,0 +1,11 @@
+--- client/meson.build.orig	2025-09-15 15:53:57 UTC
++++ client/meson.build
+@@ -33,7 +33,7 @@ symbol_map = join_paths(meson.current_source_dir(), 's
+ ]
+
+ symbol_map = join_paths(meson.current_source_dir(), 'symbol.map')
+-ldflags = cc.get_supported_link_arguments('-Wl,--version-script,@0@'.format(symbol_map))
++ldflags = '-Wl,--version-script,@0@'.format(symbol_map)
+
+ libdconf = shared_library(
+   'dconf',

--- a/devel/dconf/files/patch-gsettings_meson.build
+++ b/devel/dconf/files/patch-gsettings_meson.build
@@ -1,0 +1,11 @@
+--- gsettings/meson.build.orig	2025-09-15 15:53:57 UTC
++++ gsettings/meson.build
+@@ -4,7 +4,7 @@ symbol_map = join_paths(meson.current_source_dir(), 's
+ ]
+
+ symbol_map = join_paths(meson.current_source_dir(), 'symbol.map')
+-ldflags = cc.get_supported_link_arguments('-Wl,--version-script,@0@'.format(symbol_map))
++ldflags = '-Wl,--version-script,@0@'.format(symbol_map)
+
+ libdconf_settings = shared_library(
+   'dconfsettings',

--- a/devel/dconf/files/patch-gsettings_symbol.map
+++ b/devel/dconf/files/patch-gsettings_symbol.map
@@ -1,0 +1,11 @@
+--- gsettings/symbol.map.orig	2025-09-15 15:53:57 UTC
++++ gsettings/symbol.map
+@@ -3,8 +3,6 @@ global:
+   g_io_module_load;
+   g_io_module_unload;
+   g_io_module_query;
+-  environ;
+-  __progname;
+ local:
+   *;
+ };

--- a/devel/dconf/pkg-plist
+++ b/devel/dconf/pkg-plist
@@ -20,5 +20,3 @@ share/vala/vapi/dconf.deps
 share/vala/vapi/dconf.vapi
 @dir %%ETCDIR%%/db
 @dir %%ETCDIR%%/profile
-@postexec %D/bin/gio-querymodules %D/lib/gio/modules 2>/dev/null || /usr/bin/true
-@postunexec %D/bin/gio-querymodules %D/lib/gio/modules 2>/dev/null || /usr/bin/true


### PR DESCRIPTION
Updates dconf to 0.49.0 from the FreeBSD ports reference.

Validation: makesum, patch, build, fake, package, test, portlint -C, and git diff --check.

## Summary by Sourcery

Update the dconf port to version 0.49.0 with refreshed build and packaging metadata.

Enhancements:
- Update the dconf port to the 0.49.0 release and its current GNOME project homepage.
- Refresh packaging metadata and build configuration for the newer release, including Python test script handling and updated installed files.