### PR TITLE
textproc/gtk-doc: update to 1.36.1

### DIFF
--- a/textproc/gtk-doc/Makefile
+++ b/textproc/gtk-doc/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gtk-doc
-DISTVERSION=	1.35.1
-PORTREVISION=	2
+DISTVERSION=	1.36.1
 CATEGORIES=	textproc
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -13,6 +12,7 @@ LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pygments>0:textproc/py-pygments@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}parameterized>0:devel/py-parameterized@${PY_FLAVOR} \
 		docbook-xml>0:textproc/docbook-xml \
 		docbook-xsl>0:textproc/docbook-xsl
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}pygments>0:textproc/py-pygments@${PY_FLAVOR} \
@@ -26,15 +26,9 @@ USE_GNOME=	glib20 libxslt
 
 MESON_ARGS=	-Dyelp_manual=false
 
-PLIST_SUB=	XMLCATMGR=${XMLCATMGR} \
-		CATALOG_PORTS_SGML=${CATALOG_PORTS_SGML} \
-		CATALOG_DIR=${CATALOG_DIR}
-
-
 NO_ARCH=	yes
-NO_TEST=	yes
 TEST_ENV=	CC=${CC}
-BINARY_ALIAS= python3=${PYTHON_CMD}
+BINARY_ALIAS=	python3=${PYTHON_CMD}
 
 post-install:
 	${PYTHON_CMD:S,${FAKE_DESTDIR},,} ${PYTHON_LIBDIR}/compileall.py \

--- a/textproc/gtk-doc/distinfo
+++ b/textproc/gtk-doc/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1759575111
-SHA256 (gnome/gtk-doc-1.35.1.tar.xz) = 611c9f24edd6d88a8ae9a79d73ab0dc63c89b81e90ecc31d6b9005c5f05b25e2
-SIZE (gnome/gtk-doc-1.35.1.tar.xz) = 538008
+TIMESTAMP = 1788925953
+SHA256 (gnome/gtk-doc-1.36.1.tar.xz) = 0e517a5f97069831181be177516bde8aa8b3922398f2bdb09e265d22aecadbc5
+SIZE (gnome/gtk-doc-1.36.1.tar.xz) = 594020

--- a/textproc/gtk-doc/files/patch-meson.build
+++ b/textproc/gtk-doc/files/patch-meson.build
@@ -1,12 +1,5 @@
 --- meson.build.orig	2024-03-05 18:09:52 UTC
 +++ meson.build
-@@ -7,7 +7,7 @@ python = import('python')
- gnome = import('gnome')
- python = import('python')
- 
--python3 = python.find_installation('python3', modules: ['pygments'])
-+python3 = python.find_installation(python.find_installation().full_path(), modules: ['pygments'])
- 
  # Paths
  srcdir = meson.current_source_dir()
 @@ -134,7 +134,7 @@ configure_file(

--- a/textproc/gtk-doc/pkg-plist
+++ b/textproc/gtk-doc/pkg-plist
@@ -79,6 +79,3 @@ share/aclocal/gtk-doc.m4
 %%DATADIR%%/python/gtkdoc/rebase.py
 %%DATADIR%%/python/gtkdoc/scan.py
 %%DATADIR%%/python/gtkdoc/scangobj.py
-@preunexec %%XMLCATMGR%% -sc %%CATALOG_PORTS_SGML%% remove CATALOG %%CATALOG_DIR%%/gtk-doc.cat
-@comment share/sgml/gtk-doc/gtk-doc.cat
-@postexec %%XMLCATMGR%% -sc %%CATALOG_PORTS_SGML%% add CATALOG %%CATALOG_DIR%%/gtk-doc.cat


### PR DESCRIPTION
Updates gtk-doc to 1.36.1.

The release requires the parameterized Python module during Meson configuration, so it is a build dependency. The obsolete Meson Python-selection patch was dropped: it forced the host Python 3.11 and bypassed the port-managed Python 3.12 alias. The remaining pkgconfig installation patch is retained for MidnightBSD.

The upstream catalog is no longer staged, so the stale XML catalog hooks are removed. `NO_TEST` is removed because the full Meson suite passes.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake clean package
- bmake test: 37 passed, 1 expected failure, 0 failures
- bmake check-license
- portlint -C (0 fatal errors; 1 environment advisory)
- git diff --check

LICENSE remains gpl2+; upstream identifies GPL-2.0-or-later.

## Summary by Sourcery

Update gtk-doc to 1.36.1 and modernize its port configuration for the release.

Enhancements:
- Update gtk-doc to version 1.36.1 and align its build configuration with the new release requirements.
- Remove obsolete Python selection and XML catalog integration while preserving the platform-specific pkgconfig installation handling.
- Enable the upstream test suite for the port.

Build:
- Add the parameterized Python module as a build dependency.

Tests:
- Remove the NO_TEST restriction so the full Meson test suite is run.