### PR TITLE
devel/glibmm: update to 2.66.8

### DIFF
--- a/devel/glibmm/Makefile
+++ b/devel/glibmm/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	glibmm
-DISTVERSION=	2.66.7
+DISTVERSION=	2.66.8
 PORTEPOCH=	1
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
@@ -23,7 +23,5 @@ MESON_ARGS=	-Dbuild-documentation=false \
 # 2.68 and later are currently incompatible with consumers
 PORTSCOUT=	limit:^2\.66
 PLIST_SUB=	VERSION=2.4
-
-NO_TEST=	yes
 
 .include <bsd.port.mk>

--- a/devel/glibmm/distinfo
+++ b/devel/glibmm/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1720347052
-SHA256 (gnome/glibmm-2.66.7.tar.xz) = fe02c1e5f5825940d82b56b6ec31a12c06c05c1583cfe62f934d0763e1e542b3
-SIZE (gnome/glibmm-2.66.7.tar.xz) = 8773780
+TIMESTAMP = 1746463291
+SHA256 (gnome/glibmm-2.66.8.tar.xz) = 64f11d3b95a24e2a8d4166ecff518730f79ecc27222ef41faf7c7e0340fc9329
+SIZE (gnome/glibmm-2.66.8.tar.xz) = 8597344


### PR DESCRIPTION
Updates glibmm to 2.66.8 and restores the upstream test target.\n\nValidation:\n- bmake makesum\n- bmake patch\n- bmake check-license\n- bmake\n- bmake fake\n- bmake package\n- bmake test (33 passed)\n- portlint -C (0 fatal errors; existing warnings)\n- git diff --check

## Summary by Sourcery

Update the glibmm port to 2.66.8 and restore upstream test support.

Enhancements:
- Update glibmm to version 2.66.8 and re-enable its upstream test target.

Tests:
- Restore upstream test execution for the port.