### PR TITLE
games/gnome-tetravex: update to 3.38.3

### DIFF
--- a/games/gnome-tetravex/Makefile
+++ b/games/gnome-tetravex/Makefile
@@ -1,12 +1,8 @@
 PORTNAME=	gnome-tetravex
-PORTVERSION=	3.38.2
-PORTREVISION=	1
+PORTVERSION=	3.38.3
 CATEGORIES=	games gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
-
-PATCH_SITES=	https://gitlab.gnome.org/GNOME/${PORTNAME}/-/commit/
-PATCHFILES+=	80912d06f5e5.patch:-p1 # https://gitlab.gnome.org/GNOME/gnome-tetravex/-/merge_requests/20
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Gnome tetravex
@@ -19,9 +15,12 @@ BUILD_DEPENDS=	itstool:textproc/itstool
 
 PORTSCOUT=	limitw:1,even
 
-USES=		gettext gmake gnome localbase meson pathfix pkgconfig \
-		python tar:xz vala:build
-USE_GNOME=	cairo gtk30 intlhack librsvg2 libxml2:build
+USES=		desktop-file-utils gettext-tools gnome localbase meson \
+		pkgconfig python shebangfix tar:xz vala:build
+USE_GNOME=	glib20 gtk30
+INSTALLS_ICONS=	yes
+
+SHEBANG_FILES=	build-aux/meson_post_install.py
 
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 

--- a/games/gnome-tetravex/distinfo
+++ b/games/gnome-tetravex/distinfo
@@ -1,5 +1,3 @@
-TIMESTAMP = 1660070416
-SHA256 (gnome/gnome-tetravex-3.38.2.tar.xz) = 1fcdf10979b9a3526009d783a1c88a389918f360da4edb44fba25c71f186911b
-SIZE (gnome/gnome-tetravex-3.38.2.tar.xz) = 1004632
-SHA256 (gnome/80912d06f5e5.patch) = 16b93b4ab3488cc8aec30e8b8d029952acc096caf716b65edec2fb558f8c81e0
-SIZE (gnome/80912d06f5e5.patch) = 1308
+TIMESTAMP = 1788928144
+SHA256 (gnome/gnome-tetravex-3.38.3.tar.xz) = 83849ac064d456e1dd46b6e201c686152624c3d1ec4b99935985a49aa79172cb
+SIZE (gnome/gnome-tetravex-3.38.3.tar.xz) = 1074252

--- a/games/gnome-tetravex/pkg-plist
+++ b/games/gnome-tetravex/pkg-plist
@@ -1,5 +1,4 @@
 bin/gnome-tetravex
-share/man/man6/gnome-tetravex.6.gz
 share/applications/org.gnome.Tetravex.desktop
 share/dbus-1/services/org.gnome.Tetravex.service
 share/help/C/gnome-tetravex/figures/gnome-tetravex-logo.png
@@ -65,6 +64,15 @@ share/help/es/gnome-tetravex/move.page
 share/help/es/gnome-tetravex/size.page
 share/help/es/gnome-tetravex/usage.page
 share/help/es/gnome-tetravex/winning.page
+share/help/eu/gnome-tetravex/figures/gnome-tetravex-logo.png
+share/help/eu/gnome-tetravex/figures/gnome-tetravex-video.ogv
+share/help/eu/gnome-tetravex/hint.page
+share/help/eu/gnome-tetravex/index.page
+share/help/eu/gnome-tetravex/license.page
+share/help/eu/gnome-tetravex/move.page
+share/help/eu/gnome-tetravex/size.page
+share/help/eu/gnome-tetravex/usage.page
+share/help/eu/gnome-tetravex/winning.page
 share/help/fr/gnome-tetravex/figures/gnome-tetravex-logo.png
 share/help/fr/gnome-tetravex/figures/gnome-tetravex-video.ogv
 share/help/fr/gnome-tetravex/hint.page
@@ -110,6 +118,15 @@ share/help/it/gnome-tetravex/move.page
 share/help/it/gnome-tetravex/size.page
 share/help/it/gnome-tetravex/usage.page
 share/help/it/gnome-tetravex/winning.page
+share/help/ko/gnome-tetravex/figures/gnome-tetravex-logo.png
+share/help/ko/gnome-tetravex/figures/gnome-tetravex-video.ogv
+share/help/ko/gnome-tetravex/hint.page
+share/help/ko/gnome-tetravex/index.page
+share/help/ko/gnome-tetravex/license.page
+share/help/ko/gnome-tetravex/move.page
+share/help/ko/gnome-tetravex/size.page
+share/help/ko/gnome-tetravex/usage.page
+share/help/ko/gnome-tetravex/winning.page
 share/help/pl/gnome-tetravex/figures/gnome-tetravex-logo.png
 share/help/pl/gnome-tetravex/figures/gnome-tetravex-video.ogv
 share/help/pl/gnome-tetravex/hint.page
@@ -137,6 +154,15 @@ share/help/ro/gnome-tetravex/move.page
 share/help/ro/gnome-tetravex/size.page
 share/help/ro/gnome-tetravex/usage.page
 share/help/ro/gnome-tetravex/winning.page
+share/help/ru/gnome-tetravex/figures/gnome-tetravex-logo.png
+share/help/ru/gnome-tetravex/figures/gnome-tetravex-video.ogv
+share/help/ru/gnome-tetravex/hint.page
+share/help/ru/gnome-tetravex/index.page
+share/help/ru/gnome-tetravex/license.page
+share/help/ru/gnome-tetravex/move.page
+share/help/ru/gnome-tetravex/size.page
+share/help/ru/gnome-tetravex/usage.page
+share/help/ru/gnome-tetravex/winning.page
 share/help/sl/gnome-tetravex/figures/gnome-tetravex-logo.png
 share/help/sl/gnome-tetravex/figures/gnome-tetravex-video.ogv
 share/help/sl/gnome-tetravex/hint.page
@@ -193,6 +219,7 @@ share/help/zh_CN/gnome-tetravex/usage.page
 share/help/zh_CN/gnome-tetravex/winning.page
 share/icons/hicolor/scalable/apps/org.gnome.Tetravex-symbolic.svg
 share/icons/hicolor/scalable/apps/org.gnome.Tetravex.svg
+share/locale/ab/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/af/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/am/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/an/LC_MESSAGES/gnome-tetravex-gui.mo
@@ -283,4 +310,5 @@ share/locale/xh/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-tetravex-gui.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-tetravex-gui.mo
+share/man/man6/gnome-tetravex.6.gz
 share/metainfo/org.gnome.Tetravex.appdata.xml


### PR DESCRIPTION
Updates gnome-tetravex from 3.38.2 to 3.38.3.\n\nDrops an obsolete Meson compatibility patch included upstream, aligns build dependencies with the current release, declares icon installation, and adds new translated help and locale files. Existing GPLv2 metadata is retained.\n\nValidation: bmake makesum, patch, build, fake, package, test (2/2 passed), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update gnome-tetravex to 3.38.3 and refresh its build and packaged resources.

Enhancements:
- Update gnome-tetravex to version 3.38.3 and align its build configuration with the current release.
- Enable icon installation and shebang handling for the updated build system.
- Refresh packaged files to include the new translated help and locale resources.

Build:
- Remove the obsolete Meson compatibility patch and update the port's build dependencies and tools.