### PR TITLE
devel/libsigc++30: update to 3.8.1

### DIFF
--- a/devel/libsigc++30/Makefile
+++ b/devel/libsigc++30/Makefile
@@ -1,15 +1,14 @@
 PORTNAME=	libsigc++
-PORTVERSION=	3.6.0
-PORTREVISION=	1
+DISTVERSION=	3.8.1
 CATEGORIES=	devel
-MASTER_SITES=	GNOME
+MASTER_SITES=	https://github.com/libsigcplusplus/libsigcplusplus/releases/download/${DISTVERSION}/
 PKGNAMESUFFIX=	30
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Callback Framework for C++
 WWW=		https://libsigcplusplus.github.io/libsigcplusplus/index.html
 
-LICENSE=	lgpl2.1+
+LICENSE=	lgpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		compiler:c++17-lang gnome meson pkgconfig python:build tar:xz

--- a/devel/libsigc++30/distinfo
+++ b/devel/libsigc++30/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741618983
-SHA256 (libsigc++-3.6.0.tar.xz) = c3d23b37dfd6e39f2e09f091b77b1541fbfa17c4f0b6bf5c89baef7229080e17
-SIZE (libsigc++-3.6.0.tar.xz) = 991392
+TIMESTAMP = 1788972385
+SHA256 (libsigc++-3.8.1.tar.xz) = 4ff41d1474e501d3baeced4c989d154338206ac16471e614376496b63fe252d1
+SIZE (libsigc++-3.8.1.tar.xz) = 996324


### PR DESCRIPTION
Updates libsigc++30 from 3.6.0 to 3.8.1.

- Removes the stale PORTREVISION for the release bump.
- Uses the current upstream release source.
- Corrects the license declaration to LGPL-3.0-or-later (`lgpl3+`).

Validated: bmake makesum, patch, build, fake, package, test (42/42), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the libsigc++30 port to the 3.8.1 upstream release and align its package metadata.

Enhancements:
- Update libsigc++30 to upstream version 3.8.1 and use its current release source.
- Correct the package license declaration to LGPL-3.0-or-later.

Chores:
- Remove the obsolete PORTREVISION entry.