### PR TITLE
devel/gobject-introspection: export bootstrap pkg-config path

### DIFF
--- a/devel/gobject-introspection/Makefile
+++ b/devel/gobject-introspection/Makefile
@@ -51,7 +51,7 @@ NO_TEST=	yes
 .if ${FLAVOR:U} == bootstrap
 MAKE_ENV+=	LD_LIBRARY_PATH=${LOCALBASE}/glib-bootstrap/lib
 LDFLAGS+=	-L${LOCALBASE}/glib-bootstrap/lib
-PKG_CONFIG_PATH=${LOCALBASE}/glib-bootstrap/libdata/pkgconfig
+PKGCONFIG_PATHS+=	${LOCALBASE}/glib-bootstrap/libdata/pkgconfig
 MESON_ARGS+=	-Dcairo=disabled
 OPTIONS_DEFINE=
 PREFIX=		${LOCALBASE}/${PORTNAME}-bootstrap


### PR DESCRIPTION
Follow-up for #993.

Use the mports PKGCONFIG_PATHS mechanism so the bootstrap GLib pkg-config directory is exported to both configure and build environments.

Validated: bootstrap patch/build/fake/package/test, bootstrap check-license, portlint -C with 0 fatals (8 existing advisories), and git diff --check.

## Summary by Sourcery

Bug Fixes:
- Ensure the bootstrap GLib pkg-config directory is exported to both configure and build environments.