### PR TITLE
graphics/xviewer: add context to GI compatibility patches

### DIFF
--- a/graphics/xviewer/files/patch-meson.build
+++ b/graphics/xviewer/files/patch-meson.build
@@ -1,11 +1,15 @@
 --- meson.build.orig
 +++ meson.build
-@@ -42,0 +43,8 @@
-+
+@@ -40,6 +40,12 @@
+ gtk = dependency('gtk+-3.0')
+ libpeas = dependency('libpeas-1.0', version: '>= 0.7.4')
+ libpeas_gtk = dependency('libpeas-gtk-1.0', version: '>= 0.7.4')
 +gi = dependency('girepository-2.0', required: false)
 +use_gir20 = gi.found()
 +if not use_gir20
 +    gi = dependency('gobject-introspection-1.0', version: '>= 0.9.2')
 +endif
 +xviewer_conf.set10('USE_GIR20', use_gir20)
-+
+ pixbuf = dependency('gdk-pixbuf-2.0', version: '>= 2.19.1')
+ X11 = dependency('x11')
+ zlib = dependency('zlib')

--- a/graphics/xviewer/files/patch-src_main.c
+++ b/graphics/xviewer/files/patch-src_main.c
@@ -1,14 +1,28 @@
 --- src/main.c.orig
 +++ src/main.c
-@@ -29,0 +30,3 @@
+@@ -27,8 +27,12 @@
+ #include "config.h"
+ #endif
+ #ifdef HAVE_INTROSPECTION
 +#if USE_GIR20
 +#include <girepository/girepository.h>
 +#else
-@@ -31,0 +35 @@
+ #include <girepository.h>
+ #endif
 +#endif
-@@ -104,0 +109,3 @@
+ 
+ #include "xviewer-application.h"
+ #include "xviewer-application-internal.h"
+@@ -102,8 +106,12 @@
+ 	 * Using gtk_get_option_group here initializes gtk during parsing */
+ 	g_option_context_add_group (ctx, gtk_get_option_group (FALSE));
+ #ifdef HAVE_INTROSPECTION
 +#if USE_GIR20
 +	g_option_context_add_group (ctx, gi_repository_get_option_group ());
 +#else
-@@ -106,0 +114 @@
+ 	g_option_context_add_group (ctx, g_irepository_get_option_group ());
+ #endif
 +#endif
+ 
+ 	if (!g_option_context_parse (ctx, &argc, &argv, &error)) {
+ 		gchar *help_msg;

--- a/graphics/xviewer/files/patch-src_meson.build
+++ b/graphics/xviewer/files/patch-src_meson.build
@@ -1,4 +1,10 @@
 --- src/meson.build.orig
 +++ src/meson.build
-@@ -133,0 +134 @@
+@@ -136,6 +136,7 @@
+     gtk,
+     libpeas,
+     libpeas_gtk,
 +    gi,
+     math,
+     X11,
+     zlib,

--- a/graphics/xviewer/files/patch-src_xviewer-plugin-engine.c
+++ b/graphics/xviewer/files/patch-src_xviewer-plugin-engine.c
@@ -1,13 +1,21 @@
 --- src/xviewer-plugin-engine.c.orig
 +++ src/xviewer-plugin-engine.c
-@@ -36,0 +37,4 @@
-+
+@@ -34,7 +34,11 @@
+ #include <glib/gi18n.h>
+ #include <glib.h>
+ #include <gio/gio.h>
 +#if USE_GIR20
 +#include <girepository/girepository.h>
 +#else
-@@ -37,0 +42 @@
+ #include <girepository.h>
 +#endif
-@@ -88,0 +94,29 @@
+ 
+ #define XVIEWER_PLUGIN_DATA_DIR XVIEWER_DATA_DIR G_DIR_SEPARATOR_S "plugins"
+ 
+@@ -86,6 +90,35 @@
+ 	GError *error = NULL;
+ 
+ 	/* This should be moved to libpeas */
 +#if USE_GIR20
 +	GIRepository *repo = gi_repository_dup_default ();
 +
@@ -37,5 +45,14 @@
 +
 +	g_object_unref (repo);
 +#else
-@@ -114,0 +149 @@
+ 	if (g_irepository_require (g_irepository_get_default (),
+ 				   "Peas", "1.0", 0, &error) == NULL)
+ 	{
+@@ -112,6 +145,7 @@
+ 			   error->message);
+ 		g_clear_error (&error);
+ 	}
 +#endif
+ 
+ 	engine = XVIEWER_PLUGIN_ENGINE (g_object_new (XVIEWER_TYPE_PLUGIN_ENGINE,
+ 						  NULL));


### PR DESCRIPTION
Regenerates the GObject Introspection compatibility patches with normal unified context, addressing the post-merge review concern in #938.\n\nValidated: `bmake patch`, `bmake build`, `bmake fake`, `bmake package`, `bmake test`, `bmake check-license`, and `portlint -C` (0 fatal).\n\n`git diff --check` flags indentation in patch context lines; this is intrinsic to standard-context source patches and is covered by the successful clean patch application.

## Summary by Sourcery

Enhancements:
- Regenerate xviewer’s GObject Introspection compatibility patches with standard unified context for clearer review and maintenance.