### PR TITLE
x11-toolkits/libpanel: update to 1.10.4

### DIFF
--- a/x11-toolkits/libpanel/Makefile
+++ b/x11-toolkits/libpanel/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libpanel
-PORTVERSION=	1.10.2
+PORTVERSION=	1.10.4
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -14,6 +14,7 @@ LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
 
 USES=		gettext-tools gnome meson pkgconfig tar:xz vala:build
 USE_GNOME=	cairo glib20 gtk40 introspection:build libadwaita
+USE_LDCONFIG=	yes
 
 MESON_ARGS=	-Dintrospection=enabled \
 		-Ddocs=disabled

--- a/x11-toolkits/libpanel/distinfo
+++ b/x11-toolkits/libpanel/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1757756043
-SHA256 (gnome/libpanel-1.10.2.tar.xz) = cc12e8e10f1e4977bd12ad3ffaedcd52ac176348b4af6fe5da686b96325bfe01
-SIZE (gnome/libpanel-1.10.2.tar.xz) = 166924
+TIMESTAMP = 1788925522
+SHA256 (gnome/libpanel-1.10.4.tar.xz) = 593888a7691f0af8aaa6e193c9e14afa86a810c0c2f27515c6d813f18733b1cd
+SIZE (gnome/libpanel-1.10.4.tar.xz) = 169424

--- a/x11-toolkits/libpanel/pkg-plist
+++ b/x11-toolkits/libpanel/pkg-plist
@@ -73,7 +73,9 @@ share/locale/is/LC_MESSAGES/libpanel.mo
 share/locale/it/LC_MESSAGES/libpanel.mo
 share/locale/ka/LC_MESSAGES/libpanel.mo
 share/locale/kab/LC_MESSAGES/libpanel.mo
+share/locale/kk/LC_MESSAGES/libpanel.mo
 share/locale/ko/LC_MESSAGES/libpanel.mo
+share/locale/kw/LC_MESSAGES/libpanel.mo
 share/locale/lt/LC_MESSAGES/libpanel.mo
 share/locale/lv/LC_MESSAGES/libpanel.mo
 share/locale/nb/LC_MESSAGES/libpanel.mo
@@ -91,6 +93,7 @@ share/locale/sl/LC_MESSAGES/libpanel.mo
 share/locale/sr/LC_MESSAGES/libpanel.mo
 share/locale/sv/LC_MESSAGES/libpanel.mo
 share/locale/tr/LC_MESSAGES/libpanel.mo
+share/locale/ug/LC_MESSAGES/libpanel.mo
 share/locale/uk/LC_MESSAGES/libpanel.mo
 share/locale/zh_CN/LC_MESSAGES/libpanel.mo
 share/locale/zh_TW/LC_MESSAGES/libpanel.mo


### PR DESCRIPTION
Updates libpanel to 1.10.4.

Includes the three newly shipped translation catalogs and registers the installed shared library with the runtime linker cache.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake clean package
- bmake test / meson test (completed; upstream defines no tests)
- bmake check-license
- portlint -C (0 fatal errors; existing icon/NLS/style advisories)
- git diff --check

LICENSE remains lgpl3+. Upstream COPYING identifies LGPL version 3 with the later-version option; no license metadata change was made.

## Summary by Sourcery

Update the libpanel port to the 1.10.4 release.

Enhancements:
- Update libpanel to version 1.10.4 and register its shared library with the runtime linker cache.
- Include the three translation catalogs shipped by the updated release.