### PR TITLE
devel/py-wcwidth: update to 0.8.2

### DIFF
--- a/devel/py-wcwidth/Makefile
+++ b/devel/py-wcwidth/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	wcwidth
-PORTVERSION=	0.2.8
-PORTREVISION=	1
+PORTVERSION=	0.8.2
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -10,9 +9,12 @@ COMMENT=	Determine the printable width of the terminal
 WWW=		https://github.com/jquast/wcwidth
 
 LICENSE=	mit
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}hatchling>=0:devel/py-hatchling@${PY_FLAVOR}
 
 NO_ARCH=	yes
 USES=		python
-USE_PYTHON=	autoplist concurrent distutils
+USE_PYTHON=	autoplist concurrent pep517
 
 .include <bsd.port.mk>

--- a/devel/py-wcwidth/distinfo
+++ b/devel/py-wcwidth/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1697160405
-SHA256 (wcwidth-0.2.8.tar.gz) = 8705c569999ffbb4f6a87c6d1b80f324bd6db952f5eb0b95bc07517f4c1813d4
-SIZE (wcwidth-0.2.8.tar.gz) = 61713
+TIMESTAMP = 1782966512
+SHA256 (wcwidth-0.8.2.tar.gz) = 91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda
+SIZE (wcwidth-0.8.2.tar.gz) = 1466253


### PR DESCRIPTION
Updates py-wcwidth to 0.8.2 from the FreeBSD ports reference.

Validation: makesum, patch, build, fake, clean package, check-license, 1,318 upstream tests (10 skipped), portlint -C, and git diff --check.

## Summary by Sourcery

Update the wcwidth Python port to version 0.8.2 using its current packaging metadata and build configuration.

Enhancements:
- Update the wcwidth Python port to version 0.8.2 and migrate it to the modern PEP 517 build system.
- Declare the package license file and add the Hatchling build dependency.