### PR TITLE
x11-toolkits/gtk40: update to 4.20.4

### DIFF
--- a/x11-toolkits/gtk40/Makefile
+++ b/x11-toolkits/gtk40/Makefile
@@ -1,10 +1,12 @@
 PORTNAME=	gtk
-PORTVERSION=	4.18.6
-PORTREVISION=	1
+PORTVERSION=	4.20.4
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	4
 DIST_SUBDIR=	gnome
+
+PATCH_SITES=	https://gitlab.gnome.org/GNOME/gtk/-/commit/
+PATCHFILES=	047c8e64d4156897776ec2bc3d0613a81cfe7ad1.patch:-p1
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Gimp Toolkit for X11 GUI (current stable version)
@@ -15,32 +17,34 @@ LICENSE=	lgpl2.1+
 PORTSCOUT=	limit:1,even
 
 BUILD_DEPENDS=	${LOCALBASE}/include/libdrm/drm_fourcc.h:graphics/libdrm \
+		iso-codes>0:misc/iso-codes \
+		${PYTHON_PKGNAMEPREFIX}docutils>0:textproc/py-docutils@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}gi-docgen>0:textproc/py-gi-docgen@${PY_FLAVOR} \
 		sassc>0:textproc/sassc
 LIB_DEPENDS=	libepoxy.so:graphics/libepoxy \
 		libpng.so:graphics/png \
 		libtiff.so:graphics/tiff \
 		libfribidi.so:converters/fribidi \
-		libfontconfig.so:x11-fonts/fontconfig \
 		libfreetype.so:print/freetype2 \
 		libgraphene-1.0.so:graphics/graphene \
 		libharfbuzz.so:print/harfbuzz
-RUN_DEPENDS=	hicolor-icon-theme>=0:misc/hicolor-icon-theme \
-		adwaita-icon-theme>=0:x11-themes/adwaita-icon-theme
+RUN_DEPENDS=	hicolor-icon-theme>0:misc/hicolor-icon-theme \
+		adwaita-icon-theme>0:x11-themes/adwaita-icon-theme
 
-USES=		compiler:c11 cpe gettext gnome jpeg localbase meson \
+USES=		compiler:c11 cpe gettext-tools gnome jpeg localbase meson \
 		ninja pathfix perl5 python pkgconfig tar:xz
 CPE_VENDOR=	gnome
 CPE_PRODUCT=	gtk
 USE_LDCONFIG=	yes
 USE_PERL5=	build
 USE_GNOME=	atk cairo gdkpixbuf introspection:build pango \
-		librsvg2:run
+		librsvg2
 MESON_ARGS=	-Dbuild-testsuite=false
 LDFLAGS+=	-lexecinfo
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}
 
-LIBVERSION=	1.1800.6
+LIBVERSION=	1.2000.4
 PLIST_SUB+=	LIBVERSION=${LIBVERSION}
 
 GLIB_SCHEMAS=	org.gtk.Demo4.gschema.xml \
@@ -50,11 +54,19 @@ GLIB_SCHEMAS=	org.gtk.Demo4.gschema.xml \
 		org.gtk.gtk4.Settings.EmojiChooser.gschema.xml \
 		org.gtk.gtk4.Settings.FileChooser.gschema.xml
 
-OPTIONS_DEFINE=	CUPS COLORD DEBUG BROADWAY GSTREAMER VULKAN WAYLAND X11
-OPTIONS_DEFAULT=CUPS COLORD BROADWAY GSTREAMER VULKAN WAYLAND X11
+OPTIONS_DEFINE=	ACCESSKIT BASH CUPS COLORD DEBUG BROADWAY GSTREAMER VULKAN \
+		WAYLAND X11
+OPTIONS_DEFAULT=CUPS COLORD GSTREAMER VULKAN WAYLAND X11
 OPTIONS_SUB=	yes
 
+ACCESSKIT_DESC=	Enable AccessKit backend for accessibility (experimental)
 BROADWAY_DESC=	Enable GDK Broadway backend for showing GTK in the webbrowser using HTML5 and web sockets.
+
+ACCESSKIT_LIB_DEPENDS=	libaccesskit-c-0.17.so:accessibility/accesskit-c
+ACCESSKIT_MESON_ENABLED=	accesskit
+
+BASH_BUILD_DEPENDS=	bash-completion>0:shells/bash-completion
+
 BROADWAY_MESON_TRUE=	broadway-backend
 
 COLORD_DESC=	Color profile support
@@ -65,9 +77,9 @@ CUPS_LIB_DEPENDS=	libcups.so:print/cups
 CUPS_MESON_ENABLED=	print-cups
 
 GSTREAMER_DESC=		GStreamer multimedia backend
