### PR TITLE
security/gnome-keyring: update to 48.0

### DIFF
--- a/security/gnome-keyring/Makefile
+++ b/security/gnome-keyring/Makefile
@@ -1,12 +1,12 @@
 PORTNAME=	gnome-keyring
-PORTVERSION=	42.1
-PORTREVISION=	7
+PORTVERSION=	48.0
 CATEGORIES=	security gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Program that keeps passwords and other secrets
+WWW=		https://gitlab.gnome.org/GNOME/gnome-keyring
 
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/COPYING
@@ -22,15 +22,14 @@ RUN_DEPENDS=	pinentry-gnome3:security/pinentry-gnome
 
 PORTSCOUT=	limitw:1,even
 
-USE_GNOME=	cairo gtk30 intlhack libxslt:build
-USES=		compiler:c11 cpe gettext gmake gnome libtool localbase \
-		pathfix pkgconfig tar:xz
+USES=		compiler:c11 cpe gettext meson gnome localbase \
+		pkgconfig tar:xz
+USE_GNOME=	cairo glib20 gtk30 libxslt:build
 CPE_VENDOR=	gnome
-GNU_CONFIGURE=	yes
-GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
 USE_LDCONFIG=	yes
-CONFIGURE_ARGS=	--with-pam-dir="${PREFIX}/lib"
-INSTALL_TARGET=	install-strip
+MESON_ARGS=	-Dssh-agent=true \
+		-Dselinux=disabled \
+		-Dsystemd=disabled
 GLIB_SCHEMAS=	org.gnome.crypto.cache.gschema.xml
 
 SUB_FILES=	pkg-message

--- a/security/gnome-keyring/distinfo
+++ b/security/gnome-keyring/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1660069108
-SHA256 (gnome/gnome-keyring-42.1.tar.xz) = c7f4d040cc76a6b7fe67e08ef9106911c3c80d40fc88cbfc8e2684a4c946e3e6
-SIZE (gnome/gnome-keyring-42.1.tar.xz) = 1346284
+TIMESTAMP = 1788842862
+SHA256 (gnome/gnome-keyring-48.0.tar.xz) = f20518c920e9ea3f9c9b8b44be8c50d8d7feecd0dd5624960f77bd2ca4fbeb9d
+SIZE (gnome/gnome-keyring-48.0.tar.xz) = 767428

