### PR TITLE
x11/xdg-desktop-portal-gnome: update to 47.3

### DIFF
--- a/x11/xdg-desktop-portal-gnome/Makefile
+++ b/x11/xdg-desktop-portal-gnome/Makefile
@@ -1,32 +1,40 @@
 PORTNAME=	xdg-desktop-portal-gnome
-DISTVERSION=	43.1
+DISTVERSION=	47.3
 CATEGORIES=	x11 gnome
-MASTER_SITES=	GNOME/sources/${PORTNAME}/${PORTVERSION:C/^([0-9]+)\..*/\1/}
+MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Backend implementation for xdg-desktop-portal for GNOME
 WWW=		https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome
 
-LICENSE=	lgpl2.1
+LICENSE=	gpl2+ lgpl2.1+
+LICENSE_COMB=	multi
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	xdg-desktop-portal>0:deskutils/xdg-desktop-portal \
-		xdg-desktop-portal-gtk>0:x11/xdg-desktop-portal-gtk
+		gsettings-desktop-schemas>0:devel/gsettings-desktop-schemas
 LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
-		libgnome-desktop-4.so:x11/gnome-desktop
-RUN_DEPENDS=	xdg-desktop-portal>0:deskutils/xdg-desktop-portal \
-		xdg-desktop-portal-gtk>0:x11/xdg-desktop-portal-gtk
+		libgraphene-1.0.so:graphics/graphene \
+		libwayland-client.so:graphics/wayland
+RUN_DEPENDS=	xdg-desktop-portal>0:deskutils/xdg-desktop-portal
 
 USES=		gettext-tools gnome meson pkgconfig tar:xz xorg
 
 USE_XORG=	x11
-USE_GNOME=	cairo gdkpixbuf glib20 gtk40 libadwaita
+USE_GNOME=	cairo gdkpixbuf gnomedesktop4 glib20 gtk40 libadwaita
 GLIB_SCHEMAS=	xdg-desktop-portal-gnome.gschema.xml
+
+MESON_ARGS=	-Dsystemd=disabled \
+		-Dsystemduserunitdir=no
 
 PORTDOCS=	NEWS README.md
 
 OPTIONS_DEFINE=	DOCS
+
+post-patch:
+	@${REINPLACE_CMD} -i "" -e 's|SystemdService|#SystemdService|' \
+		${WRKSRC}/data/org.freedesktop.impl.portal.desktop.gnome.service.in
 
 post-install-DOCS-on:
 	${MKDIR} ${FAKE_DESTDIR}${DOCSDIR}

--- a/x11/xdg-desktop-portal-gnome/distinfo
+++ b/x11/xdg-desktop-portal-gnome/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1676978672
-SHA256 (gnome/xdg-desktop-portal-gnome-43.1.tar.xz) = 09adb66c6d9153e6f05df66daa2ad62a5de0e36665e9d2295173bb0ddc53b4cd
-SIZE (gnome/xdg-desktop-portal-gnome-43.1.tar.xz) = 125248
+TIMESTAMP = 1788920537
+SHA256 (gnome/xdg-desktop-portal-gnome-47.3.tar.xz) = 9f6e4b14b583367c915e9494764f27cb84927faa3f9e6e018b93bbbcf3361e44
+SIZE (gnome/xdg-desktop-portal-gnome-47.3.tar.xz) = 163996

--- a/x11/xdg-desktop-portal-gnome/files/patch-data_meson.build
+++ b/x11/xdg-desktop-portal-gnome/files/patch-data_meson.build
@@ -1,17 +1,11 @@
---- data/meson.build.orig	2022-10-18 02:27:08 UTC
+--- data/meson.build.orig	2024-05-25 18:46:09 UTC
 +++ data/meson.build
