### PR TITLE
devel/xdg-user-dirs: update to 0.20

### DIFF
--- a/devel/xdg-user-dirs/Makefile
+++ b/devel/xdg-user-dirs/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	xdg-user-dirs
-DISTVERSION=	0.19
-PORTREVISION=	2
+DISTVERSION=	0.20
 CATEGORIES=	devel
 MASTER_SITES=	https://user-dirs.freedesktop.org/releases/
 
@@ -10,7 +9,7 @@ WWW=		https://freedesktop.org/wiki/Software/xdg-user-dirs/
 
 LICENSE=	gpl2+ mit
 LICENSE_COMB=	multi
-LICENSE_FILE_gpl2+=	${WRKSRC}/COPYING
+LICENSE_FILE_gpl2+ =	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	${LOCALBASE}/share/xsl/docbook/html/docbook.xsl:textproc/docbook-xsl
 

--- a/devel/xdg-user-dirs/distinfo
+++ b/devel/xdg-user-dirs/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1759052738
-SHA256 (xdg-user-dirs-0.19.tar.xz) = e92deb929c10d4b29329397af8a2585101247f7e6177ac6f1d28e82130ed8c19
-SIZE (xdg-user-dirs-0.19.tar.xz) = 71732
+TIMESTAMP = 1788972589
+SHA256 (xdg-user-dirs-0.20.tar.xz) = b8e34286278f4fef3e1bfe9685c395ccc0eb50c14d3a2fb4953dd00fbfd3af39
+SIZE (xdg-user-dirs-0.20.tar.xz) = 53784


### PR DESCRIPTION
Updates xdg-user-dirs from 0.19 to 0.20.

- Removes stale PORTREVISION for the release bump.
- Retains MidnightBSD configuration-path patching.
- Retains the existing GPLv2+/MIT multi-license declaration and corrects per-license variable spacing.
- The upstream systemd service remains deliberately commented in the plist and is not packaged.

Validated: bmake makesum, patch, build, fake, package, test (no tests defined), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the xdg-user-dirs port to the 0.20 release.

Enhancements:
- Update the xdg-user-dirs port to version 0.20 while preserving its existing configuration-path handling and licensing metadata.

Chores:
- Remove the obsolete release-specific PORTREVISION.