-GSTREAMER_MESON_ENABLED=media-gstreamer
 GSTREAMER_USES=		gstreamer
 GSTREAMER_USE=		GSTREAMER=bad,gl
+GSTREAMER_MESON_ENABLED=media-gstreamer
 
 VULKAN_DESC=		GDK Vulkan renderer backend
 VULKAN_BUILD_DEPENDS=	glslc:graphics/shaderc \
@@ -78,7 +90,6 @@ VULKAN_MESON_ENABLED=	vulkan
 VULKAN_CFLAGS=		-Wno-error=int-conversion # https://gitlab.gnome.org/GNOME/gtk/-/issues/6033
 
 WAYLAND_DESC=		GDK Wayland backend
-WAYLAND_MESON_TRUE=	wayland-backend
 WAYLAND_BUILD_DEPENDS=	wayland-protocols>=0:graphics/wayland-protocols
 WAYLAND_LIB_DEPENDS=	libwayland-egl.so:graphics/wayland \
 			libxkbcommon.so:x11/libxkbcommon
@@ -86,23 +97,30 @@ WAYLAND_RUN_DEPENDS=	gsettings-desktop-schemas>=0:devel/gsettings-desktop-schema
 			wayland-protocols>=0:graphics/wayland-protocols
 WAYLAND_USES=		gl
 WAYLAND_USE=		GL=egl
+WAYLAND_MESON_TRUE=	wayland-backend
 
 X11_DESC=		GDK X11 backend
-X11_MESON_TRUE=		x11-backend
+X11_LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig
 X11_USES=		xorg
-X11_USE=		XORG=x11,xcomposite,xcursor,xdamage,xext,xfixes,xi,xinerama,xrandr,xrender
-
-NO_TEST=	yes
+X11_USE=		XORG=x11,xcursor,xdamage,xext,xfixes,xi,xinerama,xrandr,xrender
+X11_MESON_TRUE=		x11-backend
 
 pre-build:
