### PR TITLE
x11/gnome: update to 47

### DIFF
--- a/x11/gnome/Makefile
+++ b/x11/gnome/Makefile
@@ -1,83 +1,56 @@
 PORTNAME=	gnome
-PORTVERSION=	3.36
-PORTREVISION=	4
+PORTVERSION=	47
 CATEGORIES?=	x11 gnome
-MASTER_SITES=	# empty
-DISTFILES=	# empty
-EXTRACT_ONLY=	# empty
 
 MAINTAINER=	ports@MidnightBSD.org
-COMMENT?=	"meta-port" for the GNOME integrated X11 desktop
+COMMENT=	Metaport for the GNOME desktop
+WWW=		https://www.gnome.org/
 
 FLAVORS=	full lite
 FLAVOR?=	full
 
-RUN_DEPENDS?=	dconf-editor:devel/dconf-editor \
-		gdm>=3.0.0:x11/gdm \
-		gnome-session>=3.0.0:x11/gnome-session \
-		gnome-themes-extra>=3.28:x11-themes/gnome-themes-extra \
-		gnome-icon-theme-extras>=3.0.0:misc/gnome-icon-theme-extras \
-		gnome-icon-theme-symbolic>=3.0.0:x11-themes/gnome-icon-theme-symbolic \
-		gnome-keyring>=3.0.0:security/gnome-keyring \
-		gnome-power-manager>=3.0.0:sysutils/gnome-power-manager \
-		orca>=3.0.0:accessibility/orca \
-		gnome-shell>=3.0.0:x11/gnome-shell \
-		gnome-shell-extensions>=3.0.0:x11/gnome-shell-extensions \
-		gnome-tweaks:deskutils/gnome-tweaks \
-		sushi>=0:x11-fm/sushi \
-		nautilus>=3.0.0:x11-fm/nautilus \
-		${LOCALBASE}/share/fonts/bitstream-vera/Vera.ttf:x11-fonts/bitstream-vera \
-		yelp>=3.0.0:x11/yelp \
-		zenity>=3.0.0:x11/zenity \
-		seahorse>=3.0.0:security/seahorse \
-		gnome-control-center>=3.0.0:sysutils/gnome-control-center \
-		gnome-backgrounds>=0:x11-themes/gnome-backgrounds \
-		caribou>=0:accessibility/caribou \
-		${LOCALBASE}/share/sounds/freedesktop/index.theme:audio/freedesktop-sound-theme
-
-OPTIONS_DEFINE=	DOCS
+RUN_DEPENDS=	gdm>0:x11/gdm \
+		gnome-shell>=47.0:x11/gnome-shell \
+		xdg-desktop-portal-gnome>=47.0:x11/xdg-desktop-portal-gnome \
+		xdg-user-dirs-gtk>0:x11/xdg-user-dirs-gtk \
+		gnome-keyring>0:security/gnome-keyring \
+		orca>0:accessibility/orca \
+		sushi>0:x11-fm/sushi \
+		nautilus>0:x11-fm/nautilus \
+		gnome-console>0:x11/gnome-console \
+		zenity>0:x11/zenity \
+		adwaita-icon-theme>0:x11-themes/adwaita-icon-theme \
+		cantarell-fonts>0:x11-fonts/cantarell-fonts \
+		source-code-pro-ttf>0:x11-fonts/source-code-pro-ttf
 
 USES=		metaport
 
-.if ${FLAVOR} ==lite
-OPTIONS_EXCLUDE=	DOCS
+.if ${FLAVOR} == lite
 PKGNAMESUFFIX=	-lite
 COMMENT=	The "meta-port" of the GNOME desktop slimmed down for only the basics
-PKGMESSAGE=	${.CURDIR}/pkg-message-lite
 DESCR=		${.CURDIR}/pkg-descr-lite
 .endif
 
 .if ${FLAVOR} == "full"
