### PR TITLE
x11/gnome-desktop: update to 44.5

### DIFF
--- a/x11/gnome-desktop/Makefile
+++ b/x11/gnome-desktop/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnome-desktop
-PORTVERSION=	44.4
+PORTVERSION=	44.5
 CATEGORIES=	x11 gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -15,22 +15,20 @@ BUILD_DEPENDS=	iso-codes>0:misc/iso-codes \
 		gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas \
 		xkeyboard-config>0:x11/xkeyboard-config
 LIB_DEPENDS=	libxkbregistry.so:x11/libxkbcommon \
-		libudev.so:devel/libudev-devd \
-		libgudev-1.0.so:devel/libgudev
+		libudev.so:devel/libudev-devd
 RUN_DEPENDS=	iso-codes>0:misc/iso-codes \
 		gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas \
 		cantarell-fonts>0:x11-fonts/cantarell-fonts \
 		source-code-pro-ttf>0:x11-fonts/source-code-pro-ttf \
 		xkeyboard-config>0:x11/xkeyboard-config
 
-USES=		bison cpe gettext-tools gnome localbase:ldflags meson \
+USES=		cpe gettext-tools gnome localbase:ldflags meson \
 		pkgconfig tar:xz xorg
 USE_GNOME=	cairo gdkpixbuf gtk30 gtk40 introspection:build
 USE_XORG=	x11
 USE_LDCONFIG=	yes
 MESON_ARGS=	-Dudev=enabled \
 		-Dsystemd=disabled \
-		-Dgtk_doc=false \
 		-Ddebug_tools=false \
 		-Ddesktop_docs=false
 CPE_VENDOR=	gnome

--- a/x11/gnome-desktop/distinfo
+++ b/x11/gnome-desktop/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1757402369
-SHA256 (gnome/gnome-desktop-44.4.tar.xz) = 1d8cb9c6a328eb689b0c1269cf53834cc84d851d7e71970cdabba82706b44984
-SIZE (gnome/gnome-desktop-44.4.tar.xz) = 763656
+TIMESTAMP = 1788879267
+SHA256 (gnome/gnome-desktop-44.5.tar.xz) = 20e0995a6e3a03e8c1026c5a27bc3f45e69ffcc392ad743dcab6107a541d232f
+SIZE (gnome/gnome-desktop-44.5.tar.xz) = 765220

--- a/x11/gnome-desktop/files/patch-libgnome-desktop_gnome-desktop-thumbnail-script.c
+++ b/x11/gnome-desktop/files/patch-libgnome-desktop_gnome-desktop-thumbnail-script.c
@@ -1,0 +1,17 @@
+--- libgnome-desktop/gnome-desktop-thumbnail-script.c.orig	2026-02-09 00:58:33 UTC
++++ libgnome-desktop/gnome-desktop-thumbnail-script.c
+@@ -31,7 +31,6 @@
+ #include <glib/gstdio.h>
+ #include <string.h>
+ #include <stdlib.h>
+-#include <sys/personality.h>
+ #include <sys/stat.h>
+ #include <fcntl.h>
+
+@@ -40,6 +39,7 @@
+ #include <sys/socket.h>
+ #include <sys/ioctl.h>
+ #include <sys/utsname.h>
++#include <sys/personality.h>
+ #include <seccomp.h>
+ #endif


### PR DESCRIPTION
Updates gnome-desktop to 44.5 from the FreeBSD ports reference and adds the MidnightBSD sys/personality include-order portability fix.

Validation: makesum, patch, build, fake, clean package, tests (4/4), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the GNOME desktop library to 44.5 with the required portability adjustment for MidnightBSD.

Bug Fixes:
- Restore portability for the thumbnail script by adjusting the sys/personality header include order.

Enhancements:
- Update gnome-desktop to version 44.5 and align its dependency and build configuration with the newer release.