### PR TITLE
x11-fonts/cantarell-fonts: update to 0.311

### DIFF
--- a/x11-fonts/cantarell-fonts/Makefile
+++ b/x11-fonts/cantarell-fonts/Makefile
@@ -1,11 +1,12 @@
 PORTNAME=	cantarell-fonts
-DISTVERSION=	0.301
+DISTVERSION=	0.311
 CATEGORIES=	x11-fonts gnome
-MASTER_SITES=	GNOME
+MASTER_SITES=	https://cantarell.gnome.org/releases/
+DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Cantarell, a Humanist sans-serif font family
-WWW=		https://wiki.gnome.org/Projects/CantarellFonts
+WWW=		https://cantarell.gnome.org/
 
 LICENSE=	OFL11
 LICENSE_FILE=	${WRKSRC}/COPYING

--- a/x11-fonts/cantarell-fonts/distinfo
+++ b/x11-fonts/cantarell-fonts/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1679235982
-SHA256 (cantarell-fonts-0.301.tar.xz) = 3d35db0ac03f9e6b0d5a53577591b714238985f4cfc31a0aa17f26cd74675e83
-SIZE (cantarell-fonts-0.301.tar.xz) = 570328
+TIMESTAMP = 1788926211
+SHA256 (gnome/cantarell-fonts-0.311.tar.xz) = 706778e6f9468d534d7afe05e4f6e1586110395ef37d24df259746736fd6b702
+SIZE (gnome/cantarell-fonts-0.311.tar.xz) = 607560

--- a/x11-fonts/cantarell-fonts/pkg-plist
+++ b/x11-fonts/cantarell-fonts/pkg-plist
@@ -1,9 +1,4 @@
-%%FONTSDIR%%/Cantarell-Bold.otf
-%%FONTSDIR%%/Cantarell-ExtraBold.otf
-%%FONTSDIR%%/Cantarell-Light.otf
-%%FONTSDIR%%/Cantarell-Regular.otf
-%%FONTSDIR%%/Cantarell-Thin.otf
 %%FONTSDIR%%/Cantarell-VF.otf
 share/metainfo/org.gnome.cantarell.metainfo.xml
-@exec %D/bin/fc-cache -f -v %D/%%FONTSDIR%%
-@unexec %D/bin/fc-cache -f -v %D/%%FONTSDIR%%
+@postexec %%LOCALBASE%%/bin/fc-cache -f -v %%FONTSDIR%% || /usr/bin/true
+@postunexec %%LOCALBASE%%/bin/fc-cache -f -v %%FONTSDIR%% || /usr/bin/true


### PR DESCRIPTION
Updates Cantarell fonts to 0.311.

Upstream now installs a single variable OTF; remove the obsolete static OTF plist entries. Switch to the project release site and register the package in the GNOME distfile directory. Update deprecated font-cache lifecycle entries to explicit post-install and post-uninstall actions.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake clean package
- bmake test (upstream defines no tests)
- bmake check-license
- portlint -C (0 fatal errors; 2 style advisories)
- git diff --check

LICENSE remains OFL11; upstream COPYING is SIL Open Font License 1.1.

## Summary by Sourcery

Update the Cantarell font package to the 0.311 release and its current upstream distribution layout.

Enhancements:
- Update Cantarell fonts to version 0.311 and align package metadata with the upstream release site.
- Adjust the package contents for the upstream variable-font distribution and modernize font-cache lifecycle handling.