### PR TITLE
games/gnome-sudoku: update to 47.3

### DIFF
--- a/games/gnome-sudoku/Makefile
+++ b/games/gnome-sudoku/Makefile
@@ -1,30 +1,29 @@
 PORTNAME=	gnome-sudoku
-PORTVERSION=	42.0
-PORTREVISION=	1
+PORTVERSION=	47.3
 CATEGORIES=	games gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Sudoku game for GNOME
 WWW=		https://wiki.gnome.org/GnomeSudoku
 
-LICENSE=	gpl3
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	itstool:textproc/itstool \
-		appstream-util:devel/appstream-glib
+BUILD_DEPENDS=	itstool:textproc/itstool
 LIB_DEPENDS=	libgee-0.8.so:devel/libgee \
 		libqqwing.so:games/qqwing \
-		libjson-glib-1.0.so:devel/json-glib
+		libjson-glib-1.0.so:devel/json-glib \
+		libgraphene-1.0.so:graphics/graphene
+RUN_DEPENDS=	dbus>0:devel/dbus
 
-PORTSCOUT=	limitw:1,even
+PORTSCOUT=	limit:^47\.
 
-USES=		compiler:c++11-lang gettext gmake gnome meson \
-		python pkgconfig tar:xz vala:build
-USE_GNOME=	cairo gtk30
-
-BINARY_ALIAS=	python3=${PYTHON_CMD}
+USES=		compiler:c++11-lang desktop-file-utils gettext gnome meson \
+		pkgconfig tar:xz vala:build
+USE_GNOME=	cairo glib20 gtk40 libadwaita
+INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.Sudoku.gschema.xml
 

--- a/games/gnome-sudoku/distinfo
+++ b/games/gnome-sudoku/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1648167676
-SHA256 (gnome/gnome-sudoku-42.0.tar.xz) = 1d2eb4ddb8026b443645cf3585b8df1244e3828ee1c07518052b2599e1c5c28f
-SIZE (gnome/gnome-sudoku-42.0.tar.xz) = 380836
+TIMESTAMP = 1788918849
+SHA256 (gnome/gnome-sudoku-47.3.tar.xz) = f05cf1ef7635ca058ea237d9509eb3295e1def9e4d4e7a5d30b9151f7db90852
+SIZE (gnome/gnome-sudoku-47.3.tar.xz) = 420252

--- a/games/gnome-sudoku/pkg-plist
+++ b/games/gnome-sudoku/pkg-plist
@@ -1,5 +1,4 @@
 bin/gnome-sudoku
-share/man/man6/gnome-sudoku.6.gz
 share/applications/org.gnome.Sudoku.desktop
 share/dbus-1/services/org.gnome.Sudoku.service
 share/help/C/gnome-sudoku/basics.page
@@ -13,7 +12,6 @@ share/help/C/gnome-sudoku/figures/strategy1.png
 share/help/C/gnome-sudoku/figures/strategy2.png
 share/help/C/gnome-sudoku/highlighting.page
 share/help/C/gnome-sudoku/index.page
-share/help/C/gnome-sudoku/keyboard-shortcuts.page
 share/help/C/gnome-sudoku/legal.xml
 share/help/C/gnome-sudoku/license.page
 share/help/C/gnome-sudoku/print-blank-puzzles.page
@@ -33,7 +31,6 @@ share/help/ca/gnome-sudoku/figures/strategy1.png
 share/help/ca/gnome-sudoku/figures/strategy2.png
 share/help/ca/gnome-sudoku/highlighting.page
 share/help/ca/gnome-sudoku/index.page
-share/help/ca/gnome-sudoku/keyboard-shortcuts.page
 share/help/ca/gnome-sudoku/legal.xml
 share/help/ca/gnome-sudoku/license.page
 share/help/ca/gnome-sudoku/print-blank-puzzles.page
@@ -53,7 +50,6 @@ share/help/cs/gnome-sudoku/figures/strategy1.png
 share/help/cs/gnome-sudoku/figures/strategy2.png
 share/help/cs/gnome-sudoku/highlighting.page
 share/help/cs/gnome-sudoku/index.page
-share/help/cs/gnome-sudoku/keyboard-shortcuts.page
 share/help/cs/gnome-sudoku/legal.xml
 share/help/cs/gnome-sudoku/license.page
 share/help/cs/gnome-sudoku/print-blank-puzzles.page
@@ -73,7 +69,6 @@ share/help/da/gnome-sudoku/figures/strategy1.png
 share/help/da/gnome-sudoku/figures/strategy2.png
 share/help/da/gnome-sudoku/highlighting.page
 share/help/da/gnome-sudoku/index.page
