### PR TITLE
games/hitori: update to 44.0

### DIFF
--- a/games/hitori/Makefile
+++ b/games/hitori/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	hitori
-PORTVERSION=	3.38.4
-PORTREVISION=	2
+PORTVERSION=	44.0
 CATEGORIES=	games gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -9,7 +8,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Hitori
 WWW=		https://wiki.gnome.org/Apps/Hitori
 
-LICENSE=	gpl3
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	itstool:textproc/itstool \
@@ -19,7 +18,7 @@ PORTSCOUT=	limitw:1,even
 
 USES=		compiler:c11 gettext gmake gnome localbase meson pathfix \
 		pkgconfig tar:xz
-USE_GNOME=	cairo gtk30 librsvg2 libxml2:build
+USE_GNOME=	cairo glib20 gtk30 librsvg2 libxml2:build
 INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.hitori.gschema.xml

--- a/games/hitori/distinfo
+++ b/games/hitori/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1660070440
-SHA256 (gnome/hitori-3.38.4.tar.xz) = 8993cc91fb923788e389e03ec2aa7876d15c12bad9204cf65b2ffa0ed3922f7d
-SIZE (gnome/hitori-3.38.4.tar.xz) = 238584
+TIMESTAMP = 1788919760
+SHA256 (gnome/hitori-44.0.tar.xz) = 42270bd4f9525d180d3151bd7245335dc5cf248a984e02f68ff930da799e583b
+SIZE (gnome/hitori-44.0.tar.xz) = 248648


### PR DESCRIPTION
Updates Hitori from 3.38.4 to 44.0.

- Removes stale PORTREVISION for the release bump.
- Adds the required GLib dependency.
- Corrects the upstream GPLv3-or-later declaration to gpl3+.

Validated: bmake makesum, patch, build, fake, package, test (3/3), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the Hitori game port to version 44.0 with current dependency and licensing metadata.

Enhancements:
- Update Hitori to the 44.0 release and declare its required GLib dependency.

Chores:
- Correct the package license designation to GPLv3-or-later and remove the obsolete release revision.