### PR TITLE
textproc/yelp-tools: update to 42.1

### DIFF
--- a/textproc/yelp-tools/Makefile
+++ b/textproc/yelp-tools/Makefile
@@ -1,8 +1,7 @@
 PORTNAME=	yelp-tools
-PORTVERSION=	42.0
-PORTREVISION=	3
+PORTVERSION=	42.1
 CATEGORIES=	textproc gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -14,14 +13,11 @@ LICENSE_FILE=	${WRKSRC}/COPYING.GPL
 
 BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}lxml>0:devel/py-lxml@${PY_FLAVOR} \
 		itstool:textproc/itstool \
-		xmllint:textproc/libxml2 \
-		xsltproc:textproc/libxslt \
 		yelp-xsl>=0:textproc/yelp-xsl
-RUN_DEPENDS=	xmllint:textproc/libxml2 \
-		xsltproc:textproc/libxslt
 
-USES=		localbase meson pkgconfig python \
+USES=		gettext gnome localbase meson pathfix pkgconfig python \
 		shebangfix tar:xz
+USE_GNOME=	libxml2 libxslt
 SHEBANG_FILES=	tools/yelp-build.in tools/yelp-check.in tools/yelp-new.in
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}

--- a/textproc/yelp-tools/distinfo
+++ b/textproc/yelp-tools/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1656700502
-SHA256 (gnome/yelp-tools-42.0.tar.xz) = 2cd43063ffa7262df15dd8d379aa3ea3999d42661f07563f4802daa1149f7df4
-SIZE (gnome/yelp-tools-42.0.tar.xz) = 38788
+TIMESTAMP = 1788928402
+SHA256 (gnome/yelp-tools-42.1.tar.xz) = 3e496a4020d4145b99fd508a25fa09336a503a4e8900028421e72c6a4b11f905
+SIZE (gnome/yelp-tools-42.1.tar.xz) = 38936


### PR DESCRIPTION
Updates yelp-tools from 42.0 to 42.1.\n\nUses the canonical GNOME source path and framework-provided XML/XSLT dependencies. Existing GPLv2 metadata is retained.\n\nValidation: bmake makesum, patch, build, fake, package, test (no tests defined), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update yelp-tools to 42.1 with current GNOME port conventions and dependency handling.

Enhancements:
- Update yelp-tools to version 42.1 and use the canonical GNOME source location.
- Adopt framework-provided XML/XSLT dependencies and enable the required GNOME, gettext, and pathfix integration.