### PR TITLE
textproc/yelp-xsl: update to 42.4

### DIFF
--- a/textproc/yelp-xsl/Makefile
+++ b/textproc/yelp-xsl/Makefile
@@ -1,23 +1,23 @@
 PORTNAME=	yelp-xsl
-DISTVERSION=	42.0
-PORTREVISION=	1
+DISTVERSION=	42.4
 CATEGORIES=	textproc gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	DocBook XSLT stylesheets for yelp
-WWW=		https://www.gnome.org/
+WWW=		https://gitlab.gnome.org/GNOME/yelp-xsl
 
-LICENSE=	lgpl2.1+
-LICENSE_FILE=	${WRKSRC}/COPYING.LGPL
+LICENSE=	gpl2+ lgpl2.1+ mit
+LICENSE_COMB=	multi
 
-BUILD_DEPENDS=	itstool:textproc/itstool
+BUILD_DEPENDS=	itstool:textproc/itstool \
+		bash:shells/bash
 
-PORTSCOUT=	limitw:1,even
-
-USES=		pathfix tar:xz
-GNU_CONFIGURE=	yes
+USES=		gettext gnome localbase meson pkgconfig shebangfix \
+		tar:xz
+USE_GNOME=	libxml2 libxslt
+SHEBANG_FILES=	xslt/common/domains/gen_yelp_xml.sh
 NO_ARCH=	yes
 
 .include <bsd.port.mk>

--- a/textproc/yelp-xsl/distinfo
+++ b/textproc/yelp-xsl/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1656700465
-SHA256 (gnome/yelp-xsl-42.0.tar.xz) = 29b273cc0bd16efb6e983443803f1e9fdc03511e5c4ff6348fd30a604d4dc846
-SIZE (gnome/yelp-xsl-42.0.tar.xz) = 663824
+TIMESTAMP = 1749910659
+SHA256 (gnome/yelp-xsl-42.4.tar.xz) = fdebb07eb2e66a7fb7a0dce6ad8248ad29a4bbb134ba829128ca104f58abd7d1
+SIZE (gnome/yelp-xsl-42.4.tar.xz) = 394536

--- a/textproc/yelp-xsl/files/patch-meson.build
+++ b/textproc/yelp-xsl/files/patch-meson.build
@@ -1,0 +1,5 @@
+--- meson.build.orig	2025-06-12 16:51:49 UTC
++++ meson.build
+@@ -16 +16 @@
+-pkgconfigdir = join_paths(datadir, 'pkgconfig')
++pkgconfigdir = join_paths(prefix, 'libdata', 'pkgconfig')


### PR DESCRIPTION
Updates yelp-xsl from 42.0 to 42.4.

- Switch to the upstream Meson build system and required dependencies
- Install the pkg-config metadata under MidnightBSD libdata
- Correct declared mixed licensing and preserve MidnightBSD maintainer

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (3/3 passed)
- bmake check-license
- portlint -C (0 fatal errors)
- git diff --check

## Summary by Sourcery

Update the yelp-xsl port to 42.4 and align its build, dependency, metadata, and licensing configuration with the upstream release.

Bug Fixes:
- Correct the port’s mixed GPL, LGPL, and MIT license declarations while retaining the MidnightBSD maintainer.

Enhancements:
- Update yelp-xsl to version 42.4 and migrate the port to the upstream Meson build system with its current GNOME dependencies.
- Install pkg-config metadata in the appropriate MidnightBSD libdata location.