### PR TITLE
graphics/gdk-pixbuf2: update to 2.44.1

### DIFF
--- a/graphics/gdk-pixbuf2/Makefile
+++ b/graphics/gdk-pixbuf2/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gdk-pixbuf
-PORTVERSION=	2.42.12
-PORTREVISION=	1
+PORTVERSION=	2.44.1
 CATEGORIES=	graphics
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	2
@@ -10,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Graphic library for GTK
 WWW=		https://developer.gnome.org/gdk-pixbuf/
 
-LICENSE=	lgpl+
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		cpe gettext gnome localbase:ldflags meson pkgconfig \
@@ -19,11 +18,12 @@ CPE_VENDOR=	gnome
 USE_GNOME=	glib20 introspection:build libxslt:build
 SHEBANG_FILES=	build-aux/*.py
 USE_LDCONFIG=	yes
-MESON_ARGS=	-Dbuiltin_loaders="none" -Dgtk_doc=false -Dinstalled_tests=false -Dtests=false
+MESON_ARGS=	-Dbuiltin_loaders="none" -Dgtk_doc=false -Dinstalled_tests=false \
+		-Dtests=false -Dandroid=disabled -Dglycin=disabled
 TRIGGERS=	gdk-pixbuf-query-loaders
 SUB_LIST=	GTK2_VERSION=${GTK2_VERSION}
 
-LIBVERSION=	0.4200.12
+LIBVERSION=	0.4400.1
 PLIST_SUB+=	LIBVERSION=${LIBVERSION}
 
 OPTIONS_SUB=	yes

--- a/graphics/gdk-pixbuf2/distinfo
+++ b/graphics/gdk-pixbuf2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1740710770
-SHA256 (gnome/gdk-pixbuf-2.42.12.tar.xz) = b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7
-SIZE (gnome/gdk-pixbuf-2.42.12.tar.xz) = 6525072
+TIMESTAMP = 1758197129
+SHA256 (gnome/gdk-pixbuf-2.44.1.tar.xz) = 4eec84cfc55979045b3e0fca72c3cc081d556952ad33b30c7d29c0474db48a28
+SIZE (gnome/gdk-pixbuf-2.44.1.tar.xz) = 6538636

--- a/graphics/gdk-pixbuf2/pkg-plist
+++ b/graphics/gdk-pixbuf2/pkg-plist
@@ -3,7 +3,6 @@ bin/gdk-pixbuf-pixdata
 bin/gdk-pixbuf-query-loaders
 bin/gdk-pixbuf-thumbnailer
 include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-animation.h
-include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-autocleanups.h
 include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-core.h
 include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-enum-types.h
 include/gdk-pixbuf-2.0/gdk-pixbuf/gdk-pixbuf-features.h
@@ -142,4 +141,3 @@ share/thumbnailers/gdk-pixbuf-thumbnailer.thumbnailer
 @postunexec rm %D/lib/gdk-pixbuf-2.0/%%GTK2_VERSION%%/loaders.cache 2>&1 >/dev/null || true
 @dir lib/gdk-pixbuf-2.0/%%GTK2_VERSION%%
 @dir lib/gdk-pixbuf-2.0
-


### PR DESCRIPTION
Update gdk-pixbuf2 to 2.44.1, reset PORTREVISION for the release update, and replace the deprecated generic LGPL metadata with LGPL-2.1-or-later.

The Meson test suite remains disabled because upstream tests can invoke destructive/OOM conditions. Android and glycin backends are explicitly disabled; Android otherwise requires unavailable jnigraphics.

Validation:
- bmake makesum
- bmake check-license
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (NO_TEST=yes)
- portlint -C graphics/gdk-pixbuf2 (0 fatal errors; 2 warnings)
- git diff --check

## Summary by Sourcery

Update gdk-pixbuf2 to 2.44.1 with refreshed package metadata and disabled unsupported backends.

Enhancements:
- Update gdk-pixbuf2 to the 2.44.1 release and align its library version metadata.
- Use the specific LGPL-2.1-or-later license identifier.
- Disable unsupported Android and glycin backends in the Meson configuration.

Chores:
- Refresh package checksums and plist entries for the new release.