--- a/security/gnome-keyring/files/patch-egg_egg-unix-credentials.c
+++ b/security/gnome-keyring/files/patch-egg_egg-unix-credentials.c
@@ -1,0 +1,10 @@
+--- egg/egg-unix-credentials.c.orig	2025-03-18 08:38:44 UTC
++++ egg/egg-unix-credentials.c
+@@ -145 +145,3 @@ egg_unix_credentials_read (int sock, pid_t *pid, uid_t
+-		set_local_creds(sock, 0);
++#ifndef __FreeBSD__
++		set_local_creds(sock, 0);
++#endif
+@@ -233 +235 @@ egg_unix_credentials_setup (int sock)
+-		fprintf (stderr, "unable to set LOCAL_CREDS socket option on fd %d\n", fd);
++		fprintf (stderr, "unable to set LOCAL_CREDS socket option\n");

--- a/security/gnome-keyring/files/patch-meson.build
+++ b/security/gnome-keyring/files/patch-meson.build
@@ -1,0 +1,9 @@
+--- meson.build.orig	2025-03-18 08:38:44 UTC
++++ meson.build
+@@ -105,6 +105,7 @@ conf.set('DOTLOCK_GLIB_LOGGING', true)
+ conf.set('DOTLOCK_EXT_SYM_PREFIX', '_gkm_')
+ conf.set('HAVE_SOCKLEN_T', have_socklen_t)
++conf.set('HAVE_CMSGCRED', have_struct_cmsgcred)
+ conf.set('HAVE_GETPEERUCRED', cc.has_function('getpeerucred'))
+ conf.set('HAVE_GETPEEREID', cc.has_function('getpeereid'))
+ conf.set('HAVE_FLOCK', cc.has_function('flock'))

--- a/security/gnome-keyring/files/patch-pam_meson.build
+++ b/security/gnome-keyring/files/patch-pam_meson.build
@@ -1,0 +1,9 @@
+--- pam/meson.build.orig	2025-03-18 08:38:44 UTC
++++ pam/meson.build
+@@ -33,7 +33,7 @@ libpam_gkr = shared_library('pam_gnome_keyring',
+   link_depends: pam_gkr_symbolmap,
+   include_directories: config_h_inc,
+   install: true,
+-  install_dir: get_option('libdir') / 'security',
++  install_dir: get_option('libdir'),
+ )

--- a/security/gnome-keyring/pkg-plist
+++ b/security/gnome-keyring/pkg-plist
@@ -10,13 +10,11 @@ lib/gnome-keyring/devel/gkm-ssh-store-standalone.so
 lib/gnome-keyring/devel/gkm-xdg-store-standalone.so
 lib/pam_gnome_keyring.so
 lib/pkcs11/gnome-keyring-pkcs11.so
-share/man/man1/gnome-keyring-3.1.gz
-share/man/man1/gnome-keyring-daemon.1.gz
-share/man/man1/gnome-keyring.1.gz
 share/GConf/gsettings/org.gnome.crypto.cache.convert
 share/dbus-1/services/org.freedesktop.impl.portal.Secret.service
 share/dbus-1/services/org.freedesktop.secrets.service
 share/dbus-1/services/org.gnome.keyring.service
+share/locale/ab/LC_MESSAGES/gnome-keyring.mo
 share/locale/af/LC_MESSAGES/gnome-keyring.mo
 share/locale/ar/LC_MESSAGES/gnome-keyring.mo
 share/locale/as/LC_MESSAGES/gnome-keyring.mo
@@ -61,6 +59,7 @@ share/locale/is/LC_MESSAGES/gnome-keyring.mo
 share/locale/it/LC_MESSAGES/gnome-keyring.mo
 share/locale/ja/LC_MESSAGES/gnome-keyring.mo
 share/locale/ka/LC_MESSAGES/gnome-keyring.mo
+share/locale/kab/LC_MESSAGES/gnome-keyring.mo
 share/locale/kk/LC_MESSAGES/gnome-keyring.mo
 share/locale/km/LC_MESSAGES/gnome-keyring.mo
 share/locale/kn/LC_MESSAGES/gnome-keyring.mo
@@ -107,5 +106,8 @@ share/locale/xh/LC_MESSAGES/gnome-keyring.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-keyring.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-keyring.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-keyring.mo
+share/man/man1/gnome-keyring-3.1.gz
+share/man/man1/gnome-keyring-daemon.1.gz
+share/man/man1/gnome-keyring.1.gz
 share/p11-kit/modules/gnome-keyring.module
 share/xdg-desktop-portal/portals/gnome-keyring.portal


### PR DESCRIPTION
Updates gnome-keyring from 42.1 to 48.0 and migrates the port to Meson.

Includes MidnightBSD credential handling and PAM install-path fixes.

Validation:
- bmake package
- bmake check-license
- portlint -C (0 fatal; existing style warnings)
- git diff --check
- dbus-run-session -- meson test: 60/62 pass. Two upstream behavior assertions remain: secret-fields parse_null_invalid and daemon startup control/noaccess. The test target is retained; no NO_TEST was added.

LICENSE remains gpl2 as requested.

## Summary by Sourcery

Update the gnome-keyring port to 48.0 with Meson-based configuration and MidnightBSD compatibility fixes.

Bug Fixes:
- Add MidnightBSD-compatible credential handling and correct PAM installation paths.

Enhancements:
- Update gnome-keyring to version 48.0 and migrate the port from Autotools to Meson.

Tests:
- Retain and validate the Meson test target, with 60 of 62 tests passing against the upstream behavior assertions.