### PR TITLE
devel/jsonrpc-glib: update to 3.44.2

### DIFF
--- a/devel/jsonrpc-glib/Makefile
+++ b/devel/jsonrpc-glib/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	jsonrpc-glib
-PORTVERSION=	3.44.1
+PORTVERSION=	3.44.2
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
 
@@ -14,5 +14,6 @@ LIB_DEPENDS=	libjson-glib-1.0.so:devel/json-glib
 
 USES=		compiler:c11 gnome meson pkgconfig tar:xz vala:build
 USE_GNOME=	glib20 introspection:build
+USE_LDCONFIG=	yes
 
 .include <bsd.port.mk>

--- a/devel/jsonrpc-glib/distinfo
+++ b/devel/jsonrpc-glib/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741872025
-SHA256 (jsonrpc-glib-3.44.1.tar.xz) = 1361d17e9c805646afe5102e59baf8ca450238600fcabd01586c654b78bb30df
-SIZE (jsonrpc-glib-3.44.1.tar.xz) = 42600
+TIMESTAMP = 1788925134
+SHA256 (jsonrpc-glib-3.44.2.tar.xz) = 965496b6e1314f3468b482a5d80340dc3b0340a5402d7783cad24154aee77396
+SIZE (jsonrpc-glib-3.44.2.tar.xz) = 42724

--- a/devel/jsonrpc-glib/pkg-plist
+++ b/devel/jsonrpc-glib/pkg-plist
@@ -10,7 +10,7 @@ include/jsonrpc-glib-1.0/jsonrpc-version.h
 lib/girepository-1.0/Jsonrpc-1.0.typelib
 lib/libjsonrpc-glib-1.0.so
 lib/libjsonrpc-glib-1.0.so.1
-lib/libjsonrpc-glib-1.0.so.1.4400.1
+lib/libjsonrpc-glib-1.0.so.1.4400.2
 libdata/pkgconfig/jsonrpc-glib-1.0.pc
 share/gir-1.0/Jsonrpc-1.0.gir
 share/vala/vapi/jsonrpc-glib-1.0.deps


### PR DESCRIPTION
Update jsonrpc-glib to 3.44.2.

The shared library micro-version changed to `1.4400.2`; add `USE_LDCONFIG` and refresh the plist entry.

License remains LGPL-2.1-or-later.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake clean package
- bmake test (4/4 passed)
- bmake check-license
- portlint -C . (0 fatals; one maintainer-mode advisory)
- git diff --check

## Summary by Sourcery

Update the jsonrpc-glib port to the 3.44.2 release.

Enhancements:
- Update the jsonrpc-glib port to version 3.44.2 and enable shared-library runtime path handling.

Chores:
- Refresh the package checksums and plist for the new library micro-version.