### PR TITLE
filesystems/libgedit-gfls: update to 0.4.1

### DIFF
--- a/filesystems/libgedit-gfls/Makefile
+++ b/filesystems/libgedit-gfls/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libgedit-gfls
-DISTVERSION=	0.3.0
+DISTVERSION=	0.4.1
 CATEGORIES=	filesystems gnome
 DIST_SUBDIR=	gnome
 
@@ -9,12 +9,12 @@ WWW=		https://gitlab.gnome.org/World/gedit/libgedit-gfls
 
 LICENSE=	lgpl3+
 
-USES=		gettext gnome meson pkgconfig tar:bz2
-USE_GNOME=	glib20 gtk30 introspection:build
-
+USES=		gettext-tools gnome meson pkgconfig tar:bz2
 USE_GITLAB=	yes
 GL_SITE=	https://gitlab.gnome.org
 GL_ACCOUNT=	World/gedit
+USE_GNOME=	glib20 gtk30 introspection:build
+USE_LDCONFIG=	yes
 
 MESON_ARGS=	-Dgtk_doc=false \
 		-Dtests=false

--- a/filesystems/libgedit-gfls/distinfo
+++ b/filesystems/libgedit-gfls/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1746189344
-SHA256 (gnome/libgedit-gfls-0.3.0.tar.bz2) = a53c847a2dc16f35a9295b2176bde4dbaa91bd1410af8546992fd65236bccf95
-SIZE (gnome/libgedit-gfls-0.3.0.tar.bz2) = 30215
+TIMESTAMP = 1788921343
+SHA256 (gnome/libgedit-gfls-0.4.1.tar.bz2) = e252267943c6f582d6314969c9b33066635fe04ff518e7292f5fd461c60acdd4
+SIZE (gnome/libgedit-gfls-0.4.1.tar.bz2) = 44185


### PR DESCRIPTION
Updates libgedit-gfls from 0.3.0 to 0.4.1.\n\nThe source tree declares LGPL-3.0-or-later throughout, so the existing lgpl3+ license remains accurate.\n\nValidated:\n- bmake makesum\n- bmake patch\n- bmake build\n- bmake fake\n- bmake clean package\n- bmake test (no tests defined)\n- bmake check-license\n- portlint -C . (0 fatal errors; 2 existing style warnings)\n- git diff --check