### PR TITLE
x11-toolkits/libshumate: update to 1.4.1

### DIFF
--- a/x11-toolkits/libshumate/Makefile
+++ b/x11-toolkits/libshumate/Makefile
@@ -1,11 +1,12 @@
 PORTNAME=	libshumate
-DISTVERSION=	1.4.0
+DISTVERSION=	1.4.1
 CATEGORIES=	x11-toolkits geography
 MASTER_SITES=	GNOME
+DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GTK4 widget to display maps
-WWW=		https://wiki.gnome.org/Projects/libshumate
+WWW=		https://gitlab.gnome.org/GNOME/libshumate
 
 LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
@@ -16,7 +17,7 @@ LIB_DEPENDS=	libjson-glib-1.0.so:devel/json-glib \
 		libsoup-3.0.so:devel/libsoup3 \
 		libgraphene-1.0.so:graphics/graphene
 
-USES=		gettext gnome meson pkgconfig sqlite tar:xz vala:build
+USES=		gettext-tools gnome meson pkgconfig sqlite tar:xz vala:build
 USE_GNOME=	cairo gdkpixbuf gtk40 introspection:build
 USE_LDCONFIG=	yes
 MESON_ARGS=	-Dsysprof=disabled

--- a/x11-toolkits/libshumate/distinfo
+++ b/x11-toolkits/libshumate/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1742025159
-SHA256 (libshumate-1.4.0.tar.xz) = 3984368e0259862b3810d1ddc86d2dadd6d372a2b32376ccf4aff7c2e48c6d30
-SIZE (libshumate-1.4.0.tar.xz) = 5911764
+TIMESTAMP = 1788925687
+SHA256 (gnome/libshumate-1.4.1.tar.xz) = 09d91ade7627ac212a24cdda669dbfc4a24ece6af9229b60b1da5597caf31aac
+SIZE (gnome/libshumate-1.4.1.tar.xz) = 5911760


### PR DESCRIPTION
Updates libshumate to 1.4.1.

Retains the existing MidnightBSD test policy: the upstream suite has three GTK tests that require a display, while the Meson test environment does not inherit DISPLAY. Validation was nevertheless completed with 13 headless tests through Meson plus the three GTK tests under a temporary Xvfb display; all 16 passed.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake clean package
- upstream test suite: 16/16 passed across headless and temporary Xvfb environments
- bmake check-license
- portlint -C (0 fatal errors; 2 style advisories)
- git diff --check

LICENSE remains lgpl2.1+; upstream COPYING is LGPL version 2.1 or later.

## Summary by Sourcery

Update the libshumate port to the 1.4.1 release while preserving its existing licensing and test policy.

Enhancements:
- Update the libshumate port to version 1.4.1 and refresh its upstream project metadata.

Build:
- Adjust the port's build tooling and distfile handling for the updated release.

Tests:
- Validate the updated port and all 16 upstream tests across headless and Xvfb environments.