### PR TITLE
textproc/libxslt: update to 1.1.45

### DIFF
--- a/textproc/libxslt/Makefile
+++ b/textproc/libxslt/Makefile
@@ -1,8 +1,7 @@
 PORTNAME=	libxslt
-DISTVERSION=	1.1.43
-PORTREVISION=	2
+DISTVERSION=	1.1.45
 CATEGORIES=	textproc gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${DISTVERSION:R}/
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -14,40 +13,32 @@ LICENSE_FILE=	${WRKSRC}/Copyright
 
 # See note in textproc/libxml2 for why this port uses autotools
 # from the choices of that and CMake.
-USES=		cpe gmake gnome libtool localbase:ldflags pathfix pkgconfig tar:xz
+USES=		cpe gmake gnome libtool localbase:ldflags pathfix perl5 pkgconfig tar:xz
 CPE_VENDOR=	xmlsoft
 GNU_CONFIGURE=	yes
 USE_GNOME=	libxml2
 USE_LDCONFIG=	yes
 
-CONFIGURE_ARGS=	--with-html-dir=${PREFIX}/share/doc \
-		--without-python
+CONFIGURE_ARGS=	--without-python
 INSTALL_TARGET=	install-strip
-#TEST_TARGET=	check
-NO_TEST=	yes
+USE_PERL5=	test
+TEST_TARGET=	check
 
 PLIST_SUB=	LIBVERSION=${PORTVERSION}
 
-OPTIONS_DEFINE=	CRYPTO MEM_DEBUG STATIC
-OPTIONS_DEFAULT=	CRYPTO STATIC
+OPTIONS_DEFINE=	CRYPTO PLUGINS STATIC
+OPTIONS_DEFAULT=	CRYPTO PLUGINS STATIC
 OPTIONS_SUB=		yes
 
 CRYPTO_DESC=	Enable crypto support
-MEM_DEBUG_DESC=	Enable memory debugging
+PLUGINS_DESC=	Enable dynamically-loaded plugins support
 
 CRYPTO_LIB_DEPENDS=	libgcrypt.so:security/libgcrypt \
 			libgpg-error.so:security/libgpg-error
 CRYPTO_CONFIGURE_WITH=	crypto
 
-MEM_DEBUG_CONFIGURE_WITH=	mem-debug
+PLUGINS_CONFIGURE_WITH=	plugins
 
 STATIC_CONFIGURE_ENABLE=	static
-
-post-patch:
-	@${REINPLACE_CMD} -e '/^install-data-am:/ s|install-data-local||' \
-		${WRKSRC}/doc/Makefile.in
-	@${REINPLACE_CMD} -e 's|[$$](bindir)/xsltproc|../xsltproc/xsltproc|g ; \
-		s|[$$](bindir)/xmllint|../xmllint/xmllint|g' \
-		${WRKSRC}/doc/Makefile.in
 
 .include <bsd.port.mk>

--- a/textproc/libxslt/distinfo
+++ b/textproc/libxslt/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1747170090
-SHA256 (gnome/libxslt-1.1.43.tar.xz) = 5a3d6b383ca5afc235b171118e90f5ff6aa27e9fea3303065231a6d403f0183a
-SIZE (gnome/libxslt-1.1.43.tar.xz) = 1518364
+TIMESTAMP = 1788842360
+SHA256 (gnome/libxslt-1.1.45.tar.xz) = 9acfe68419c4d06a45c550321b3212762d92f41465062ca4ea19e632ee5d216e
+SIZE (gnome/libxslt-1.1.45.tar.xz) = 1519992

--- a/textproc/libxslt/pkg-plist
+++ b/textproc/libxslt/pkg-plist
@@ -17,6 +17,7 @@ include/libxslt/preproc.h
 include/libxslt/security.h
 include/libxslt/templates.h
 include/libxslt/transform.h
+include/libxslt/transformInternals.h
 include/libxslt/variables.h
 include/libxslt/xslt.h
 include/libxslt/xsltInternals.h
@@ -29,17 +30,14 @@ lib/cmake/libxslt/libxslt-config.cmake
 %%STATIC%%lib/libexslt.a
 lib/libexslt.so
 lib/libexslt.so.0
-lib/libexslt.so.0.8.24
+lib/libexslt.so.0.8.25
 %%STATIC%%lib/libxslt.a
 lib/libxslt.so
 lib/libxslt.so.1
-lib/libxslt.so.1.1.43
+lib/libxslt.so.%%LIBVERSION%%
 lib/xsltConf.sh
 libdata/pkgconfig/libexslt.pc
 libdata/pkgconfig/libxslt.pc
-share/man/man1/xsltproc.1.gz
-share/man/man3/libexslt.3.gz
-share/man/man3/libxslt.3.gz
 share/gtk-doc/html/libexslt/general.html
 share/gtk-doc/html/libexslt/home.png
 share/gtk-doc/html/libexslt/index.html
@@ -78,4 +76,7 @@ share/gtk-doc/html/libxslt/libxslt.devhelp2
 share/gtk-doc/html/libxslt/right.png
 share/gtk-doc/html/libxslt/style.css
 share/gtk-doc/html/libxslt/up.png
-@dir lib/libxslt-plugins
+share/man/man1/xsltproc.1.gz
+share/man/man3/libexslt.3.gz
+share/man/man3/libxslt.3.gz
+%%PLUGINS%%@dir lib/libxslt-plugins


### PR DESCRIPTION
Updates libxslt to 1.1.45 from the FreeBSD ports reference.

Validation: makesum, patch, build, fake, package, test (751 passed), portlint -C, and git diff --check.

## Summary by Sourcery

Update the libxslt port to 1.1.45 with refreshed options, packaging metadata, and test integration.

Enhancements:
- Update libxslt to version 1.1.45 and align its packaging with the current upstream port configuration.
- Add optional dynamically loaded plugin support and enable the upstream test suite during port validation.

Tests:
- Enable libxslt's Perl-based test target for package validation.