### PR TITLE
www/epiphany: update to 47.7

### DIFF
--- a/www/epiphany/Makefile
+++ b/www/epiphany/Makefile
@@ -1,16 +1,17 @@
 PORTNAME=	epiphany
-PORTVERSION=	47.3.1
-PORTREVISION=	1
+PORTVERSION=	47.7
 CATEGORIES=	www gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Extremely lightweight and simple web browser for GNOME
-WWW=		https://www.gnome.org/projects/epiphany/
+WWW=		https://apps.gnome.org/Epiphany/
 
 LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
+
+PORTSCOUT=	limit:^47\.
 
 BUILD_DEPENDS=	gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas \
 		iso-codes>=0:misc/iso-codes \
@@ -21,22 +22,19 @@ LIB_DEPENDS=	libgcr-4.so:security/gcr \
 		libsecret-1.so:security/libsecret \
 		libsoup-3.0.so:devel/libsoup3 \
 		libnettle.so:security/nettle \
+		libportal.so:deskutils/libportal \
 		libportal-gtk4.so:deskutils/libportal-gtk4 \
 		libwebkitgtk-6.0.so:www/webkit2-gtk@60
-RUN_DEPENDS=	gnome-icon-theme-symbolic>=0:x11-themes/gnome-icon-theme-symbolic \
-		gnome-icon-theme>=0:misc/gnome-icon-theme \
-		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas \
-		iso-codes>=0:misc/iso-codes
-
-PORTSCOUT=	limitw:1,even
+RUN_DEPENDS=	gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas \
+		iso-codes>=0:misc/iso-codes \
+		dbus>0:devel/dbus
 
 USES=		compiler:c++11-lib cpe desktop-file-utils gettext gnome \
 		gstreamer libarchive localbase:ldflags meson pkgconfig python \
-		shebangfix sqlite tar:xz xorg
+		sqlite tar:xz
 
 CPE_VENDOR=	gnome
-USE_GNOME=	cairo gdkpixbuf glib20 gtk40 intltool libadwaita libxml2 libxslt
-USE_XORG=	x11
+USE_GNOME=	cairo gdkpixbuf glib20 gtk40 libadwaita libxml2
 USE_LDCONFIG=	yes
 MESON_ARGS=	-Db_lundef=false \
 		-Dunit_tests=disabled

--- a/www/epiphany/distinfo
+++ b/www/epiphany/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741181779
-SHA256 (gnome/epiphany-47.3.1.tar.xz) = 795d7b81f18b7487d9e9bfc0cb2d68a893d2200f45f9397cd42cb3392b2081a9
-SIZE (gnome/epiphany-47.3.1.tar.xz) = 4094916
+TIMESTAMP = 1748092877
+SHA256 (gnome/epiphany-47.7.tar.xz) = 6bbdef91e67883f57b6d6de2f5443f6a3a4fc7033d87c9f26d445cfbca074e32
+SIZE (gnome/epiphany-47.7.tar.xz) = 4100068


### PR DESCRIPTION
Updates Epiphany to 47.7 and aligns its dependency metadata with the current upstream port.\n\nValidation:\n- bmake makesum\n- bmake patch\n- bmake check-license\n- bmake\n- bmake fake\n- bmake package\n- bmake test (2 passed)\n- portlint -C (0 fatal errors; pre-existing warnings)\n- git diff --check

## Summary by Sourcery

Enhancements:
- Update the Epiphany web browser port to version 47.7 and align its upstream metadata, runtime dependencies, and desktop integration settings.