### PR TITLE
devel/libgee: declare LGPLv2.1-or-later

### DIFF
--- a/devel/libgee/Makefile
+++ b/devel/libgee/Makefile
@@ -8,7 +8,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GObject collection library
 WWW=		https://wiki.gnome.org/Projects/Libgee
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 PORTSCOUT=	limitw:1,even


### PR DESCRIPTION
Correct the license metadata to LGPLv2.1-or-later, matching upstream COPYING and source notices.

Validated: bmake check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Enhancements:
- Correct libgee's license metadata to declare LGPLv2.1-or-later, matching the upstream licensing terms.