-@@ -15,14 +15,6 @@ configure_file(
-   install_dir: dbus_service_dir,
+@@ -41,7 +41,7 @@ configure_file(
  )
  
--# systemd unit
--configure_file(
--  input: 'xdg-desktop-portal-gnome.service.in',
--  output: 'xdg-desktop-portal-gnome.service',
--  configuration: libexecdir_conf,
--  install_dir: systemduserunitdir,
--)
--
- # Desktop file
- desktop_in = configure_file(
-   input: 'xdg-desktop-portal-gnome.desktop.in.in',
+ # systemd unit
+-if systemduserunitdir != ''
++if systemduserunitdir != 'no'
+   configure_file(
+     input: 'xdg-desktop-portal-gnome.service.in',
+     output: 'xdg-desktop-portal-gnome.service',

--- a/x11/xdg-desktop-portal-gnome/files/patch-meson.build
+++ b/x11/xdg-desktop-portal-gnome/files/patch-meson.build
@@ -1,24 +1,11 @@
---- meson.build.orig	2022-10-18 02:27:08 UTC
+--- meson.build.orig	2024-05-25 18:46:09 UTC
 +++ meson.build
-@@ -11,15 +11,6 @@ datadir = get_option('datadir')
- libdir = get_option('libdir')
- libexecdir = get_option('libexecdir')
+@@ -13,7 +13,7 @@ systemduserunitdir = get_option('systemduserunitdir')
  
--systemduserunitdir = get_option('systemduserunitdir')
+ build_systemd_service = get_option('systemd')
+ systemduserunitdir = get_option('systemduserunitdir')
 -if systemduserunitdir == ''
--  systemd = dependency('systemd', version: '>= 242')
--  systemduserunitdir = systemd.get_pkgconfig_variable(
--    'systemduserunitdir',
--    define_variable: ['prefix', get_option('prefix')]
--  )
--endif
--
- dbus_service_dir = get_option('dbus_service_dir')
- if dbus_service_dir == ''
-   dbus_service_dir = datadir / 'dbus-1' / 'services'
-@@ -35,5 +26,4 @@ summary({
-   'libdir': libdir,
-   'libexecdir': libexecdir,
-   'dbus_service_dir': dbus_service_dir,
--  'systemduserunitdir': systemduserunitdir,
- })
++if systemduserunitdir != 'no'
+   systemd = dependency('systemd', version: '>= 242', required: build_systemd_service)
+   if build_systemd_service.allowed() and systemd.found()
+     systemduserunitdir = systemd.get_variable(

--- a/x11/xdg-desktop-portal-gnome/files/patch-src_screencastwidget.c
+++ b/x11/xdg-desktop-portal-gnome/files/patch-src_screencastwidget.c
@@ -1,0 +1,11 @@
+--- src/screencastwidget.c.orig	2025-02-17 11:16:56 UTC
++++ src/screencastwidget.c
+@@ -57,7 +57,7 @@ struct _ScreenCastWidget
+   ScreenCastPersistMode  persist_mode;
+
+   DisplayStateTracker   *display_state_tracker;
+-  ulong                  monitors_changed_handler_id;
++  gulong                 monitors_changed_handler_id;
+
+   ShellIntrospect       *shell_introspect;
+   GListModel            *filter_model;

--- a/x11/xdg-desktop-portal-gnome/pkg-plist
+++ b/x11/xdg-desktop-portal-gnome/pkg-plist
@@ -2,6 +2,7 @@ libexec/xdg-desktop-portal-gnome
 share/applications/xdg-desktop-portal-gnome.desktop
 share/dbus-1/services/org.freedesktop.impl.portal.desktop.gnome.service
 share/locale/ab/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/be/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/bg/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/ca/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/cs/LC_MESSAGES/xdg-desktop-portal-gnome.mo
@@ -9,6 +10,7 @@ share/locale/da/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/de/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/el/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/en_GB/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/eo/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/es/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/eu/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/fa/LC_MESSAGES/xdg-desktop-portal-gnome.mo
@@ -17,16 +19,21 @@ share/locale/fr/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/fur/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/gl/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/he/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/hi/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/hr/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/hu/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/id/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/ie/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/is/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/it/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/ja/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/ka/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/kab/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/kk/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/ko/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/lt/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/lv/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/nb/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/ne/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/nl/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/oc/LC_MESSAGES/xdg-desktop-portal-gnome.mo
@@ -40,6 +47,7 @@ share/locale/sk/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/sl/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/sr/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/sv/LC_MESSAGES/xdg-desktop-portal-gnome.mo
+share/locale/th/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/tr/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/uk/LC_MESSAGES/xdg-desktop-portal-gnome.mo
 share/locale/zh_CN/LC_MESSAGES/xdg-desktop-portal-gnome.mo


### PR DESCRIPTION
Updates xdg-desktop-portal-gnome from 43.1 to 47.3.\n\nIncludes current dependencies, systemd-disabled Meson handling for MidnightBSD, updated plist entries, and corrected GPLv2-or-later plus LGPLv2.1-or-later licensing metadata.\n\nValidation: bmake makesum, patch, build, fake, package, test, check-license; portlint -C (warnings only); git diff --check.

## Summary by Sourcery

Update the GNOME xdg-desktop-portal backend to 47.3 and align its MidnightBSD packaging, build configuration, dependencies, and licensing metadata.

Bug Fixes:
- Update the GNOME xdg-desktop-portal backend to version 47.3 with current runtime and build dependencies.
- Add a portability fix for the screencast monitor-change handler type.

Enhancements:
- Adapt the port to the newer Meson build configuration and disable systemd integration for MidnightBSD.
- Refresh package contents and correct the combined GPLv2-or-later and LGPLv2.1-or-later license metadata.