### PR TITLE
net/gnome-online-accounts: update to 3.54.11

### DIFF
--- a/net/gnome-online-accounts/Makefile
+++ b/net/gnome-online-accounts/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gnome-online-accounts
-PORTVERSION=	3.54.5
-PORTREVISION=	1
+PORTVERSION=	3.54.11
 CATEGORIES=	net
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -24,6 +23,7 @@ USES=		compiler:c++11-lib desktop-file-utils gettext-tools gnome \
 USE_GNOME=	glib20 gtk40 introspection:build libadwaita libxml2 \
 		libxslt:build
 USE_LDCONFIG=	yes
+INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.online-accounts.gschema.xml
 

--- a/net/gnome-online-accounts/distinfo
+++ b/net/gnome-online-accounts/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1754163646
-SHA256 (gnome/gnome-online-accounts-3.54.5.tar.xz) = e8f127b532295a29912d1c00734931df9affa4ebfc44ad0de5c296c3d27d2c95
-SIZE (gnome/gnome-online-accounts-3.54.5.tar.xz) = 485912
+TIMESTAMP = 1773581814
+SHA256 (gnome/gnome-online-accounts-3.54.11.tar.xz) = c2aaffd4c66cdf8c5f1b08ea4e374357b4c667436740f740732bc1069b5e92a5
+SIZE (gnome/gnome-online-accounts-3.54.11.tar.xz) = 489728


### PR DESCRIPTION
Updates gnome-online-accounts to 3.54.11.\n\nValidation:\n- bmake makesum\n- bmake patch\n- bmake\n- bmake fake\n- bmake package\n- bmake test (no upstream tests defined)\n- bmake check-license\n- portlint -C\n- git diff --check

## Summary by Sourcery

Enhancements:
- Update the GNOME Online Accounts port to version 3.54.11 and enable installation of its icons.