### PR TITLE
games/aisleriot: fix patch whitespace

### DIFF
--- a/games/aisleriot/files/patch-meson.build
+++ b/games/aisleriot/files/patch-meson.build
@@ -1,22 +1,22 @@
 --- meson.build.orig	2023-09-17 17:11:49 UTC
 +++ meson.build
 @@ -263,11 +263,7 @@ foreach
- 
+
  # Distribution
- 
+
 -distro = run_command(
 -  'bash',
 -  '-c',
 -  'source /etc/os-release && echo $ID || echo unknown; exit 0'
 -).stdout().strip()
 +distro = host_machine.system().to_lower()
- 
+
  # Options
- 
+
 @@ -280,6 +276,7 @@ theme_kde_base_paths = {
    'ubuntu':   '/usr/share/kde4/apps/carddecks',
  }
- 
+
 +# games/pysolfc-cardsets
  theme_pysol_base_paths = {
    'centos':   '/usr/share/PySolFC',
@@ -27,5 +27,5 @@
    'ubuntu':   '/usr/share/games/pysol',
 +  'freebsd':  '/usr/local/share/PySolFC',
  }
- 
+
  theme_kde_path = get_option('theme_kde_path')


### PR DESCRIPTION
Removes trailing whitespace from the Meson portability patch introduced by #899.

Validation: git diff --check.

## Summary by Sourcery

Bug Fixes:
- Remove trailing whitespace from the Aisleriot Meson portability patch.