### PR TITLE
devel/template-glib: update to 3.40.0

### DIFF
--- a/devel/template-glib/Makefile
+++ b/devel/template-glib/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	template-glib
-PORTVERSION=	3.36.3
+PORTVERSION=	3.40.0
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
 
@@ -12,7 +12,9 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	valac:lang/vala
 
-USES=		bison compiler:c11 gettext gnome meson pkgconfig tar:xz
+USES=		bison compiler:c11 gettext-tools gnome meson pkgconfig \
+		tar:xz
 USE_GNOME=	glib20 introspection
+USE_LDCONFIG=	yes
 
 .include <bsd.port.mk>

--- a/devel/template-glib/distinfo
+++ b/devel/template-glib/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741162281
-SHA256 (template-glib-3.36.3.tar.xz) = d528b35b2cf90e07dae50e25e12fbadb0eb048f57fd5151cf9f6e98cce1df20e
-SIZE (template-glib-3.36.3.tar.xz) = 65620
+TIMESTAMP = 1788929360
+SHA256 (template-glib-3.40.0.tar.xz) = e533ec2f6c24cc6df66ac55ac824fadd1b4a5f433a11cbf3a6b25815c0cfcfd5
+SIZE (template-glib-3.40.0.tar.xz) = 66368

--- a/devel/template-glib/pkg-plist
+++ b/devel/template-glib/pkg-plist
@@ -13,9 +13,11 @@ include/template-glib-1.0/tmpl-version.h
 lib/girepository-1.0/Template-1.0.typelib
 lib/libtemplate_glib-1.0.so
 lib/libtemplate_glib-1.0.so.0
-lib/libtemplate_glib-1.0.so.0.3600.3
+lib/libtemplate_glib-1.0.so.0.4000.0
 libdata/pkgconfig/template-glib-1.0.pc
 share/gir-1.0/Template-1.0.gir
+share/locale/ar/LC_MESSAGES/template-glib.mo
+share/locale/bg/LC_MESSAGES/template-glib.mo
 share/locale/ca/LC_MESSAGES/template-glib.mo
 share/locale/cs/LC_MESSAGES/template-glib.mo
 share/locale/da/LC_MESSAGES/template-glib.mo
@@ -33,6 +35,8 @@ share/locale/id/LC_MESSAGES/template-glib.mo
 share/locale/it/LC_MESSAGES/template-glib.mo
 share/locale/ka/LC_MESSAGES/template-glib.mo
 share/locale/kab/LC_MESSAGES/template-glib.mo
+share/locale/kk/LC_MESSAGES/template-glib.mo
+share/locale/kw/LC_MESSAGES/template-glib.mo
 share/locale/lt/LC_MESSAGES/template-glib.mo
 share/locale/nl/LC_MESSAGES/template-glib.mo
 share/locale/pl/LC_MESSAGES/template-glib.mo


### PR DESCRIPTION
Updates template-glib from 3.36.3 to 3.40.0.\n\nUpdates the concrete shared-library filename, adds newly staged translations, and enables ldconfig handling. Existing LGPL 2.1 metadata is retained.\n\nValidation: bmake makesum, patch, build, fake, package, test (2/2 passed), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the template-glib port to the 3.40.0 release and adjust its packaging configuration.

Enhancements:
- Update the template-glib port to version 3.40.0 with refreshed distfiles and package contents.
- Enable gettext tooling and shared-library cache handling for the updated port.