### PR TITLE
net/libcloudproviders: update to 0.4.0

### DIFF
--- a/net/libcloudproviders/Makefile
+++ b/net/libcloudproviders/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	libcloudproviders
-PORTVERSION=	0.3.6
+PORTVERSION=	0.4.0
 CATEGORIES=	net
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+.[0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -10,7 +10,8 @@ WWW=		https://gitlab.gnome.org/GNOME/libcloudproviders
 
 LICENSE=	lgpl3
 
-USES=	tar:xz meson gnome vala:build pkgconfig
+USES=	gnome meson pkgconfig tar:xz vala:build
 USE_GNOME=	glib20 introspection:build
+USE_LDCONFIG=	yes
 
 .include <bsd.port.mk>

--- a/net/libcloudproviders/distinfo
+++ b/net/libcloudproviders/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741183758
-SHA256 (gnome/libcloudproviders-0.3.6.tar.xz) = 3b75110b3a4fdef4c5c5a440e48701fe054d2ae061d156c89136bb5ba05e74b7
-SIZE (gnome/libcloudproviders-0.3.6.tar.xz) = 23844
+TIMESTAMP = 1788928484
+SHA256 (gnome/libcloudproviders-0.4.0.tar.xz) = 247b228d1027b2683868e7d7080d38693a457e908aadd0c119d52de59a398064
+SIZE (gnome/libcloudproviders-0.4.0.tar.xz) = 23580

--- a/net/libcloudproviders/pkg-plist
+++ b/net/libcloudproviders/pkg-plist
@@ -8,7 +8,7 @@ include/cloudproviders/enums.h
 lib/girepository-1.0/CloudProviders-0.3.typelib
 lib/libcloudproviders.so
 lib/libcloudproviders.so.0
-lib/libcloudproviders.so.0.3.6
+lib/libcloudproviders.so.0.4.0
 libdata/pkgconfig/cloudproviders.pc
 share/gir-1.0/CloudProviders-0.3.gir
 share/vala/vapi/cloudproviders.deps


### PR DESCRIPTION
Updates libcloudproviders to 0.4.0 now that the host Meson satisfies upstream requirements.

Validated: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C (0 fatals), and git diff --check.

## Summary by Sourcery

Update the libcloudproviders port to the 0.4.0 release.

Enhancements:
- Update the libcloudproviders port to version 0.4.0 and enable shared-library runtime integration.

Build:
- Refresh the GNOME source location and port packaging metadata for the new release.