### PR TITLE
games/gnome-chess: update to 47.0

### DIFF
--- a/games/gnome-chess/Makefile
+++ b/games/gnome-chess/Makefile
@@ -1,27 +1,25 @@
 PORTNAME=	gnome-chess
-PORTVERSION=	43.0
-PORTREVISION=	2
+PORTVERSION=	47.0
 CATEGORIES=	games gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Gnome chess
 WWW=		https://wiki.gnome.org/Apps/Chess
 
-LICENSE=	gpl3
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	appstream-util:devel/appstream-glib \
-		itstool:textproc/itstool
-LIB_DEPENDS=	libadwaita-1.so:x11-toolkits/libadwaita
+BUILD_DEPENDS=	itstool:textproc/itstool
+RUN_DEPENDS=	dbus>0:devel/dbus
 
 PORTSCOUT=	limitw:1,even
 
-USES=		desktop-file-utils gettext gl gnome localbase meson pkgconfig \
+USES=		desktop-file-utils gettext gnome localbase meson pkgconfig \
 		python:build tar:xz vala:build
-USE_GNOME=	cairo gtk40 librsvg2 libxml2:build
-USE_GL=		egl gl
+USE_GNOME=	cairo gtk40 libadwaita librsvg2 libxml2:build
+INSTALLS_ICONS=	yes
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 
 LDFLAGS+=	-lm

--- a/games/gnome-chess/distinfo
+++ b/games/gnome-chess/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1664993307
-SHA256 (gnome/gnome-chess-43.0.tar.xz) = 6433fedf2f42fb22bf202d9f138ec2ee07237ad5d743809050b5c809b56cdbcb
-SIZE (gnome/gnome-chess-43.0.tar.xz) = 658156
+TIMESTAMP = 1788919162
+SHA256 (gnome/gnome-chess-47.0.tar.xz) = 3a443a2c7880e6ad131b75add8074edbe5982b76abb842904fe3df9c2c50e87e
+SIZE (gnome/gnome-chess-47.0.tar.xz) = 825264


### PR DESCRIPTION
Updates GNOME Chess to 47.0, enables icon-cache maintenance, and corrects the verified GPLv3-or-later declaration.\n\nValidated: `bmake makesum`, `bmake patch`, `bmake build`, `bmake fake`, `bmake package`, `bmake test` (4/4), `bmake check-license`, `portlint -C`, and `git diff --check`.

## Summary by Sourcery

Update the GNOME Chess port to version 47.0 with refreshed dependencies and packaging metadata.

Bug Fixes:
- Correct the package license declaration to GPLv3-or-later.

Enhancements:
- Update GNOME Chess from 43.0 to 47.0 and align its dependencies with the new release.
- Enable icon-cache maintenance for installed application icons.