### PR TITLE
audio/pavucontrol: update to 6.1

### DIFF
--- a/audio/pavucontrol/Makefile
+++ b/audio/pavucontrol/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	pavucontrol
-PORTVERSION=	5.0
-PORTREVISION=	4
+PORTVERSION=	6.1
 CATEGORIES=	audio
 MASTER_SITES=	http://freedesktop.org/software/pulseaudio/${PORTNAME}/
 
@@ -11,23 +10,12 @@ WWW=		https://freedesktop.org/software/pulseaudio/pavucontrol/
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-LIB_DEPENDS=	libcanberra-gtk3.so:audio/libcanberra-gtk3 \
-		libjson-glib-1.0.so:devel/json-glib \
+LIB_DEPENDS=	libjson-glib-1.0.so:devel/json-glib \
 		libpulse.so:audio/pulseaudio
 
-USES=		compiler:c++11-lang gettext gmake gnome pkgconfig tar:xz
-USE_GNOME=	glibmm gtkmm30 intltool libsigc++20
-USE_CXXSTD=	c++11
+USES=		gettext gnome meson pkgconfig tar:xz
+USE_GNOME=	gtkmm40 intltool
 
-GNU_CONFIGURE=	yes
-CFLAGS+=	-I${LOCALBASE}/include
-LDFLAGS+=	-L${LOCALBASE}/lib
-
-CONFIGURE_ARGS=	--disable-lynx
-
-post-patch:
-# Install locales files in right place
-	${REINPLACE_CMD} -e 's|[$$][(]DATADIRNAME[)]|share|' \
-		${WRKSRC}/po/Makefile.in.in
+MESON_ARGS=	-Dlynx=false
 
 .include <bsd.port.mk>

--- a/audio/pavucontrol/distinfo
+++ b/audio/pavucontrol/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1629161871
-SHA256 (pavucontrol-5.0.tar.xz) = ce2b72c3b5f1a70ad0df19dd81750f9455bd20870d1d3a36d20536af2e8f4e7a
-SIZE (pavucontrol-5.0.tar.xz) = 194248
+TIMESTAMP = 1754808572
+SHA256 (pavucontrol-6.1.tar.xz) = 0dce61c1088eafa04c270e1fb79eb7aff47e98567f7d28c65a7bee6cd24e415d
+SIZE (pavucontrol-6.1.tar.xz) = 169488

--- a/audio/pavucontrol/pkg-plist
+++ b/audio/pavucontrol/pkg-plist
@@ -1,5 +1,5 @@
 bin/pavucontrol
-share/applications/pavucontrol.desktop
+share/applications/org.pulseaudio.pavucontrol.desktop
 %%DOCSDIR%%/README.html
 %%DOCSDIR%%/style.css
 share/locale/as/LC_MESSAGES/pavucontrol.mo
@@ -22,6 +22,7 @@ share/locale/he/LC_MESSAGES/pavucontrol.mo
 share/locale/hi/LC_MESSAGES/pavucontrol.mo
 share/locale/hr/LC_MESSAGES/pavucontrol.mo
 share/locale/hu/LC_MESSAGES/pavucontrol.mo
+share/locale/id/LC_MESSAGES/pavucontrol.mo
 share/locale/it/LC_MESSAGES/pavucontrol.mo
 share/locale/ja/LC_MESSAGES/pavucontrol.mo
 share/locale/kk/LC_MESSAGES/pavucontrol.mo
@@ -38,6 +39,7 @@ share/locale/pa/LC_MESSAGES/pavucontrol.mo
 share/locale/pl/LC_MESSAGES/pavucontrol.mo
 share/locale/pt/LC_MESSAGES/pavucontrol.mo
 share/locale/pt_BR/LC_MESSAGES/pavucontrol.mo
+share/locale/ro/LC_MESSAGES/pavucontrol.mo
 share/locale/ru/LC_MESSAGES/pavucontrol.mo
 share/locale/si/LC_MESSAGES/pavucontrol.mo
 share/locale/sk/LC_MESSAGES/pavucontrol.mo
@@ -52,4 +54,4 @@ share/locale/tr/LC_MESSAGES/pavucontrol.mo
 share/locale/uk/LC_MESSAGES/pavucontrol.mo
 share/locale/zh_CN/LC_MESSAGES/pavucontrol.mo
 share/locale/zh_TW/LC_MESSAGES/pavucontrol.mo
-%%DATADIR%%/pavucontrol.glade
+share/metainfo/org.pulseaudio.pavucontrol.metainfo.xml


### PR DESCRIPTION
Update Pavucontrol to 6.1 and migrate the port from Autotools/GTKmm 3 to Meson/GTKmm 4. The existing GPLv2 declaration remains accurate: the release LICENSE is GPL version 2.

Validation: `bmake makesum patch build fake package test check-license`; `portlint -C` (0 fatals); `git diff --check`.

## Summary by Sourcery

Update the Pavucontrol port to 6.1 and modernize its build and GUI toolkit integration.

Enhancements:
- Update Pavucontrol to version 6.1 and migrate the port to Meson with GTKmm 4.

Build:
- Replace the Autotools-based build configuration with Meson and update the port dependencies for the new GTKmm stack.

Chores:
- Refresh distinfo and package plist entries for the new release.