### PR TITLE
textproc/libxmlb: update to 0.3.27

### DIFF
--- a/textproc/libxmlb/Makefile
+++ b/textproc/libxmlb/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libxmlb
-DISTVERSION=	0.3.14
+DISTVERSION=	0.3.27
 CATEGORIES=	textproc
 MASTER_SITES=	https://github.com/hughsie/${PORTNAME}/releases/download/${DISTVERSION}/
 
@@ -15,6 +15,7 @@ LIB_DEPENDS=	libstemmer.so:textproc/snowballstemmer \
 
 USES=		gnome meson pkgconfig localbase:ldflags tar:xz
 USE_GNOME=	glib20 introspection:build
+USE_LDCONFIG=	yes
 
 MESON_ARGS=	-Dstemmer=true
 

--- a/textproc/libxmlb/distinfo
+++ b/textproc/libxmlb/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1693109922
-SHA256 (libxmlb-0.3.14.tar.xz) = a2f0056eed14ff791aee2b08b1514a0f1b6cf215f0579138a8cae8c45a0d3b0f
-SIZE (libxmlb-0.3.14.tar.xz) = 100288
+TIMESTAMP = 1788929370
+SHA256 (libxmlb-0.3.27.tar.xz) = 63fa0275f7454d77c10e0af37f79dfdb071821caf429a57dbd9598ea3a9defd6
+SIZE (libxmlb-0.3.27.tar.xz) = 107024

--- a/textproc/libxmlb/pkg-plist
+++ b/textproc/libxmlb/pkg-plist
@@ -29,7 +29,7 @@ libexec/installed-tests/libxmlb/test.quirk
 libexec/installed-tests/libxmlb/test.xml
 libexec/installed-tests/libxmlb/test.xml.gz.gz.gz
 libexec/installed-tests/libxmlb/test.xml.xz
-libexec/installed-tests/libxmlb/test.xml.zstd
+libexec/installed-tests/libxmlb/test.xml.zst
 libexec/installed-tests/libxmlb/xb-self-test
 share/man/man1/xb-tool.1.gz
 share/gir-1.0/Xmlb-2.0.gir


### PR DESCRIPTION
Updates libxmlb to 0.3.27, corrects the staged zstd test-data filename, and registers its shared library.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (2/2 passed)
- bmake check-license
- portlint -C (0 fatal errors; two pre-existing/general warnings)
- git diff --check

## Summary by Sourcery

Update the libxmlb port to 0.3.27 and ensure its shared library is properly registered.

Bug Fixes:
- Correct the staged zstd test-data filename.

Enhancements:
- Update libxmlb to version 0.3.27 and register its shared library with the system linker cache.