### PR TITLE
x11-toolkits/libgedit-gtksourceview: update to 299.7.0

### DIFF
--- a/x11-toolkits/libgedit-gtksourceview/Makefile
+++ b/x11-toolkits/libgedit-gtksourceview/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	libgedit-gtksourceview
-DISTVERSION=	299.6.0
-PORTREVISION=	1
+DISTVERSION=	299.7.0
 CATEGORIES=	x11-toolkits
 DIST_SUBDIR=	gnome
 
@@ -10,13 +9,15 @@ WWW=		https://gitlab.gnome.org/World/gedit/libgedit-gtksourceview
 
 LICENSE=	lgpl2.1
 
-USES=		gettext-tools gnome meson pkgconfig tar:bz2
-USE_GNOME=	cairo gdkpixbuf glib20 gtk30 libxml2 introspection:build
-USE_LDCONFIG=	yes
+LIB_DEPENDS=	libgedit-amtk-5.so:x11-toolkits/amtk \
+		libgedit-gfls-1.so:filesystems/libgedit-gfls
 
+USES=		gettext-tools gnome meson pkgconfig tar:bz2
 USE_GITLAB=	yes
 GL_SITE=	https://gitlab.gnome.org
 GL_ACCOUNT=	World/gedit
+USE_GNOME=	cairo gdkpixbuf glib20 gtk30 libxml2 introspection:build
+USE_LDCONFIG=	yes
 
 MESON_ARGS=	-Dgtk_doc=false \
 		-Dtests=false

--- a/x11-toolkits/libgedit-gtksourceview/distinfo
+++ b/x11-toolkits/libgedit-gtksourceview/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1768240022
-SHA256 (gnome/libgedit-gtksourceview-299.6.0.tar.bz2) = e0c79788f548dbc94f932faaab91ef823a9e9d336ef6f1f049623116121d2e75
-SIZE (gnome/libgedit-gtksourceview-299.6.0.tar.bz2) = 694671
+TIMESTAMP = 1788930211
+SHA256 (gnome/libgedit-gtksourceview-299.7.0.tar.bz2) = c0baf7fcf756ad0b47150ea17e5de2cacb0833bbda13c6a625f57f3d00aee0bf
+SIZE (gnome/libgedit-gtksourceview-299.7.0.tar.bz2) = 692779

--- a/x11-toolkits/libgedit-gtksourceview/pkg-plist
+++ b/x11-toolkits/libgedit-gtksourceview/pkg-plist
@@ -1,6 +1,4 @@
 include/libgedit-gtksourceview-300/gtksourceview/completion-providers/words/gtksourcecompletionwords.h
-include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceiconv.h
-include/libgedit-gtksourceview-300/gtksourceview/file-loading-and-saving/gtksourceinputstream.h
 include/libgedit-gtksourceview-300/gtksourceview/gtksource-enumtypes.h
 include/libgedit-gtksourceview-300/gtksourceview/gtksource.h
 include/libgedit-gtksourceview-300/gtksourceview/gtksourceautocleanups.h
@@ -40,7 +38,7 @@ include/libgedit-gtksourceview-300/gtksourceview/gtksourceutils.h
 include/libgedit-gtksourceview-300/gtksourceview/gtksourceview.h
 lib/girepository-1.0/GtkSource-300.typelib
 lib/libgedit-gtksourceview-300.so
-lib/libgedit-gtksourceview-300.so.4
+lib/libgedit-gtksourceview-300.so.5
 libdata/pkgconfig/libgedit-gtksourceview-300.pc
 share/gir-1.0/GtkSource-300.gir
 %%DATADIR%%-300/language-specs/R.lang


### PR DESCRIPTION
Updates libgedit-gtksourceview to 299.7.0, adds its AMTK/GFLS dependencies, and corrects the installed-library manifest.\n\nValidated: `bmake makesum`, `bmake patch`, `bmake build`, `bmake fake`, `bmake package`, `bmake test`, `bmake check-license`, `portlint -C`, and `git diff --check`.\n\nThe dependent AMTK 5.10.0 and corrected libgedit-gfls 0.4.1 packages were built and installed locally for validation.

## Summary by Sourcery

Update libgedit-gtksourceview to 299.7.0 with its required libraries and corrected packaging metadata.

Bug Fixes:
- Correct the installed-library manifest for libgedit-gtksourceview.

Enhancements:
- Update libgedit-gtksourceview to version 299.7.0 and declare its AMTK and GFLs library dependencies.