### PR TITLE
devel/dconf: update to 0.49.0

### DIFF
--- a/devel/dconf/Makefile
+++ b/devel/dconf/Makefile
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Configuration database system for GNOME
 WWW=		https://gitlab.gnome.org/GNOME/dconf
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	docbook-xsl>=0:textproc/docbook-xsl \


### PR DESCRIPTION
Updates dconf to 0.49.0 and refreshes the Meson portability patches.

Preserves MidnightBSD gio-querymodules package hooks; FreeBSD UCL scripts are not compatible with mport. Declares LGPL-2.1-or-later as confirmed by upstream COPYING.

Validated: bmake makesum, patch, build, fake, package, test (NO_TEST retained), check-license, portlint -C (0 fatals), and git diff --check.

## Summary by Sourcery

Update dconf to 0.49.0 while retaining MidnightBSD packaging compatibility and correcting its license declaration.

Enhancements:
- Update the dconf port to version 0.49.0 and refresh its portability patches.
- Preserve MidnightBSD gio-querymodules packaging hooks while omitting incompatible FreeBSD UCL scripts.

Chores:
- Confirm the port’s LGPL-2.1-or-later licensing against upstream metadata.