### PR TITLE
Update gucharmap to 17.0.2

### DIFF
--- a/deskutils/gucharmap/Makefile
+++ b/deskutils/gucharmap/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gucharmap
-PORTVERSION=	17.0.0 # must sync with textproc/UCD
+PORTVERSION=	17.0.2 # must sync with textproc/UCD
 CATEGORIES=	deskutils gnome
 DIST_SUBDIR=	gnome
 

--- a/deskutils/gucharmap/distinfo
+++ b/deskutils/gucharmap/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1757593163
-SHA256 (gnome/gucharmap-17.0.0.tar.bz2) = 09988f67ae82d057a993ab21df2ac94503a8a836da5f8e36e5e8864d8d45a295
-SIZE (gnome/gucharmap-17.0.0.tar.bz2) = 1505830
+TIMESTAMP = 1788920922
+SHA256 (gnome/gucharmap-17.0.2.tar.bz2) = d5aa79bee703846af9ba477803e0fd8c8f63d9c7c522a48e64ebf304bfbfe324
+SIZE (gnome/gucharmap-17.0.2.tar.bz2) = 1514068


### PR DESCRIPTION
Updates deskutils/gucharmap from 17.0.0 to 17.0.2.

Upstream 17.0.2 explicitly requires Unicode 17.0.0, so the existing textproc/UCD dependency remains correct.

Validation:
- bmake makesum, patch, build, fake, clean package
- bmake test (no tests defined)
- bmake check-license
- portlint -C deskutils/gucharmap (0 fatals; NLS warning)
- git diff --check

## Summary by Sourcery

Enhancements:
- Update the gucharmap port to release 17.0.2 while retaining its synchronized Unicode 17.0.0 dependency.