-	-${RM} -r ${WRKSRC}/docs/gtk.info*
+	@${RM} -r ${WRKSRC}/docs/gtk.info*
 
 post-install:
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/engines
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/loaders
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/modules
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/engines
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/loaders
-	@${MKDIR} ${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/modules
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/engines
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/loaders
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/modules
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/engines
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/loaders
+	@${MKDIR} ${FAKE_DESTDIR}${PREFIX}/lib/gtk-4.0/${GTK4_VERSION}/modules
+
+pre-test:
+	@if [ ! -e ${WRKDIR}/.meson_build_tests ]; then \
+		${RM} ${CONFIGURE_COOKIE} ${BUILD_COOKIE}; \
+		${MAKE} -C${.CURDIR} build MESON_ARGS="${MESON_ARGS} --reconfigure -Dbuild-testsuite=true"; \
+		${TOUCH} ${WRKDIR}/.meson_build_tests; \
+	fi
 
 .include <bsd.port.mk>

--- a/x11-toolkits/gtk40/Makefile
+++ b/x11-toolkits/gtk40/Makefile
@@ -58,6 +58,7 @@ OPTIONS_DEFINE=	ACCESSKIT BASH CUPS COLORD DEBUG BROADWAY GSTREAMER VULKAN \
 		WAYLAND X11
 OPTIONS_DEFAULT=CUPS COLORD GSTREAMER VULKAN WAYLAND X11
 OPTIONS_SUB=	yes
+INSTALLS_ICONS=	yes
 
 ACCESSKIT_DESC=	Enable AccessKit backend for accessibility (experimental)
 BROADWAY_DESC=	Enable GDK Broadway backend for showing GTK in the webbrowser using HTML5 and web sockets.

--- a/x11-toolkits/gtk40/distinfo
+++ b/x11-toolkits/gtk40/distinfo
@@ -1,3 +1,5 @@
-TIMESTAMP = 1752500048
-SHA256 (gnome/gtk-4.18.6.tar.xz) = e1817c650ddc3261f9a8345b3b22a26a5d80af154630dedc03cc7becefffd0fa
-SIZE (gnome/gtk-4.18.6.tar.xz) = 17710412
+TIMESTAMP = 1788959416
+SHA256 (gnome/gtk-4.20.4.tar.xz) = a21f825bd44afc4dd99ba4eea8ff57c8f2e51085cb402a68ed4cbb35299826a4
+SIZE (gnome/gtk-4.20.4.tar.xz) = 16019448
+SHA256 (gnome/047c8e64d4156897776ec2bc3d0613a81cfe7ad1.patch) = f9f19bae08c599d0ed63b841a3e3d9b7d549e90b42653513d4f02f696bae3fd2
+SIZE (gnome/047c8e64d4156897776ec2bc3d0613a81cfe7ad1.patch) = 1113

--- a/x11-toolkits/gtk40/files/patch-dmabuf
+++ b/x11-toolkits/gtk40/files/patch-dmabuf
@@ -1,10 +1,12 @@
 --- dma-buf-compat.h.orig	2024-08-27 18:15:44 UTC
 +++ dma-buf-compat.h
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,36 @@
 +#ifdef __linux__
 +#include <linux/dma-buf.h>
++#include <linux/udmabuf.h>
 +#else
 +typedef uint64_t __u64;
++typedef uint32_t __u32;
 +
 +// From https://github.com/evadot/drm-subtree or https://reviews.freebsd.org/D23085
 +struct dma_buf_sync
@@ -22,18 +24,29 @@
 +
 +#define DMA_BUF_BASE       'b'
 +#define DMA_BUF_IOCTL_SYNC _IOW(DMA_BUF_BASE, 0, struct dma_buf_sync)
++
++struct udmabuf_create
++{
++  __u32 memfd;
++  __u32 flags;
++  __u64 offset;
++  __u64 size;
++};
++
++#define UDMABUF_FLAGS_CLOEXEC 0x01
++#define UDMABUF_IOCTL_BASE 'u'
++#define UDMABUF_CREATE _IOW(UDMABUF_IOCTL_BASE, 0x42, struct udmabuf_create)
 +#endif
 --- gdk/gdkdmabuf.c.orig	2024-08-27 18:17:03 UTC
 +++ gdk/gdkdmabuf.c
-@@ -28,8 +28,8 @@
- #ifdef HAVE_DMABUF
+@@ -30,6 +30,5 @@
+ #include <fcntl.h>
  #include <sys/mman.h>
  #include <sys/ioctl.h>
 -#include <linux/dma-buf.h>
+-#include <linux/udmabuf.h>
  #include <epoxy/egl.h>
 +#include "../dma-buf-compat.h"
- 
- typedef struct _GdkDrmFormatInfo GdkDrmFormatInfo;
  
 --- gsk/gpu/gskgpudownloadop.c.orig	2024-09-13 14:11:36 UTC
 +++ gsk/gpu/gskgpudownloadop.c
@@ -57,6 +70,27 @@
  #endif
  
  struct _GskVulkanImage
+--- testsuite/gdk/udmabuf.c.orig	2026-09-09 00:00:00 UTC
++++ testsuite/gdk/udmabuf.c
+@@ -8,8 +8,8 @@
+ #include <inttypes.h>
+ #include <fcntl.h>
+ #include <sys/mman.h>
+ #include <sys/ioctl.h>
+-#include <linux/udmabuf.h>
++#include "../../dma-buf-compat.h"
+ #include <errno.h>
+ #include <gtk/gtk.h>
+ #include <gio/gio.h>
+--- testsuite/gdk/meson.build.orig	2025-02-13 19:07:42 UTC
++++ testsuite/gdk/meson.build
+@@ -45,5 +45,5 @@ if os_linux
+ else
+   tests += [
+-    { 'name': 'colorstate' }
++    { 'name': 'colorstate', 'sources': [ 'udmabuf.c' ] },
+   ]
+ endif
 --- meson.build.orig	2024-08-27 18:19:59 UTC
 +++ meson.build
 @@ -636,7 +636,7 @@ cdata.set('HAVE_DRM_FOURCC_H', libdrm_dep.found())

--- a/x11-toolkits/gtk40/pkg-plist
+++ b/x11-toolkits/gtk40/pkg-plist
@@ -107,6 +107,7 @@ include/gtk-4.0/gsk/gpu/gskglrenderer.h
 include/gtk-4.0/gsk/gpu/gskvulkanrenderer.h
 include/gtk-4.0/gsk/gsk.h
 include/gtk-4.0/gsk/gskcairorenderer.h
+include/gtk-4.0/gsk/gskcomponenttransfer.h
 include/gtk-4.0/gsk/gskenums.h
 include/gtk-4.0/gsk/gskenumtypes.h
 include/gtk-4.0/gsk/gskglshader.h
@@ -286,6 +287,7 @@ include/gtk-4.0/gtk/gtkgrid.h
 include/gtk-4.0/gtk/gtkgridlayout.h
 include/gtk-4.0/gtk/gtkgridview.h
 include/gtk-4.0/gtk/gtkheaderbar.h
+include/gtk-4.0/gtk/gtkiconpaintable.h
 include/gtk-4.0/gtk/gtkicontheme.h
 include/gtk-4.0/gtk/gtkimage.h
 include/gtk-4.0/gtk/gtkimcontext.h
@@ -416,12 +418,10 @@ lib/girepository-1.0/Gdk-4.0.typelib
 %%X11%%lib/girepository-1.0/GdkX11-4.0.typelib
 lib/girepository-1.0/Gsk-4.0.typelib
 lib/girepository-1.0/Gtk-4.0.typelib
-%%GSTREAMER%%lib/gtk-4.0/4.0.0/media/libmedia-gstreamer.so
-%%CUPS%%lib/gtk-4.0/4.0.0/printbackends/libprintbackend-cups.so
-lib/gtk-4.0/4.0.0/printbackends/libprintbackend-file.so
 lib/libgtk-4.so
 lib/libgtk-4.so.1
 lib/libgtk-4.so.%%LIBVERSION%%
+%%ACCESSKIT%%libdata/pkgconfig/gtk4-accesskit.pc
 libdata/pkgconfig/gtk4-atspi.pc
 %%BROADWAY%%libdata/pkgconfig/gtk4-broadway.pc
 libdata/pkgconfig/gtk4-unix-print.pc
@@ -432,6 +432,14 @@ share/applications/org.gtk.Demo4.desktop
 share/applications/org.gtk.PrintEditor4.desktop
 share/applications/org.gtk.WidgetFactory4.desktop
 share/applications/org.gtk.gtk4.NodeEditor.desktop
+%%BASH%%share/bash-completion/completions/gtk4-builder-tool
+%%BASH%%share/bash-completion/completions/gtk4-demo
+%%BASH%%share/bash-completion/completions/gtk4-image-tool
+%%BASH%%share/bash-completion/completions/gtk4-node-editor
+%%BASH%%share/bash-completion/completions/gtk4-path-tool
+%%BASH%%share/bash-completion/completions/gtk4-print-editor
+%%BASH%%share/bash-completion/completions/gtk4-rendernode-tool
+%%BASH%%share/bash-completion/completions/gtk4-widget-factory
 share/gettext/its/gtk4builder.its
 share/gettext/its/gtk4builder.loc
 share/gir-1.0/Gdk-4.0.gir
@@ -530,7 +538,6 @@ share/locale/it/LC_MESSAGES/gtk40.mo
 share/locale/ja/LC_MESSAGES/gtk40.mo
 share/locale/ka/LC_MESSAGES/gtk40.mo
 share/locale/kab/LC_MESSAGES/gtk40.mo
-share/locale/kg/LC_MESSAGES/gtk40.mo
 share/locale/kk/LC_MESSAGES/gtk40.mo
 share/locale/km/LC_MESSAGES/gtk40.mo
 share/locale/kn/LC_MESSAGES/gtk40.mo
@@ -578,7 +585,6 @@ share/locale/ta/LC_MESSAGES/gtk40.mo
 share/locale/te/LC_MESSAGES/gtk40.mo
 share/locale/tg/LC_MESSAGES/gtk40.mo
 share/locale/th/LC_MESSAGES/gtk40.mo
-share/locale/tk/LC_MESSAGES/gtk40.mo
 share/locale/tr/LC_MESSAGES/gtk40.mo
 share/locale/tt/LC_MESSAGES/gtk40.mo
 share/locale/ug/LC_MESSAGES/gtk40.mo
@@ -603,6 +609,3 @@ share/metainfo/org.gtk.gtk4.NodeEditor.appdata.xml
 @dir lib/gtk-4.0/%%GTK4_VERSION%%/engines
 @dir lib/gtk-4.0/%%GTK4_VERSION%%/loaders
 @dir lib/gtk-4.0/%%GTK4_VERSION%%/modules
-@postexec /usr/local/bin/glib-compile-schemas /usr/local/share/glib-2.0/schemas
-@postexec /usr/local/bin/gio-querymodules /usr/local/lib/gtk-4.0/4.0.0/printbackends
-@postexec gtk4-update-icon-cache -q -t -f /usr/local/share/icons/hicolor


### PR DESCRIPTION
Updates GTK4 to 4.20.4.

The MidnightBSD dma-buf compatibility patch is refreshed for linux/udmabuf.h and its test helpers.

Validated: bmake makesum, patch, build, fake, package, check-license, portlint -C (0 fatals), and git diff --check.

The upstream Meson suite compiles fully, but its Wayland renderer runtime tests require a compositor unavailable in this headless build environment; tests remain enabled.

## Summary by Sourcery

Update the GTK4 port to 4.20.4 with refreshed compatibility support, dependency integration, backend options, and test handling.

New Features:
- Add optional AccessKit accessibility support and bash-completion integration.
- Enable GTK test builds through the port test target while retaining the upstream test suite.

Bug Fixes:
- Refresh the dma-buf compatibility patch and associated packaging metadata for the newer GTK release.

Enhancements:
- Update GTK4 to version 4.20.4 and align dependencies, backend options, library versioning, icon installation, and staging behavior with the new release.

Tests:
- Support rebuilding the Meson test suite on demand during port testing.