### PR TITLE
devel/libsigc++20: update to 2.12.2

### DIFF
--- a/devel/libsigc++20/Makefile
+++ b/devel/libsigc++20/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	libsigc++
-DISTVERSION=	2.12.1
+DISTVERSION=	2.12.2
 CATEGORIES=	devel
 MASTER_SITES=	GNOME \
 		https://github.com/libsigcplusplus/libsigcplusplus/releases/download/${DISTVERSION}/
@@ -8,7 +8,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Callback Framework for C++
 WWW=		https://github.com/libsigcplusplus/libsigcplusplus
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 PORTSCOUT=	limit:^2\.12\.

--- a/devel/libsigc++20/distinfo
+++ b/devel/libsigc++20/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1720347977
-SHA256 (libsigc++-2.12.1.tar.xz) = a9dbee323351d109b7aee074a9cb89ca3e7bcf8ad8edef1851f4cf359bd50843
-SIZE (libsigc++-2.12.1.tar.xz) = 5041732
+TIMESTAMP = 1788977873
+SHA256 (libsigc++-2.12.2.tar.xz) = 7d4cdf1e4332ebfee8085ad960075045e7763cb291b3ccf4744d7cbf08a22b75
+SIZE (libsigc++-2.12.2.tar.xz) = 5316284


### PR DESCRIPTION
Update libsigc++ 2.0 to 2.12.2. The release COPYING explicitly permits LGPL 2.1 or any later version, so declare the accurate MidnightBSD `lgpl2.1+` identifier.

Validation: `bmake makesum patch build fake package test check-license`; 32/32 Meson tests passed; `portlint -C` (0 fatals); `git diff --check`.

## Summary by Sourcery

Enhancements:
- Update the libsigc++20 port to release 2.12.2 and declare its LGPL 2.1-or-later licensing accurately.