### PR TITLE
graphics/xviewer: update to 3.4.16

### DIFF
--- a/graphics/xviewer/Makefile
+++ b/graphics/xviewer/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	xviewer
-PORTVERSION=	3.4.8
-PORTREVISION=	1
+DISTVERSION=	3.4.16
 CATEGORIES=	graphics gnome
 DIST_SUBDIR=	gnome
 
@@ -24,7 +23,8 @@ USES=		meson compiler:c++11-lang desktop-file-utils gettext-tools \
 		gnome localbase pkgconfig xorg
 USE_GITHUB=	yes
 GH_ACCOUNT=	linuxmint
-USE_GNOME=	atk cairo gdkpixbuf gtk30 introspection pango
+USE_GNOME=	atk cairo gdkpixbuf2xlib glib20 gtk30 introspection pango
+INSTALLS_ICONS=	yes
 USE_XORG=	x11
 GLIB_SCHEMAS=	org.x.viewer.enums.xml org.x.viewer.gschema.xml
 

--- a/graphics/xviewer/distinfo
+++ b/graphics/xviewer/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1737906844
-SHA256 (gnome/linuxmint-xviewer-3.4.8_GH0.tar.gz) = c8abe0e9a19ba867c620a1c417bb719b6c1e07e5baa444697d1e71ad8f676889
-SIZE (gnome/linuxmint-xviewer-3.4.8_GH0.tar.gz) = 2547011
+TIMESTAMP = 1788927213
+SHA256 (gnome/linuxmint-xviewer-3.4.16_GH0.tar.gz) = 41323bd88c032ce158ce1970f945aa7b6c7fc11fcc211bdfd54ea9d8701d9866
+SIZE (gnome/linuxmint-xviewer-3.4.16_GH0.tar.gz) = 2479897

--- a/graphics/xviewer/files/patch-meson.build
+++ b/graphics/xviewer/files/patch-meson.build
@@ -1,0 +1,11 @@
+--- meson.build.orig
++++ meson.build
+@@ -42,0 +43,8 @@
++
++gi = dependency('girepository-2.0', required: false)
++use_gir20 = gi.found()
++if not use_gir20
++    gi = dependency('gobject-introspection-1.0', version: '>= 0.9.2')
++endif
++xviewer_conf.set10('USE_GIR20', use_gir20)
++

--- a/graphics/xviewer/files/patch-src_main.c
+++ b/graphics/xviewer/files/patch-src_main.c
@@ -1,0 +1,14 @@
+--- src/main.c.orig
++++ src/main.c
+@@ -29,0 +30,3 @@
++#if USE_GIR20
++#include <girepository/girepository.h>
++#else
+@@ -31,0 +35 @@
++#endif
+@@ -104,0 +109,3 @@
++#if USE_GIR20
++	g_option_context_add_group (ctx, gi_repository_get_option_group ());
++#else
+@@ -106,0 +114 @@
++#endif

--- a/graphics/xviewer/files/patch-src_meson.build
+++ b/graphics/xviewer/files/patch-src_meson.build
@@ -1,0 +1,4 @@
+--- src/meson.build.orig
++++ src/meson.build
+@@ -133,0 +134 @@
++    gi,

--- a/graphics/xviewer/files/patch-src_xviewer-plugin-engine.c
+++ b/graphics/xviewer/files/patch-src_xviewer-plugin-engine.c
@@ -1,0 +1,41 @@
+--- src/xviewer-plugin-engine.c.orig
++++ src/xviewer-plugin-engine.c
+@@ -36,0 +37,4 @@
++
++#if USE_GIR20
++#include <girepository/girepository.h>
++#else
+@@ -37,0 +42 @@
++#endif
+@@ -88,0 +94,29 @@
++#if USE_GIR20
++	GIRepository *repo = gi_repository_dup_default ();
++
++	if (gi_repository_require (repo, "Peas", "1.0", 0, &error) == NULL)
++	{
++		g_warning ("Error loading Peas typelib: %s\n",
++			   error->message);
++		g_clear_error (&error);
++	}
++
++	if (gi_repository_require (repo, "PeasGtk", "1.0", 0, &error) == NULL)
++	{
++		g_warning ("Error loading PeasGtk typelib: %s\n",
++			   error->message);
++		g_clear_error (&error);
++	}
++
++	typelib_path = g_build_filename (LIBDIR, "xviewer", "girepository-1.0", NULL);
++
++	if (gi_repository_require_private (repo, typelib_path,
++					   "Xviewer", "3.0", 0, &error) == NULL)
++	{
++		g_warning ("Error loading Xviewer typelib: %s\n",
++			   error->message);
++		g_clear_error (&error);
++	}
++
++	g_object_unref (repo);
++#else
+@@ -114,0 +149 @@
++#endif

--- a/graphics/xviewer/pkg-plist
+++ b/graphics/xviewer/pkg-plist
@@ -1472,6 +1472,7 @@ share/locale/ko/LC_MESSAGES/xviewer.mo
 share/locale/ks/LC_MESSAGES/xviewer.mo
 share/locale/ku/LC_MESSAGES/xviewer.mo
 share/locale/la/LC_MESSAGES/xviewer.mo
+share/locale/lo/LC_MESSAGES/xviewer.mo
 share/locale/lt/LC_MESSAGES/xviewer.mo
 share/locale/lv/LC_MESSAGES/xviewer.mo
 share/locale/mai/LC_MESSAGES/xviewer.mo


### PR DESCRIPTION
Updates xviewer from 3.4.8 to 3.4.16.\n\nAdds the upstream gobject-introspection 2.0 compatibility patch needed with current GLib, restores required GNOME dependencies, and adds the new Lao translation. GPLv2+ metadata remains unchanged.\n\nValidation: bmake makesum, patch, build, fake, package, test (no tests defined), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the xviewer port to 3.4.16 and maintain compatibility with current GNOME platform dependencies.

New Features:
- Update xviewer to version 3.4.16 with the new Lao translation and installed application icons.

Bug Fixes:
- Add compatibility for the current gobject-introspection 2.0 API used with modern GLib.

Enhancements:
- Restore the GNOME dependencies required by the updated xviewer port.