### PR TITLE
multimedia/libmediaart: update to 1.9.7

### DIFF
--- a/multimedia/libmediaart/Makefile
+++ b/multimedia/libmediaart/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libmediaart
-DISTVERSION=	1.9.6
+DISTVERSION=	1.9.7
 CATEGORIES=	multimedia devel
 MASTER_SITES=	GNOME
 
@@ -11,9 +11,9 @@ LICENSE=	gpl2 lgpl2.1
 LICENSE_COMB=	dual
 
 USES=		gnome meson pathfix pkgconfig tar:xz vala:build
-USE_GNOME=	gdkpixbuf introspection:build
+USE_GNOME=	glib20 gdkpixbuf introspection:build
 USE_LDCONFIG=	yes
 
-MESON_ARGS=	-Dimage_library=gdk-pixbuf -Dgtk_doc=false
+MESON_ARGS=	-Dimage_library=gdk-pixbuf
 
 .include <bsd.port.mk>

--- a/multimedia/libmediaart/distinfo
+++ b/multimedia/libmediaart/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1656315714
-SHA256 (libmediaart-1.9.6.tar.xz) = c3bc5025d7db380587f9c8eb800c611f6b5a16d6b4b78fcff93f62876a677f17
-SIZE (libmediaart-1.9.6.tar.xz) = 5551220
+TIMESTAMP = 1788926864
+SHA256 (libmediaart-1.9.7.tar.xz) = 2b43dd9f54f0d8d0b89e2addb83341ab06d7b98cb1b2e704383584af9c560f6b
+SIZE (libmediaart-1.9.7.tar.xz) = 5549844

--- a/multimedia/libmediaart/pkg-plist
+++ b/multimedia/libmediaart/pkg-plist
@@ -6,7 +6,7 @@ include/libmediaart-2.0/libmediaart/mediaart.h
 lib/girepository-1.0/MediaArt-2.0.typelib
 lib/libmediaart-2.0.so
 lib/libmediaart-2.0.so.0
-lib/libmediaart-2.0.so.0.906.0
+lib/libmediaart-2.0.so.0.907.0
 libdata/pkgconfig/libmediaart-2.0.pc
 share/gir-1.0/MediaArt-2.0.gir
 share/vala/vapi/libmediaart-2.0.deps


### PR DESCRIPTION
Updates libmediaart to 1.9.7.

Includes the upstream ABI micro-version plist update and declares GLib explicitly; removes the no-longer-supported gtk_doc Meson option.

Validation: bmake makesum, patch, build, fake, clean package, test (1/1 passed), check-license, portlint -C (0 fatal errors; 2 advisories), git diff --check.

LICENSE remains gpl2 lgpl2.1 with dual combination.

## Summary by Sourcery

Update the libmediaart port to the 1.9.7 release and align its build metadata with current upstream requirements.

Enhancements:
- Update libmediaart to version 1.9.7 with the upstream ABI metadata refresh.
- Declare GLib as an explicit GNOME dependency and remove the obsolete gtk_doc Meson option.