-RUN_DEPENDS+=	epiphany>=3.0.0:www/epiphany \
-		gucharmap>=3.0.0:deskutils/gucharmap \
-		gnome-characters>=3.0.0:deskutils/gnome-characters \
-		gnome-calendar>=3.0:deskutils/gnome-calendar \
-		eog>=3.0.0:graphics/eog \
-		eog-plugins>=3.0.0:graphics/eog-plugins \
-		gedit>=3.0.0:editors/gedit \
-		gedit-plugins>=3.0.0:editors/gedit-plugins \
-		gnome-terminal>=3.0.0:x11/gnome-terminal \
-		brasero>=3.0.0:sysutils/brasero \
-		accerciser>=3.0.0:accessibility/accerciser \
-		gnome-calculator>=3.0.0:math/gnome-calculator \
-		gnome-utils>=3.6.0:deskutils/gnome-utils \
-		file-roller>=3.0.0:archivers/file-roller \
-		evince>=3.0.0:graphics/evince \
-		vino>=3.0.0:net/vino \
-		vinagre>=3.0.0:net/vinagre \
-		gnome-games>=3.0.0:games/gnome-games \
-		totem>=3.0.0:multimedia/totem \
-		gconf-editor>=3.0.0:sysutils/gconf-editor \
-		gnome-color-manager>=0:graphics/gnome-color-manager \
-		evolution>=3.0.0:mail/evolution \
-		cheese>=3.0.0:multimedia/cheese
-
-.endif # !gnome3-lite section
-
-DOCS_RUN_DEPENDS=	gnome-user-docs>=0:misc/gnome-user-docs \
-			gnome-getting-started-docs>=0:misc/gnome-getting-started-docs
-
-do-install:   # empty
-
+RUN_DEPENDS+=	epiphany>0:www/epiphany \
+		gucharmap>0:deskutils/gucharmap \
+		gnome-characters>0:deskutils/gnome-characters \
+		gnome-calendar>0:deskutils/gnome-calendar \
+		gnome-clocks>0:deskutils/gnome-clocks \
+		gnome-font-viewer>0:deskutils/gnome-font-viewer \
+		gnome-maps>0:deskutils/gnome-maps \
+		gnome-weather>0:deskutils/gnome-weather \
+		gnome-tweaks>0:deskutils/gnome-tweaks \
+		eog>0:graphics/eog \
+		gnome-text-editor>0:editors/gnome-text-editor \
+		gnome-calculator>0:math/gnome-calculator \
+		file-roller>0:archivers/file-roller \
+		gnome-user-docs>0:misc/gnome-user-docs \
+		yelp>0:x11/yelp \
+		totem>0:multimedia/totem \
+		evolution>0:mail/evolution \
+		geary>0:mail/geary \
+		gnome-shell-extensions>0:x11/gnome-shell-extensions
+.endif
 
 .include <bsd.port.mk>

--- a/x11/gnome/Makefile
+++ b/x11/gnome/Makefile
@@ -29,6 +29,7 @@ USES=		metaport
 PKGNAMESUFFIX=	-lite
 COMMENT=	The "meta-port" of the GNOME desktop slimmed down for only the basics
 DESCR=		${.CURDIR}/pkg-descr-lite
+PKGMESSAGE=	${.CURDIR}/pkg-message-lite
 .endif
 
 .if ${FLAVOR} == "full"

--- a/x11/gnome/pkg-descr
+++ b/x11/gnome/pkg-descr
@@ -1,4 +1,2 @@
-GNU Network Object Model Environment
-
-This metaport installs the entire GNOME 3 desktop, including
-the user applications released with it.
+This metaport installs the complete GNOME desktop, including the user
+applications released with it.

--- a/x11/gnome/pkg-descr-lite
+++ b/x11/gnome/pkg-descr-lite
@@ -1,5 +1,3 @@
-GNU Network Object Model Environment
-
-This metaport installs the pieces of the GNOME 3 desktop that
-are needed to provide a functional desktop. The x11/gnome3
-meta port, contains the full version of the GNOME 3 desktop environment.
+This metaport installs the GNOME desktop components needed to provide a
+functional desktop. The x11/gnome metaport contains the complete GNOME desktop
+environment.

--- a/x11/gnome/pkg-message
+++ b/x11/gnome/pkg-message
@@ -1,7 +1,7 @@
 [
 { type: install
   message: <<EOM
-Congratulations!  GNOME 3 has been successfully installed on your system.
+Congratulations!  GNOME has been successfully installed on your system.
 EOM
 }
 ]

--- a/x11/gnome/pkg-message-lite
+++ b/x11/gnome/pkg-message-lite
@@ -1,16 +1,16 @@
 [
 { type: install
   message: <<EOM
-The GNOME 3 desktop Lite edition has been successfully installed.
+The GNOME desktop Lite edition has been successfully installed.
 
-The Lite edition only includes the minimal components to get a working GNOME 3
-Desktop. The user then has to install prefered applications like editor,
+The Lite edition only includes the minimal components for a working GNOME
+desktop. The user can then install preferred applications such as an editor,
 web browser or e-mail client. If you wish to install the full desktop, you can
-remove this port, and install the x11/gnome3 port or package.  That can be best
+remove this port and install the x11/gnome port or package. That can be
 accomplished using the following commands:
 
-# mport delete gnome3-lite
-# cd /usr/mports/x11/gnome3
+# mport delete gnome-lite
+# cd /usr/mports/x11/gnome
 # make install clean
 
 Alternatively, you can install additional GNOME components individually


### PR DESCRIPTION
Update the GNOME desktop metaport to the GNOME 47 curated full and lite dependency sets, replacing discontinued GNOME 3-era components with current applications and desktop integration.

Validation: `bmake -DNO_DEPENDS package test` for full and lite; `check-license`; `portlint -C` (0 fatals); `git diff --check`.

## Summary by Sourcery

Update the GNOME metaport to provide curated GNOME 47 full and lite desktop environments.

New Features:
- Update the full and lite GNOME metaport dependency sets to the GNOME 47 desktop applications and integration components.

Enhancements:
- Replace obsolete GNOME 3-era dependencies with current desktop applications, themes, fonts, and portal support while retaining distinct full and lite flavors.

Documentation:
- Refresh the GNOME metaport descriptions and installation messages for the updated desktop dependency sets.