### PR TITLE
devel/libdex: update to 1.0.0

### DIFF
--- a/devel/libdex/Makefile
+++ b/devel/libdex/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libdex
-PORTVERSION=	0.10.1
+PORTVERSION=	1.0.0
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -15,6 +15,7 @@ USE_GNOME=	glib20 introspection:build
 USE_LDCONFIG=	yes
 
 MESON_ARGS=	-Dexamples=false \
-		-Dtests=false
+		-Dtests=false \
+		-Dliburing=disabled
 
 .include <bsd.port.mk>

--- a/devel/libdex/distinfo
+++ b/devel/libdex/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1751101875
-SHA256 (gnome/libdex-0.10.1.tar.xz) = 7472e88090db2b228307505edeba4483e872681340cb0404ae64ac3da5bed0a6
-SIZE (gnome/libdex-0.10.1.tar.xz) = 102088
+TIMESTAMP = 1788927577
+SHA256 (gnome/libdex-1.0.0.tar.xz) = 7b8f5c5db3796e14e12e10422e2356766ba830b92815fee70bbc867b5b207f5d
+SIZE (gnome/libdex-1.0.0.tar.xz) = 107124

--- a/devel/libdex/pkg-plist
+++ b/devel/libdex/pkg-plist
@@ -18,6 +18,7 @@ include/libdex-1/dex-platform.h
 include/libdex-1/dex-promise.h
 include/libdex-1/dex-scheduler.h
 include/libdex-1/dex-static-future.h
+include/libdex-1/dex-thread.h
 include/libdex-1/dex-thread-pool-scheduler.h
 include/libdex-1/dex-timeout.h
 include/libdex-1/dex-unix-signal.h


### PR DESCRIPTION
Updates libdex to 1.0.0.

Adds the new public dex-thread header and disables the optional liburing backend, matching the supported dependency set.

Validation: bmake makesum, patch, build, fake, clean package, test (upstream defines no tests), check-license, portlint -C (0 fatal errors; 1 environment advisory), git diff --check.

LICENSE remains lgpl2.1.

## Summary by Sourcery

Update the libdex port to version 1.0.0 with its new public header and supported backend configuration.

New Features:
- Add the public dex-thread header to the libdex package.

Enhancements:
- Update libdex to the 1.0.0 release and disable the optional liburing backend to match supported dependencies.