### PR TITLE
x11/ptyxis: update to 47.13

### DIFF
--- a/x11/ptyxis/Makefile
+++ b/x11/ptyxis/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	ptyxis
-DISTVERSION=	47.10 # 48 still as a rc
+DISTVERSION=	47.13
 CATEGORIES=	x11 gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -16,9 +16,10 @@ LIB_DEPENDS=	libportal-gtk4.so:deskutils/libportal-gtk4 \
 							libjson-glib-1.0.so:devel/json-glib
 RUN_DEPENDS=	gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
 
-USES=		cpe desktop-file-utils gettext gnome localbase:ldflags meson pkgconfig
-USE_GNOME=	dconf gdkpixbuf glib20 gtk40 intltool libadwaita pango vte3
+USES=		cpe desktop-file-utils gettext gnome localbase:ldflags meson pkgconfig tar:xz
+USE_GNOME=	dconf gdkpixbuf glib20 gtk40 libadwaita pango vte3
 
 GLIB_SCHEMAS=	org.gnome.Ptyxis.gschema.xml
+INSTALLS_ICONS=	yes
 
 .include <bsd.port.mk>

--- a/x11/ptyxis/distinfo
+++ b/x11/ptyxis/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1742055179
-SHA256 (gnome/ptyxis-47.10.tar.gz) = 35ba18c3c34b1abb751dd02413e957988abde0757d9a232057b4e8ab8a230a0d
-SIZE (gnome/ptyxis-47.10.tar.gz) = 2606884
+TIMESTAMP = 1788920346
+SHA256 (gnome/ptyxis-47.13.tar.xz) = a47e5a9c64ea0ad9cc2e2599ae95c0c62f6c3110b888e6e4c3a9ab2ccb1031e2
+SIZE (gnome/ptyxis-47.13.tar.xz) = 2298840

--- a/x11/ptyxis/pkg-plist
+++ b/x11/ptyxis/pkg-plist
@@ -12,6 +12,7 @@ share/locale/es/LC_MESSAGES/ptyxis.mo
 share/locale/eu/LC_MESSAGES/ptyxis.mo
 share/locale/fa/LC_MESSAGES/ptyxis.mo
 share/locale/fi/LC_MESSAGES/ptyxis.mo
+share/locale/fr/LC_MESSAGES/ptyxis.mo
 share/locale/he/LC_MESSAGES/ptyxis.mo
 share/locale/hi/LC_MESSAGES/ptyxis.mo
 share/locale/id/LC_MESSAGES/ptyxis.mo


### PR DESCRIPTION
Updates Ptyxis from 47.10 to 47.13.\n\n- Preserve MidnightBSD portability patches\n- Add the new French translation and icon-cache metadata\n- GPL-3.0-or-later source declarations confirm existing gpl3+ metadata\n\nValidation:\n- bmake makesum\n- bmake patch\n- bmake build\n- bmake fake\n- bmake clean package\n- bmake test (3/3 passed)\n- bmake check-license\n- portlint -C . (0 fatals; 3 existing style warnings)\n- git diff --check

## Summary by Sourcery

Update the Ptyxis port to version 47.13 and align its packaging metadata with the release.

Enhancements:
- Update the Ptyxis port to release 47.13 while retaining its existing portability support.

Build:
- Adjust the port to handle the updated release archive format and remove the obsolete intltool dependency.

Chores:
- Install the application’s icon metadata and update package contents for the new release.