### PR TITLE
devel/py-python-dbusmock: update to 0.38.1

### DIFF
--- a/devel/py-python-dbusmock/Makefile
+++ b/devel/py-python-dbusmock/Makefile
@@ -1,22 +1,39 @@
 PORTNAME=	python-dbusmock
-PORTVERSION=	0.22.0
-PORTREVISION=	1
+DISTVERSION=	0.38.1
 CATEGORIES=	devel python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+DISTNAME=	${PORTNAME:S/-/_/}-${DISTVERSION}
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Mock D-Bus objects for tests
+WWW=		https://pypi.org/project/python-dbusmock
 
-LICENSE=	lgpl3
+LICENSE=	lgpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+BUILD_DEPENDS=	${PY_SETUPTOOLS} \
+		${PYTHON_PKGNAMEPREFIX}setuptools-scm>0:devel/py-setuptools-scm@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}wheel>0:devel/py-wheel@${PY_FLAVOR}
 RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}dbus>0:devel/py-dbus@${PY_FLAVOR}
 
 USES=		gnome python
 USE_GNOME=	pygobject3
-USE_PYTHON=	autoplist distutils
+USE_PYTHON=	autoplist pep517 unittest
 
+BINARY_ALIAS=	python3=${PYTHON_CMD}
 NO_ARCH=	yes
+
+PORTDOCS=	README.md
+
+OPTIONS_DEFINE=	DOCS
+
+post-patch:
+	@${REINPLACE_CMD} -e 's|/usr/bin/python3|${PYTHON_CMD}|' \
+		${WRKSRC}/tests/test_api.py
+
+post-install-DOCS-on:
+	@${MKDIR} ${FAKE_DESTDIR}${DOCSDIR}
+	${INSTALL_DATA} ${PORTDOCS:S|^|${WRKSRC}/|} ${FAKE_DESTDIR}${DOCSDIR}
 
 .include <bsd.port.mk>

--- a/devel/py-python-dbusmock/distinfo
+++ b/devel/py-python-dbusmock/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1619644986
-SHA256 (python-dbusmock-0.22.0.tar.gz) = 2191919cc411fb94953b36e46bfd55ee5ad4162432ee0d0892bc2c4770ff5d7c
-SIZE (python-dbusmock-0.22.0.tar.gz) = 68626
+TIMESTAMP = 1788973350
+SHA256 (python_dbusmock-0.38.1.tar.gz) = 221b65e1c2e48de9fd11bf7e8c165adaf91648f49a11f390d086a498386f2984
+SIZE (python_dbusmock-0.38.1.tar.gz) = 108144

--- a/devel/py-python-dbusmock/pkg-descr
+++ b/devel/py-python-dbusmock/pkg-descr
@@ -3,5 +3,3 @@ D-Bus. This is useful for writing tests for software which talks to
 D-Bus services such as upower, systemd, logind, gnome-session or
 others, and it is hard (or impossible without root privileges) to set
 the state of the real services to what you expect in your tests.
-
-WWW: https://pypi.org/project/python-dbusmock


### PR DESCRIPTION
Updates python-dbusmock from 0.22.0 to 0.38.1.

- Migrates the package to PEP 517 with its upstream build requirements.
- Corrects source-declared LGPLv3-or-later metadata to `lgpl3+`.
- Restores upstream unittest coverage and fixes its test-only hard-coded `/usr/bin/python3` service activation path to use the selected Python interpreter.
- Adds optional README documentation and moves WWW to the Makefile.

Validated: bmake makesum, patch, build, fake, clean package, test (166 run, 74 upstream skips), check-license, portlint -C (0 fatal), and git diff --check.

## Summary by Sourcery

Update the python-dbusmock port to 0.38.1 and align its packaging, metadata, documentation, and test configuration with the newer upstream release.

New Features:
- Update python-dbusmock to version 0.38.1 with optional README documentation packaging.

Bug Fixes:
- Use the selected Python interpreter for test service activation instead of a hard-coded system path.

Enhancements:
- Migrate the port to PEP 517 packaging and restore upstream unittest coverage.
- Correct the package license metadata to LGPLv3-or-later.

Tests:
- Enable the upstream unittest suite for the port.