### PR TITLE
x11/gnome-console: update to 48.1

### DIFF
--- a/x11/gnome-console/Makefile
+++ b/x11/gnome-console/Makefile
@@ -11,9 +11,10 @@ WWW=		https://apps.gnome.org/Console/
 LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas
-LIB_DEPENDS=	libgtop-2.0.so:devel/libgtop \
+BUILD_DEPENDS= 	gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas
+LIB_DEPENDS= 	libgtop-2.0.so:devel/libgtop \
 		libpcre2-8.so:devel/pcre2
+RUN_DEPENDS= 	gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas
 
 USES=		compiler:c11 desktop-file-utils gettext-tools gnome localbase \
 		meson pkgconfig tar:xz

--- a/x11/gnome-console/Makefile
+++ b/x11/gnome-console/Makefile
@@ -1,33 +1,27 @@
 PORTNAME=	gnome-console
-PORTVERSION=	43.0
-PORTREVISION=	1
+PORTVERSION=	48.1
 CATEGORIES=	x11 gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Minimal terminal for GNOME
-WWW=		https://gitlab.gnome.org/GNOME/console
+WWW=		https://apps.gnome.org/Console/
 
-LICENSE=	gpl2+
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	itstool>0:textproc/itstool \
-		sassc>0:textproc/sassc
-LIB_DEPENDS=	libenchant-2.so:textproc/enchant2 \
-		libgtop-2.0.so:devel/libgtop \
-		libhandy-1.so:x11-toolkits/libhandy \
-		libicudata.so:devel/icu \
-		libpcre2-8.so:devel/pcre2 \
-		libvte-2.91.so:x11-toolkits/vte3
+BUILD_DEPENDS=	gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas
+LIB_DEPENDS=	libgtop-2.0.so:devel/libgtop \
+		libpcre2-8.so:devel/pcre2
 
-USES=		compiler:c11 desktop-file-utils gettext gnome localbase meson \
-		pkgconfig tar:xz
+USES=		compiler:c11 desktop-file-utils gettext-tools gnome localbase \
+		meson pkgconfig tar:xz
 USE_CSTD=	c11
-USE_GNOME=	gtk30 gtksourceview5 libadwaita
-MESON_ARGS=	${${PORTVERSION:R}<44:?-Dwerror=false:}
+USE_GNOME=	glib20 gtk40 libadwaita pango vte3
 GLIB_SCHEMAS=	org.gnome.Console.gschema.xml
+INSTALLS_ICONS=	yes
 
-PORTSCOUT=	limitw:1,even
+PORTSCOUT=	limit:^48
 
 .include <bsd.port.mk>

--- a/x11/gnome-console/distinfo
+++ b/x11/gnome-console/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1674849024
-SHA256 (gnome/gnome-console-43.0.tar.xz) = b9642485a37a70e82cc10553b0e2681756ba361ff5e4cbf3182f150231fea99e
-SIZE (gnome/gnome-console-43.0.tar.xz) = 161916
+TIMESTAMP = 1788966543
+SHA256 (gnome/gnome-console-48.1.tar.xz) = 70d10999fe5f5b1bf4b5583efc4828d8361c7c87e8fbae49d4a4ff9726276bcf
+SIZE (gnome/gnome-console-48.1.tar.xz) = 211012


### PR DESCRIPTION
Updates GNOME Console to 48.1 and corrects the source-declared GPLv3-or-later license metadata.

Validation: `bmake makesum patch build fake package test check-license`; Meson test 1/1 passed; `portlint -C` has no port errors after ignoring the generated local package artifact, and `git diff --check` passed.

## Summary by Sourcery

Update the GNOME Console port to version 48.1 and align its license and dependency metadata with the current release.

Bug Fixes:
- Correct the package license metadata to GPLv3-or-later.

Enhancements:
- Update GNOME Console from 43.0 to 48.1 with refreshed GNOME dependencies and packaging metadata.