-share/help/da/gnome-sudoku/keyboard-shortcuts.page
 share/help/da/gnome-sudoku/legal.xml
 share/help/da/gnome-sudoku/license.page
 share/help/da/gnome-sudoku/print-blank-puzzles.page
@@ -93,7 +88,6 @@ share/help/de/gnome-sudoku/figures/strategy1.png
 share/help/de/gnome-sudoku/figures/strategy2.png
 share/help/de/gnome-sudoku/highlighting.page
 share/help/de/gnome-sudoku/index.page
-share/help/de/gnome-sudoku/keyboard-shortcuts.page
 share/help/de/gnome-sudoku/legal.xml
 share/help/de/gnome-sudoku/license.page
 share/help/de/gnome-sudoku/print-blank-puzzles.page
@@ -113,7 +107,6 @@ share/help/el/gnome-sudoku/figures/strategy1.png
 share/help/el/gnome-sudoku/figures/strategy2.png
 share/help/el/gnome-sudoku/highlighting.page
 share/help/el/gnome-sudoku/index.page
-share/help/el/gnome-sudoku/keyboard-shortcuts.page
 share/help/el/gnome-sudoku/legal.xml
 share/help/el/gnome-sudoku/license.page
 share/help/el/gnome-sudoku/print-blank-puzzles.page
@@ -133,7 +126,6 @@ share/help/es/gnome-sudoku/figures/strategy1.png
 share/help/es/gnome-sudoku/figures/strategy2.png
 share/help/es/gnome-sudoku/highlighting.page
 share/help/es/gnome-sudoku/index.page
-share/help/es/gnome-sudoku/keyboard-shortcuts.page
 share/help/es/gnome-sudoku/legal.xml
 share/help/es/gnome-sudoku/license.page
 share/help/es/gnome-sudoku/print-blank-puzzles.page
@@ -153,7 +145,6 @@ share/help/eu/gnome-sudoku/figures/strategy1.png
 share/help/eu/gnome-sudoku/figures/strategy2.png
 share/help/eu/gnome-sudoku/highlighting.page
 share/help/eu/gnome-sudoku/index.page
-share/help/eu/gnome-sudoku/keyboard-shortcuts.page
 share/help/eu/gnome-sudoku/legal.xml
 share/help/eu/gnome-sudoku/license.page
 share/help/eu/gnome-sudoku/print-blank-puzzles.page
@@ -173,7 +164,6 @@ share/help/fr/gnome-sudoku/figures/strategy1.png
 share/help/fr/gnome-sudoku/figures/strategy2.png
 share/help/fr/gnome-sudoku/highlighting.page
 share/help/fr/gnome-sudoku/index.page
-share/help/fr/gnome-sudoku/keyboard-shortcuts.page
 share/help/fr/gnome-sudoku/legal.xml
 share/help/fr/gnome-sudoku/license.page
 share/help/fr/gnome-sudoku/print-blank-puzzles.page
@@ -193,7 +183,6 @@ share/help/gl/gnome-sudoku/figures/strategy1.png
 share/help/gl/gnome-sudoku/figures/strategy2.png
 share/help/gl/gnome-sudoku/highlighting.page
 share/help/gl/gnome-sudoku/index.page
-share/help/gl/gnome-sudoku/keyboard-shortcuts.page
 share/help/gl/gnome-sudoku/legal.xml
 share/help/gl/gnome-sudoku/license.page
 share/help/gl/gnome-sudoku/print-blank-puzzles.page
@@ -213,7 +202,6 @@ share/help/hu/gnome-sudoku/figures/strategy1.png
 share/help/hu/gnome-sudoku/figures/strategy2.png
 share/help/hu/gnome-sudoku/highlighting.page
 share/help/hu/gnome-sudoku/index.page
-share/help/hu/gnome-sudoku/keyboard-shortcuts.page
 share/help/hu/gnome-sudoku/legal.xml
 share/help/hu/gnome-sudoku/license.page
 share/help/hu/gnome-sudoku/print-blank-puzzles.page
@@ -233,7 +221,6 @@ share/help/id/gnome-sudoku/figures/strategy1.png
 share/help/id/gnome-sudoku/figures/strategy2.png
 share/help/id/gnome-sudoku/highlighting.page
 share/help/id/gnome-sudoku/index.page
-share/help/id/gnome-sudoku/keyboard-shortcuts.page
 share/help/id/gnome-sudoku/legal.xml
 share/help/id/gnome-sudoku/license.page
 share/help/id/gnome-sudoku/print-blank-puzzles.page
@@ -253,7 +240,6 @@ share/help/ko/gnome-sudoku/figures/strategy1.png
 share/help/ko/gnome-sudoku/figures/strategy2.png
 share/help/ko/gnome-sudoku/highlighting.page
 share/help/ko/gnome-sudoku/index.page
