### PR TITLE
devel/glibmm26: update to 2.86.0

### DIFF
--- a/devel/glibmm26/Makefile
+++ b/devel/glibmm26/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	glibmm
-PORTVERSION=	2.80.1
+PORTVERSION=	2.86.0
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	26
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	C++ interfaces for glib2
 WWW=		https://www.gtkmm.org/
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 
 USES=		compiler:c++11-lang gettext gnome meson pathfix perl5 \
 		pkgconfig python:build shebangfix tar:xz
@@ -22,7 +22,5 @@ MESON_ARGS=	-Dbuild-documentation=false
 
 PORTSCOUT=	limitw:1,even
 PLIST_SUB=	VERSION=2.68
-
-NO_TEST=	yes
 
 .include <bsd.port.mk>

--- a/devel/glibmm26/distinfo
+++ b/devel/glibmm26/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1729876339
-SHA256 (gnome/glibmm-2.80.1.tar.xz) = f1a0c0ec514e3774bf993396f17f72106b40912c7d7cc9d10da31ba15517e3f5
-SIZE (gnome/glibmm-2.80.1.tar.xz) = 9560436
+TIMESTAMP = 1788972690
+SHA256 (gnome/glibmm-2.86.0.tar.xz) = 39c0e9f6da046d679390774efdb9ad564436236736dc2f7825e614b2d4087826
+SIZE (gnome/glibmm-2.86.0.tar.xz) = 9519556


### PR DESCRIPTION
Updates glibmm26 from 2.80.1 to 2.86.0.

- Re-enables the upstream test suite by removing stale NO_TEST.
- Corrects the source-declared LGPL-2.1-or-later license to `lgpl2.1+`.
- ABI remains on the libglibmm-2.68.so.1/libgiomm-2.68.so.1 line, so dependent revisions are unchanged.

Validated: bmake makesum, patch, build, fake, package, test (36 pass, 2 expected compile-failure cases), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update glibmm26 to version 2.86.0 and align its licensing and test configuration with the new release.

Enhancements:
- Update the glibmm26 port to the 2.86.0 release while retaining the existing ABI package line.
- Correct the port’s LGPL license expression to reflect the upstream declaration.
- Re-enable the upstream test suite for the port.