### PR TITLE
x11-toolkits/gtkmm40: update to 4.20.0

### DIFF
--- a/x11-toolkits/gtkmm40/Makefile
+++ b/x11-toolkits/gtkmm40/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gtkmm
-PORTVERSION=	4.18.0
+PORTVERSION=	4.20.0
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	40
@@ -12,7 +12,8 @@ WWW=		https://gtkmm.gnome.org/
 LICENSE=	lgpl2.1+
 
 LIB_DEPENDS=	libepoxy.so:graphics/libepoxy \
-		libgraphene-1.0.so:graphics/graphene
+		libgraphene-1.0.so:graphics/graphene \
+		libvulkan.so:graphics/vulkan-loader
 
 USES=		compiler:c++17-lang gnome meson pkgconfig \
 		python:build tar:xz

--- a/x11-toolkits/gtkmm40/distinfo
+++ b/x11-toolkits/gtkmm40/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1745067249
-SHA256 (gnome/gtkmm-4.18.0.tar.xz) = 2ee31c15479fc4d8e958b03c8b5fbbc8e17bc122c2a2f544497b4e05619e33ec
-SIZE (gnome/gtkmm-4.18.0.tar.xz) = 17063416
+TIMESTAMP = 1788928300
+SHA256 (gnome/gtkmm-4.20.0.tar.xz) = daad9bf9b70f90975f91781fc7a656c923a91374261f576c883cd3aebd59c833
+SIZE (gnome/gtkmm-4.20.0.tar.xz) = 17463040


### PR DESCRIPTION
Updates GTK C++ bindings to 4.20.0.

Adds the Vulkan loader dependency required by the new release.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (upstream has no tests defined)
- bmake check-license
- portlint -C . (0 fatal errors)
- git diff --check

## Summary by Sourcery

Update the gtkmm40 port to release 4.20.0 and include its Vulkan loader dependency.

Enhancements:
- Update the GTK C++ bindings port to version 4.20.0.
- Add the Vulkan loader as a required runtime dependency.