-share/help/ko/gnome-sudoku/keyboard-shortcuts.page
 share/help/ko/gnome-sudoku/legal.xml
 share/help/ko/gnome-sudoku/license.page
 share/help/ko/gnome-sudoku/print-blank-puzzles.page
@@ -273,7 +259,6 @@ share/help/pl/gnome-sudoku/figures/strategy1.png
 share/help/pl/gnome-sudoku/figures/strategy2.png
 share/help/pl/gnome-sudoku/highlighting.page
 share/help/pl/gnome-sudoku/index.page
-share/help/pl/gnome-sudoku/keyboard-shortcuts.page
 share/help/pl/gnome-sudoku/legal.xml
 share/help/pl/gnome-sudoku/license.page
 share/help/pl/gnome-sudoku/print-blank-puzzles.page
@@ -293,7 +278,6 @@ share/help/pt_BR/gnome-sudoku/figures/strategy1.png
 share/help/pt_BR/gnome-sudoku/figures/strategy2.png
 share/help/pt_BR/gnome-sudoku/highlighting.page
 share/help/pt_BR/gnome-sudoku/index.page
-share/help/pt_BR/gnome-sudoku/keyboard-shortcuts.page
 share/help/pt_BR/gnome-sudoku/legal.xml
 share/help/pt_BR/gnome-sudoku/license.page
 share/help/pt_BR/gnome-sudoku/print-blank-puzzles.page
@@ -313,7 +297,6 @@ share/help/ru/gnome-sudoku/figures/strategy1.png
 share/help/ru/gnome-sudoku/figures/strategy2.png
 share/help/ru/gnome-sudoku/highlighting.page
 share/help/ru/gnome-sudoku/index.page
-share/help/ru/gnome-sudoku/keyboard-shortcuts.page
 share/help/ru/gnome-sudoku/legal.xml
 share/help/ru/gnome-sudoku/license.page
 share/help/ru/gnome-sudoku/print-blank-puzzles.page
@@ -333,7 +316,6 @@ share/help/sv/gnome-sudoku/figures/strategy1.png
 share/help/sv/gnome-sudoku/figures/strategy2.png
 share/help/sv/gnome-sudoku/highlighting.page
 share/help/sv/gnome-sudoku/index.page
-share/help/sv/gnome-sudoku/keyboard-shortcuts.page
 share/help/sv/gnome-sudoku/legal.xml
 share/help/sv/gnome-sudoku/license.page
 share/help/sv/gnome-sudoku/print-blank-puzzles.page
@@ -353,7 +335,6 @@ share/help/uk/gnome-sudoku/figures/strategy1.png
 share/help/uk/gnome-sudoku/figures/strategy2.png
 share/help/uk/gnome-sudoku/highlighting.page
 share/help/uk/gnome-sudoku/index.page
-share/help/uk/gnome-sudoku/keyboard-shortcuts.page
 share/help/uk/gnome-sudoku/legal.xml
 share/help/uk/gnome-sudoku/license.page
 share/help/uk/gnome-sudoku/print-blank-puzzles.page
@@ -364,6 +345,7 @@ share/help/uk/gnome-sudoku/strategy.page
 share/help/uk/gnome-sudoku/translate.page
 share/icons/hicolor/scalable/apps/org.gnome.Sudoku.svg
 share/icons/hicolor/symbolic/apps/org.gnome.Sudoku-symbolic.svg
+share/locale/ab/LC_MESSAGES/gnome-sudoku.mo
 share/locale/af/LC_MESSAGES/gnome-sudoku.mo
 share/locale/am/LC_MESSAGES/gnome-sudoku.mo
 share/locale/ar/LC_MESSAGES/gnome-sudoku.mo
@@ -454,4 +436,5 @@ share/locale/xh/LC_MESSAGES/gnome-sudoku.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-sudoku.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-sudoku.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-sudoku.mo
-share/metainfo/org.gnome.Sudoku.appdata.xml
+share/man/man6/gnome-sudoku.6.gz
+share/metainfo/org.gnome.Sudoku.metainfo.xml


### PR DESCRIPTION
Updates GNOME Sudoku to 47.3, corrects its license metadata to GPLv3-or-later, and enables icon installation handling.\n\nValidated with bmake makesum, patch, build, fake, package, test (2/2 passed), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update GNOME Sudoku to 47.3 and align its packaging with the current GNOME application requirements.

New Features:
- Update GNOME Sudoku to version 47.3 with GTK 4 and libadwaita support.

Bug Fixes:
- Correct the package license metadata to GPLv3-or-later.

Enhancements:
- Enable desktop integration and icon installation for the application.
- Refresh runtime dependencies and packaged file metadata for the updated release.