### PR TITLE
graphics/eog: install icon cache

### DIFF
--- a/graphics/eog/Makefile
+++ b/graphics/eog/Makefile
@@ -25,6 +25,7 @@ USES=		compiler:c++11-lang desktop-file-utils gettext-tools gnome \
 		tar:xz xorg
 USE_GNOME=	cairo gnomedesktop3 gtk30 introspection librsvg2
 USE_XORG=	x11
+INSTALLS_ICONS=	yes
 
 MESON_ARGS=	-Dlibportal=false
 


### PR DESCRIPTION
Adds the missing icon-cache hook for the icons installed by the already-merged Eye of GNOME 50.1 update.\n\nValidated: `bmake check-license`, `portlint -C`, and `git diff --check`. The full 50.1 build/package/test validation was completed by the merged update.

## Summary by Sourcery

Enhancements:
- Enable icon-cache maintenance for the Eye of GNOME port.