### PR TITLE
x11/mate-menus: update to 1.28.1

### DIFF
--- a/x11/mate-menus/Makefile
+++ b/x11/mate-menus/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	mate-menus
-PORTVERSION=	1.28.0
+DISTVERSION=	1.28.1
 CATEGORIES=	x11 mate
-MASTER_SITES=	MATE
+MASTER_SITES=	https://github.com/mate-desktop/${PORTNAME}/releases/download/v${DISTVERSION}/
 DIST_SUBDIR=	mate
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -11,12 +11,11 @@ WWW=		https://mate-desktop.org/
 LICENSE=	gpl2 lgpl
 LICENSE_COMB=	dual
 
-PORTSCOUT=	limitw:1,even
-
 USES=		gettext gmake gnome libtool localbase pathfix pkgconfig \
 		python tar:xz
 USE_GNOME=	glib20 intltool introspection:buid
 USE_LDCONFIG=	yes
+PORTSCOUT=	site:https://github.com/mate-desktop/mate-menus/releases/ limitw:1,even
 GNU_CONFIGURE=	yes
 INSTALL_TARGET=	install-strip
 

--- a/x11/mate-menus/Makefile
+++ b/x11/mate-menus/Makefile
@@ -13,7 +13,7 @@ LICENSE_COMB=	dual
 
 USES=		gettext gmake gnome libtool localbase pathfix pkgconfig \
 		python tar:xz
-USE_GNOME=	glib20 intltool introspection:buid
+USE_GNOME=	glib20 intltool introspection:build
 USE_LDCONFIG=	yes
 PORTSCOUT=	site:https://github.com/mate-desktop/mate-menus/releases/ limitw:1,even
 GNU_CONFIGURE=	yes

--- a/x11/mate-menus/distinfo
+++ b/x11/mate-menus/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1712015782
-SHA256 (mate/mate-menus-1.28.0.tar.xz) = cf40c75c7d6f0aad1d4969828fc62025c6222bc6a84f0bb9d6ead7e45970508d
-SIZE (mate/mate-menus-1.28.0.tar.xz) = 420212
+TIMESTAMP = 1788930275
+SHA256 (mate/mate-menus-1.28.1.tar.xz) = d6a61d3bfbf58176fb52049f115d4e3a0d108fe5f1ef87438fafd86384e603d1
+SIZE (mate/mate-menus-1.28.1.tar.xz) = 441584


### PR DESCRIPTION
Update mate-menus to 1.28.1.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test
- bmake check-license
- portlint -C (0 fatal errors; existing NLS and maintainer-mode advisories)
- git diff --check

## Summary by Sourcery

Enhancements:
- Update the mate-menus port to release 1.28.1 and align its source, version-tracking, and build configuration with current port conventions.