### PR TITLE
audio/sonata: update to 1.7.3

### DIFF
--- a/audio/sonata/Makefile
+++ b/audio/sonata/Makefile
@@ -7,6 +7,7 @@ PKGNAMEPREFIX=		${PYTHON_PKGNAMEPREFIX}
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Elegant music player for MPD
+WWW=		https://github.com/multani/sonata
 
 LICENSE=	gpl3
 
@@ -32,7 +33,7 @@ MPD_DESC=	Install Music Player Daemon
 OPTIONS_SUB=	yes
 
 MPD_RUN_DEPENDS+=	musicpd:audio/musicpd
-MMKEYS_RUN_DEPENDS=${PYTHON_PKGNAMEPREFIX}dbus>=0.82.4:devel/py-dbus@${FLAVOR}
+MMKEYS_RUN_DEPENDS=${PYTHON_PKGNAMEPREFIX}dbus>=0.82.4:devel/py-dbus@${PY_FLAVOR}
 ICONSDIR=	share/icons/hicolor/128x128/apps
 
 post-patch:

--- a/audio/sonata/Makefile
+++ b/audio/sonata/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=		sonata
-DISTVERSION=		1.7b1-22
-DISTVERSIONSUFFIX=	-gcee3555
-PORTREVISION=	2
+DISTVERSIONPREFIX=	v
+DISTVERSION=		1.7.3
+PORTEPOCH=		1
 CATEGORIES=		audio python
 PKGNAMEPREFIX=		${PYTHON_PKGNAMEPREFIX}
 
@@ -10,24 +10,47 @@ COMMENT=	Elegant music player for MPD
 
 LICENSE=	gpl3
 
-RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}python-mpd2>=0.4.6:audio/py-python-mpd2@${PY_FLAVOR}
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}setuptools>=63.1.0:devel/py-setuptools@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}wheel>=0.48.0:devel/py-wheel@${PY_FLAVOR}
+RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}python-mpd2>=0.4.6:audio/py-python-mpd2@${PY_FLAVOR} \
+		xdg-open:devel/xdg-utils
 
 USES=		gettext gnome pkgconfig python
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	multani
 USE_GNOME=	pygobject3
-USE_PYTHON=	distutils autoplist
+USE_PYTHON=	autoplist pep517
+INSTALLS_ICONS=	yes
 
-OPTIONS_DEFINE=	DOCS MMKEYS MPD TAGLIB
+PLIST_FILES=	${ICONSDIR}/sonata.png
+
+OPTIONS_DEFINE=	DOCS MMKEYS MPD
 OPTIONS_DEFAULT=	MPD
 MMKEYS_DESC=	Enable instance single support for mmkeys
 MPD_DESC=	Install Music Player Daemon
-TAGLIB_DESC=	Install support for editing metadata
 OPTIONS_SUB=	yes
 
 MPD_RUN_DEPENDS+=	musicpd:audio/musicpd
 MMKEYS_RUN_DEPENDS=${PYTHON_PKGNAMEPREFIX}dbus>=0.82.4:devel/py-dbus@${FLAVOR}
-TAGLIB_RUN_DEPENDS=	${PYTHON_PKGNAMEPREFIX}tagpy>=0.94.5:audio/py-tagpy@${FLAVOR}
+ICONSDIR=	share/icons/hicolor/128x128/apps
+
+post-patch:
+	${REINPLACE_CMD} \
+		-e "s,\(name=\)'Sonata',\1'sonata',1" \
+		-e "s,/etc/mpd.conf,${PREFIX}/etc/musicpd.conf,1" \
+		-e "s,/var/lib/mpd,/var/mpd,g" \
+		-e "s,gksu,mdo,1" \
+		-e 's,\("service"\, \)"mpd",\1"musicpd",1' \
+		-e 's,ps wwu -C mpd,mdo ps -ww -U mpd,1' \
+		${WRKSRC}/sonata/plugins/ui/localmpd.glade \
+		${WRKSRC}/sonata/plugins/localmpd.py \
+		${WRKSRC}/po/*.po \
+		${WRKSRC}/setup.py
+
+post-install:
+	${MKDIR} ${PREFIX}/${ICONSDIR}
+	${INSTALL_DATA} ${WRKSRC}/sonata/pixmaps/sonata.png \
+		${PREFIX}/${ICONSDIR}
 
 .include <bsd.port.mk>

--- a/audio/sonata/distinfo
+++ b/audio/sonata/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1580382764
-SHA256 (multani-sonata-1.7b1-22-gcee3555_GH0.tar.gz) = ac28360a5c576ad40c6fdf591de30ed90c4a5f63a366254794ac2a646d3ae680
-SIZE (multani-sonata-1.7b1-22-gcee3555_GH0.tar.gz) = 2258513
+TIMESTAMP = 1788978505
+SHA256 (multani-sonata-v1.7.3_GH0.tar.gz) = 0e79c833a93d4e6b6279a45f5c95197c3c88c820ddb8c7a78a12fdd1e8e3923a
+SIZE (multani-sonata-v1.7.3_GH0.tar.gz) = 2257912

--- a/audio/sonata/pkg-descr
+++ b/audio/sonata/pkg-descr
@@ -19,5 +19,3 @@ FEATURES:
 	+ Support for multimedia keys
 	+ Commandline control
 	+ Available in 24 languages
-
-WWW: http://sonata.berlios.de/index.html


### PR DESCRIPTION
Update Sonata to 1.7.3 and migrate its Python packaging to PEP 517. Add the desktop icon, current runtime dependency, and MidnightBSD-specific local MPD configuration paths. PORTEPOCH preserves the upgrade path from the earlier 1.7b1 snapshot.

Validation: makesum, patch, build, fake, package, test target, check-license, `portlint -C` (0 fatals), and `git diff --check`. The local mport database could not register py312-wheel 0.48.0 after a normal upgrade; source build/package validation therefore used that dependency staged in its isolated worktree. py-wheel is submitted separately in #1010.

## Summary by Sourcery

Update the Sonata port to 1.7.3 and modernize its packaging and MidnightBSD integration.

New Features:
- Update Sonata to the 1.7.3 release with desktop icon installation and current runtime dependencies.
- Add MidnightBSD-specific MPD configuration and service integration.

Enhancements:
- Migrate Sonata packaging to PEP 517 and preserve upgrades from the previous snapshot with PORTEPOCH.
- Remove the obsolete Taglib option and align dependency handling with current Python port conventions.