### PR TITLE
graphics/cairomm11: update to 1.19.0

### DIFF
--- a/graphics/cairomm11/Makefile
+++ b/graphics/cairomm11/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	cairomm
-PORTVERSION=	1.18.0
-PORTREVISION=	1
+PORTVERSION=	1.19.0
 CATEGORIES=	graphics
 MASTER_SITES=	https://cairographics.org/releases/
 PKGNAMESUFFIX=	11
@@ -20,7 +19,6 @@ USE_GNOME=	cairo libsigc++30 libxslt
 
 MESON_ARGS=	-Dmaintainer-mode=false \
 		-Dbuild-documentation=false \
-		-Dbuild-examples=false \
-		-Dbuild-tests=false
+	-Dbuild-examples=false
 
 .include <bsd.port.mk>

--- a/graphics/cairomm11/distinfo
+++ b/graphics/cairomm11/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1703009007
-SHA256 (cairomm-1.18.0.tar.xz) = b81255394e3ea8e8aa887276d22afa8985fc8daef60692eb2407d23049f03cfb
-SIZE (cairomm-1.18.0.tar.xz) = 632520
+TIMESTAMP = 1788928858
+SHA256 (cairomm-1.19.0.tar.xz) = 8b14f03a0e5178c7ff8f7b288cb342a61711c84c9fbed6e663442cfcc873ce5b
+SIZE (cairomm-1.19.0.tar.xz) = 767144


### PR DESCRIPTION
Updates cairomm11 to 1.19.0 and enables the upstream Meson test suite.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (7/7 passed)
- bmake check-license
- portlint -C (0 fatal errors; 3 pre-existing warnings)
- git diff --check

## Summary by Sourcery

Update cairomm11 to 1.19.0 and enable upstream test coverage.

Enhancements:
- Update the cairomm11 port to the 1.19.0 release and enable its upstream Meson test suite.

Tests:
- Enable and validate the upstream Meson tests, with all seven tests passing.