### PR TITLE
audio/rhythmbox: update to 3.4.9

### DIFF
--- a/audio/rhythmbox/Makefile
+++ b/audio/rhythmbox/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	rhythmbox
-PORTVERSION=	3.4.8
-PORTREVISION=	1
+PORTVERSION=	3.4.9
 CATEGORIES=	audio gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -15,13 +14,10 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 BUILD_DEPENDS=	${LOCALBASE}/include/linux/videodev2.h:multimedia/v4l_compat \
 		itstool:textproc/itstool
 LIB_DEPENDS=	libtotem-plparser.so:multimedia/totem-pl-parser \
-		libdbus-1.so:devel/dbus \
-		libdbus-glib-1.so:devel/dbus-glib \
 		libsoup-3.0.so:devel/libsoup3 \
 		libpeas-1.0.so:devel/libpeas1 \
 		libjson-glib-1.0.so:devel/json-glib \
 		libsecret-1.so:security/libsecret \
-		libgudev-1.0.so:devel/libgudev \
 		libtdb.so:databases/tdb
 
 USES=		desktop-file-utils gettext gnome gstreamer localbase:ldflags meson \
@@ -29,15 +25,14 @@ USES=		desktop-file-utils gettext gnome gstreamer localbase:ldflags meson \
 USE_GNOME=	cairo gdkpixbuf glib20 gtk30 introspection libxml2
 USE_XORG=	ice x11 xorgproto
 USE_GSTREAMER=	flac lame jpeg cdparanoia vorbis
-MESON_ARGS=	-Dapidoc=false \
-		-Dtests=disabled
+MESON_ARGS=	-Dtests=disabled
 USE_LDCONFIG=	yes
 
 GLIB_SCHEMAS=	org.gnome.rhythmbox.gschema.xml
 
 OPTIONS_SUB=	yes
-OPTIONS_DEFINE=	BRASERO DAAP DOCS GRILO IPOD LIRC MTP NLS NOTIFY PYTHON
-OPTIONS_DEFAULT=BRASERO NOTIFY PYTHON
+OPTIONS_DEFINE=	BRASERO DAAP GRILO IPOD LIRC MTP NLS NOTIFY PYTHON
+OPTIONS_DEFAULT=NOTIFY PYTHON
 BRASERO_DESC=	Brasero disc burning support
 BRASERO_MESON_ENABLED=	brasero
 BRASERO_LIB_DEPENDS=	libbrasero-media3.so:sysutils/brasero
@@ -46,9 +41,8 @@ DAAP_MESON_ENABLED=	daap
 DAAP_LIB_DEPENDS=	libdmapsharing-4.0.so:net/libdmapsharing
 GRILO_DESC=		Media discovery with Grilo
 GRILO_MESON_ENABLED=	grilo
-GRILO_BUILD_DEPENDS=	grilo>=0.3.1:net/grilo
 GRILO_LIB_DEPENDS=	libgrilo-0.3.so:net/grilo
-GRILO_RUN_DEPENDS=	grilo-plugins>=0.3.2:net/grilo-plugins
+GRILO_RUN_DEPENDS=	grilo-plugins>0:net/grilo-plugins
 IPOD_DESC=		iPod support
 IPOD_MESON_ENABLED=	ipod
 IPOD_LIB_DEPENDS=	libgpod.so:audio/libgpod \
@@ -56,14 +50,18 @@ IPOD_LIB_DEPENDS=	libgpod.so:audio/libgpod \
 			libimobiledevice-1.0.so:comms/libimobiledevice
 LIRC_MESON_ENABLED=	lirc
 LIRC_LIB_DEPENDS=	liblirc_client.so:comms/lirc
-MTP_MESON_ENABLED=	mtp
-MTP_LIB_DEPENDS=	libmtp.so:multimedia/libmtp
+MTP_MESON_ENABLED=	mtp gudev
+MTP_LIB_DEPENDS=	libmtp.so:multimedia/libmtp \
+			libgudev-1.0.so:devel/libgudev
 NOTIFY_MESON_ENABLED=	libnotify
 NOTIFY_LIB_DEPENDS=	libnotify.so:devel/libnotify
 PYTHON_MESON_ENABLED=	plugins_python
 PYTHON_USES=		python
 PYTHON_USE=		gnome=pygobject3
-PYTHON_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}libpeas1>=0:devel/py-libpeas1@${PY_FLAVOR}
+PYTHON_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}libpeas1>=0:devel/py-libpeas1@${PY_FLAVOR} \
+			zeitgeist>0:sysutils/zeitgeist \
+			avahi-app>0:net/avahi-app
 PYTHON_BINARY_ALIAS=	python3=${PYTHON_CMD}
+PYTHON_BROKEN_OFF=	https://gitlab.gnome.org/GNOME/rhythmbox/-/work_items/2135
 
 .include <bsd.port.mk>

--- a/audio/rhythmbox/distinfo
+++ b/audio/rhythmbox/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741163451
-SHA256 (gnome/rhythmbox-3.4.8.tar.xz) = 2016a8a8d2a959c07a467ac9682c6ed605ba8883fb760410d68b68ab838df9f2
-SIZE (gnome/rhythmbox-3.4.8.tar.xz) = 3679500
+TIMESTAMP = 1788875510
+SHA256 (gnome/rhythmbox-3.4.9.tar.xz) = e42291a18df7a21ffe6b352bf73f05d7e298bb4e05bce5967f98ee8cee4408f1
+SIZE (gnome/rhythmbox-3.4.9.tar.xz) = 3686916

--- a/audio/rhythmbox/pkg-plist
+++ b/audio/rhythmbox/pkg-plist
@@ -88,8 +88,6 @@ lib/librhythmbox-core.so.10.0.0
 %%PYTHON%%lib/rhythmbox/plugins/artsearch/musicbrainz.py
 %%PYTHON%%lib/rhythmbox/plugins/artsearch/oldcache.py
 %%PYTHON%%lib/rhythmbox/plugins/artsearch/songinfo.py
-lib/rhythmbox/plugins/android/android.plugin
-lib/rhythmbox/plugins/android/libandroid.so
 lib/rhythmbox/plugins/audiocd/audiocd.plugin
 lib/rhythmbox/plugins/audiocd/libaudiocd.so
 lib/rhythmbox/plugins/audioscrobbler/audioscrobbler.plugin


### PR DESCRIPTION
Updates Rhythmbox to 3.4.9 from the FreeBSD ports reference while retaining available MidnightBSD GStreamer dependencies.

Validation: makesum, patch, clean package, AppData test (1/1), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the Rhythmbox port to 3.4.9 while preserving supported optional integrations and current platform dependencies.

Enhancements:
- Update the Rhythmbox port to version 3.4.9 and align its dependency and optional feature definitions with the newer release.
- Adjust Python plugin dependencies and mark the Python option as broken due to an upstream issue.
- Refresh the package metadata and installed file list for the updated release.