### PR TITLE
games/gnome-mines: update to 48.1

### DIFF
--- a/games/gnome-mines/Makefile
+++ b/games/gnome-mines/Makefile
@@ -13,11 +13,13 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	itstool:textproc/itstool
 LIB_DEPENDS=	libgnome-games-support-2.so:games/libgnome-games-support2
+RUN_DEPENDS=	gtk-update-icon-cache:graphics/gtk-update-icon-cache
 
 USES=		desktop-file-utils gettext gnome localbase meson pkgconfig \
-		tar:xz vala:build
+		python:build tar:xz vala:build
 USE_GNOME=	glib20 gtk40 libadwaita
 
+BINARY_ALIAS=	python3=${PYTHON_VERSION}
 GLIB_SCHEMAS=	org.gnome.Mines.gschema.xml
 INSTALLS_ICONS=	yes
 PORTSCOUT=	limitw:1,even

--- a/games/gnome-mines/Makefile
+++ b/games/gnome-mines/Makefile
@@ -1,27 +1,25 @@
 PORTNAME=	gnome-mines
-PORTVERSION=	40.1
-PORTREVISION=	2
+PORTVERSION=	48.1
 CATEGORIES=	games gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
-COMMENT=	Gnome minesweeper
-WWW=		https://wiki.gnome.org/Apps/Mines
+COMMENT=	Clear hidden mines from a minefield
+WWW=		https://gitlab.gnome.org/GNOME/gnome-mines
 
-LICENSE=	gpl3
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	itstool:textproc/itstool
-LIB_DEPENDS=	libgnome-games-support-1.so:games/libgnome-games-support \
-		libgee-0.8.so:devel/libgee
+LIB_DEPENDS=	libgnome-games-support-2.so:games/libgnome-games-support2
 
-PORTSCOUT=	limitw:1,even
+USES=		desktop-file-utils gettext gnome localbase meson pkgconfig \
+		tar:xz vala:build
+USE_GNOME=	glib20 gtk40 libadwaita
 
-USES=		gettext gnome localbase meson pkgconfig python:build tar:xz vala:build
-USE_GNOME=	gtk30 librsvg2
-
-BINARY_ALIAS=	python3=${PYTHON_VERSION}
 GLIB_SCHEMAS=	org.gnome.Mines.gschema.xml
+INSTALLS_ICONS=	yes
+PORTSCOUT=	limitw:1,even
 
 .include <bsd.port.mk>

--- a/games/gnome-mines/distinfo
+++ b/games/gnome-mines/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1646339170
-SHA256 (gnome/gnome-mines-40.1.tar.xz) = 3502e9b3f71cb3b2e711c0e6019187febcc2bca877e3d456dcab700f7be31272
-SIZE (gnome/gnome-mines-40.1.tar.xz) = 280768
+TIMESTAMP = 1745515117
+SHA256 (gnome/gnome-mines-48.1.tar.xz) = ef4b2d2dde3bec614157edde4d9189cc6afe692952a2dd55b2870e2e62ed8104
+SIZE (gnome/gnome-mines-48.1.tar.xz) = 331488

--- a/games/gnome-mines/pkg-plist
+++ b/games/gnome-mines/pkg-plist
@@ -1,6 +1,6 @@
 bin/gnome-mines
-share/man/man6/gnome-mines.6.gz
 share/applications/org.gnome.Mines.desktop
+share/dbus-1/services/org.gnome.Mines.service
 %%DATADIR%%/themes/bgcolors/1mines.svg
 %%DATADIR%%/themes/bgcolors/2mines.svg
 %%DATADIR%%/themes/bgcolors/3mines.svg
@@ -268,6 +268,21 @@ share/help/pt_BR/gnome-mines/license.page
 share/help/pt_BR/gnome-mines/new-game.page
 share/help/pt_BR/gnome-mines/rules.page
 share/help/pt_BR/gnome-mines/translate.page
+share/help/ru/gnome-mines/board-size.page
+share/help/ru/gnome-mines/bug-filing.page
+share/help/ru/gnome-mines/develop.page
+share/help/ru/gnome-mines/documentation.page
+share/help/ru/gnome-mines/figures/flag-question.svg
+share/help/ru/gnome-mines/figures/flag.svg
+share/help/ru/gnome-mines/figures/flags.png
+share/help/ru/gnome-mines/figures/org.gnome.Mines.svg
+share/help/ru/gnome-mines/flags.page
+share/help/ru/gnome-mines/high-scores.page
+share/help/ru/gnome-mines/index.page
+share/help/ru/gnome-mines/license.page
+share/help/ru/gnome-mines/new-game.page
+share/help/ru/gnome-mines/rules.page
+share/help/ru/gnome-mines/translate.page
 share/help/sl/gnome-mines/board-size.page
 share/help/sl/gnome-mines/bug-filing.page
 share/help/sl/gnome-mines/develop.page
@@ -315,6 +330,7 @@ share/help/uk/gnome-mines/rules.page
 share/help/uk/gnome-mines/translate.page
 share/icons/hicolor/scalable/apps/org.gnome.Mines.svg
 share/icons/hicolor/symbolic/apps/org.gnome.Mines-symbolic.svg
+share/locale/ab/LC_MESSAGES/gnome-mines.mo
 share/locale/af/LC_MESSAGES/gnome-mines.mo
 share/locale/am/LC_MESSAGES/gnome-mines.mo
 share/locale/an/LC_MESSAGES/gnome-mines.mo
@@ -406,4 +422,5 @@ share/locale/xh/LC_MESSAGES/gnome-mines.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-mines.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-mines.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-mines.mo
-share/metainfo/org.gnome.Mines.appdata.xml
+share/man/man6/gnome-mines.6.gz
+share/metainfo/org.gnome.Mines.metainfo.xml


### PR DESCRIPTION
Updates GNOME Mines to 48.1, switching to the GTK4/libadwaita and libgnome-games-support2 dependency stack.\n\nValidation:\n- bmake clean && bmake package\n- bmake test (2/2)\n- bmake check-license\n- git diff --check\n\nportlint was previously clean; after packaging it reports only the retained local untracked .mport artifact, which is intentionally not committed.

## Summary by Sourcery

Update the GNOME Mines port to the 48.1 release and align its runtime dependencies and packaging with the current GNOME platform.

Enhancements:
- Update GNOME Mines to version 48.1 with its modern GTK4, libadwaita, and libgnome-games-support2 dependency stack.
- Refresh port metadata and packaging for the updated application, including desktop integration and icon installation.