### PR TITLE
devel/py-pygobject: update to 3.58.0

### DIFF
--- a/devel/py-pygobject/Makefile
+++ b/devel/py-pygobject/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	pygobject
-DISTVERSION=	3.50.2
-PORTREVISION?=	1
+DISTVERSION=	3.58.0
 CATEGORIES=	devel python
 MASTER_SITES=	GNOME
 PKGNAMEPREFIX?=	${PYTHON_PKGNAMEPREFIX}
@@ -33,6 +32,8 @@ do-install:
 	@${MKDIR} ${PREFIX}/include/pygobject-3.0
 	${INSTALL_DATA} ${WRKSRC}/gi/pygobject.h \
 		${PREFIX}/include/pygobject-3.0/pygobject.h
+	${INSTALL_DATA} ${WRKSRC}/gi/pygobject-types.h \
+		${PREFIX}/include/pygobject-3.0/pygobject-types.h
 .else
 BUILD_DEPENDS+=	${PYTHON_PKGNAMEPREFIX}meson-python>=0.12.1:devel/meson-python@${PY_FLAVOR}
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}cairo>=1.16:graphics/py-cairo@${PY_FLAVOR} \

--- a/devel/py-pygobject/distinfo
+++ b/devel/py-pygobject/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1761489022
-SHA256 (gnome/pygobject-3.50.2.tar.gz) = ece6b860aab77cb649fdfc6e88d8a83765e7a62f7ffd39a628d6e2a0d397a7ff
-SIZE (gnome/pygobject-3.50.2.tar.gz) = 1085854
+TIMESTAMP = 1788973154
+SHA256 (gnome/pygobject-3.58.0.tar.gz) = 45068697de3ffe46840ca369705f23118b34db4f7deb63f6eff079a6734ddcca
+SIZE (gnome/pygobject-3.58.0.tar.gz) = 1408568

--- a/devel/pygobject-common/Makefile
+++ b/devel/pygobject-common/Makefile
@@ -6,6 +6,7 @@ COMMENT=	Common files for Python bindings for GObject Introspection
 NO_BUILD=	yes
 NO_ARCH=	yes
 PLIST_FILES=	include/pygobject-3.0/pygobject.h \
+		include/pygobject-3.0/pygobject-types.h \
 		libdata/pkgconfig/pygobject-3.0.pc
 
 SLAVE_PORT=	common


### PR DESCRIPTION
Updates PyGObject from 3.50.2 to 3.58.0, including the paired `pygobject-common` header ownership update.

- Removes the stale conditional PORTREVISION for the release bump.
- Adds the newly shipped `pygobject-types.h` to the common package.
- Keeps MidnightBSD py-cairo dependency naming and source-verified LGPL 2.1 metadata.

Validated: bmake makesum, patch, build, fake, package for both py312-pygobject and pygobject-common, check-license, portlint -C for the master port (0 fatal), and git diff --check. The existing port has no enabled upstream test target; optional upstream test wiring excludes known potentially nonterminating tests and was deliberately not added.

## Summary by Sourcery

Update the PyGObject ports to 3.58.0 and include the newly shipped common header.

Enhancements:
- Update PyGObject and its common package to version 3.58.0.
- Install and package the newly provided PyGObject type declarations.