### PR TITLE
devel/gobject-introspection: update to 1.86.0

### DIFF
--- a/devel/gobject-introspection/Makefile
+++ b/devel/gobject-introspection/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gobject-introspection
-DISTVERSION=	1.84.0
-PORTREVISION=	2
+DISTVERSION=	1.86.0
 PORTEPOCH=	1
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
@@ -10,8 +9,10 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Generate interface introspection data for GObject libraries
 WWW=		https://gi.readthedocs.io/en/latest/
 
-LICENSE=	gpl2 lgpl
+LICENSE=	gpl2+ lgpl+
 LICENSE_COMB=	multi
+LICENSE_FILE_gpl2+ =	${WRKSRC}/COPYING.GPL
+LICENSE_FILE_lgpl+ =	${WRKSRC}/COPYING.LGPL
 
 LIB_DEPENDS=	libffi.so:devel/libffi
 
@@ -20,8 +21,6 @@ FLAVOR?=	${FLAVORS:[1]}
 
 #PKGCONFIG_BASE=	yes
 
-MAKE_ENV+= LD_LIBRARY_PATH=${LOCALBASE}/glib-bootstrap/lib
-
 default_LIB_DEPENDS=	libglib-2.0.so:devel/glib20
 
 bootstrap_PKGNAMESUFFIX=	-bootstrap
@@ -29,10 +28,9 @@ bootstrap_BUILD_DEPENDS=	${LOCALBASE}/glib-bootstrap/lib/libglib-2.0.so:devel/gl
 bootstrap_RUN_DEPENDS=		${LOCALBASE}/glib-bootstrap/lib/libglib-2.0.so:devel/glib20@bootstrap
 
 #LDFLAGS+= -lc_nonshared
-LDFLAGS+= -L/usr/local/glib-bootstrap/lib -L/usr/local/lib
 
 USES=		bison gettext localbase:ldflags meson pkgconfig python tar:xz
-BINARY_ALIAS=  python3=${PYTHON_CMD}
+BINARY_ALIAS=	python3=${PYTHON_CMD}
 USE_LDCONFIG=	yes
 MESON_ARGS=	-Ddoctool=disabled \
 		-Dpython=${PYTHON_CMD} \
@@ -40,7 +38,7 @@ MESON_ARGS=	-Ddoctool=disabled \
 		-Dglib:dtrace=disabled -Dglib:systemtap=disabled \
 		-Dglib:sysprof=disabled \
 		-Dglib:c_link_args="-lc_nonshared"
-CFLAGS+=	-D__BSD_VISIBLE=1  -L${LOCALBASE}/glib-bootstrap/lib
+CFLAGS+=	-D__BSD_VISIBLE=1
 #-lc_nonshared -I/usr/local/include/python3.11/
 PORTSCOUT=	limitw:1,even
 
@@ -51,8 +49,10 @@ TEST_LIB_DEPENDS=	libcairo.so:graphics/cairo
 NO_TEST=	yes
 
 .if ${FLAVOR:U} == bootstrap
-PKG_CONFIG_PATH=/usr/local/glib-bootstrap/libdata/pkgconfig
-MESON_ARGS+=	-Dcairo=disabled 
+MAKE_ENV+=	LD_LIBRARY_PATH=${LOCALBASE}/glib-bootstrap/lib
+LDFLAGS+=	-L${LOCALBASE}/glib-bootstrap/lib
+PKG_CONFIG_PATH=${LOCALBASE}/glib-bootstrap/libdata/pkgconfig
+MESON_ARGS+=	-Dcairo=disabled
 OPTIONS_DEFINE=
 PREFIX=		${LOCALBASE}/${PORTNAME}-bootstrap
 PLIST_FILES+=	/usr/local/libdata/ldconfig/gobject-introspection-bootstrap

--- a/devel/gobject-introspection/distinfo
+++ b/devel/gobject-introspection/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1743669169
-SHA256 (gnome/gobject-introspection-1.84.0.tar.xz) = 945b57da7ec262e5c266b89e091d14be800cc424277d82a02872b7d794a84779
-SIZE (gnome/gobject-introspection-1.84.0.tar.xz) = 1080316
+TIMESTAMP = 1788971713
+SHA256 (gnome/gobject-introspection-1.86.0.tar.xz) = 920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae
+SIZE (gnome/gobject-introspection-1.86.0.tar.xz) = 1083172


### PR DESCRIPTION
Updates GObject Introspection from 1.84.0 to 1.86.0.\n\n- Reset the stale PORTREVISION for the version increment.\n- Declare the GPLv2-or-later and Library GPLv2-or-later license files with a multi-license combination.\n- Keep GLib bootstrap paths bootstrap-only; the default flavor now scans against the regular GLib ABI.\n\nValidation: bmake makesum, patch, build, fake, package, test, check-license, portlint -C (0 fatal errors), and git diff --check.

## Summary by Sourcery

Update the GObject Introspection port to 1.86.0 while separating bootstrap-only configuration from the default build.

Enhancements:
- Update GObject Introspection to version 1.86.0 and align its licensing metadata with the GPLv2-or-later and LGPLv2-or-later license files.
- Ensure bootstrap-specific GLib paths and dependencies remain confined to the bootstrap flavor while the default flavor uses the regular GLib ABI.