### PR TITLE
games/gnome-games: update to 47

### DIFF
--- a/games/gnome-games/Makefile
+++ b/games/gnome-games/Makefile
@@ -1,42 +1,25 @@
 PORTNAME=	gnome-games
-PORTVERSION=	3.24.0
-PORTREVISION=	2
+PORTVERSION=	47
 CATEGORIES=	games gnome
-MASTER_SITES=   # empty
-DISTFILES=      # empty
-EXTRACT_ONLY=   # empty
 
 MAINTAINER=	ports@MidnightBSD.org
-COMMENT=	Gnome games meta port
+COMMENT=	Curated GNOME games meta port
 
 LICENSE=	agg
 
-NO_BUILD=	yes
-NO_MTREE=       yes
+USES=		metaport
 
 RUN_DEPENDS=	five-or-more:games/five-or-more \
 		atomix:games/atomix \
-		four-in-a-row:games/four-in-a-row \
 		gnome-2048:games/gnome-2048 \
 		gnome-chess:games/gnome-chess \
-		gnome-klotski:games/gnome-klotski \
 		gnome-mahjongg:games/gnome-mahjongg \
 		gnome-mines:games/gnome-mines \
 		gnome-nibbles:games/gnome-nibbles \
 		gnome-robots:games/gnome-robots \
 		gnome-sudoku:games/gnome-sudoku \
-		gnome-tetravex:games/gnome-tetravex \
-		hitori:games/hitori \
 		lightsoff:games/lightsoff \
-		quadrapassel:games/quadrapassel \
-		swell-foop:games/swell-foop \
-		tali:games/tali
-
-.if ${ARCH} == amd64
-RUN_DEPENDS+=	aisleriot>=0:games/aisleriot
-.endif
-
-do-install:
-	${MKDIR} ${WRKSRC}
+		aisleriot>=0:games/aisleriot \
+		swell-foop:games/swell-foop
 
 .include <bsd.port.mk>

--- a/games/gnome-games/Makefile
+++ b/games/gnome-games/Makefile
@@ -19,7 +19,10 @@ RUN_DEPENDS=	five-or-more:games/five-or-more \
 		gnome-robots:games/gnome-robots \
 		gnome-sudoku:games/gnome-sudoku \
 		lightsoff:games/lightsoff \
-		aisleriot>=0:games/aisleriot \
 		swell-foop:games/swell-foop
+
+.if ${ARCH:Uunknown} == amd64
+RUN_DEPENDS+=	aisleriot>=0:games/aisleriot
+.endif
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Update the GNOME Games metaport to the current GNOME 47 curated set. The metaport now uses the standard `metaport` extension and follows the current FreeBSD dependency set.

Validation: `bmake -DNO_DEPENDS package test check-license`; `portlint -C` (0 fatals); `git diff --check`.

## Summary by Sourcery

Update the GNOME Games metaport to the GNOME 47 curated game set.

Enhancements:
- Update the GNOME Games metaport to version 47 and align its curated game dependencies with the current FreeBSD set.
- Adopt the standard metaport framework and simplify the port definition.