### PR TITLE
games/tali: update to 40.9

### DIFF
--- a/games/tali/Makefile
+++ b/games/tali/Makefile
@@ -1,15 +1,14 @@
 PORTNAME=	tali
-PORTVERSION=	40.8
-PORTREVISION=	3
+PORTVERSION=	40.9
 CATEGORIES=	games gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Gnome tali
 WWW=		https://wiki.gnome.org/Apps/Tali
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	itstool:textproc/itstool

--- a/games/tali/distinfo
+++ b/games/tali/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1660070245
-SHA256 (gnome/tali-40.8.tar.xz) = 6c178c160fcbb4d11be3d1569d538e0e78140d50bbdb52a7583188f795c017ee
-SIZE (gnome/tali-40.8.tar.xz) = 1686244
+TIMESTAMP = 1788922187
+SHA256 (gnome/tali-40.9.tar.xz) = fa9ede366f0a72e4caa52189c3ab0b10c1b56a80c7885b016602558c44dce7d3
+SIZE (gnome/tali-40.9.tar.xz) = 1672980


### PR DESCRIPTION
Updates Tali to 40.9 and corrects the license declaration to GPLv2-or-later.\n\nValidated with makesum, patch, build, fake, package, 2/2 tests, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the Tali game port to version 40.9 with corrected licensing metadata.

Bug Fixes:
- Update the Tali game port to release 40.9.

Enhancements:
- Correct the declared license to GPLv2-or-later and update the GNOME source configuration.