### PR TITLE
net-im/meanwhile: update to 1.1.1

### DIFF
--- a/net-im/meanwhile/Makefile
+++ b/net-im/meanwhile/Makefile
@@ -1,8 +1,6 @@
 PORTNAME=	meanwhile
-PORTVERSION=	1.0.2
-PORTREVISION=	5
+PORTVERSION=	1.1.1
 CATEGORIES=	net-im
-MASTER_SITES=	SF
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Open Source implementation of the Lotus Sametime protocol
@@ -10,8 +8,12 @@ WWW=		http://meanwhile.sourceforge.net/
 
 LICENSE=	lgpl
 
-USES=		gmake gnome libtool pathfix pkgconfig
+USES=		autoreconf gmake gnome libtool pathfix pkgconfig
 USE_GCC=	yes
+USE_GITHUB=	yes
+GH_ACCOUNT=	obriencj
+GH_PROJECT=	${PORTNAME}
+GH_TAGNAME=	v${PORTVERSION}
 USE_GNOME=	glib20
 USE_LDCONFIG=	yes
 GNU_CONFIGURE=	yes

--- a/net-im/meanwhile/distinfo
+++ b/net-im/meanwhile/distinfo
@@ -1,2 +1,3 @@
-SHA256 (meanwhile-1.0.2.tar.gz) = 38a8059eaa549cbcb45ca0a5b453e9608ceadab360db2ae14581fb22ddabdf23
-SIZE (meanwhile-1.0.2.tar.gz) = 479325
+TIMESTAMP = 1788980983
+SHA256 (obriencj-meanwhile-1.1.1-v1.1.1_GH0.tar.gz) = 10de306f03897572b30ce68ca80dffd04ec218f6842bbe0a47bb8cce933698d0
+SIZE (obriencj-meanwhile-1.1.1-v1.1.1_GH0.tar.gz) = 180449

--- a/net-im/meanwhile/pkg-plist
+++ b/net-im/meanwhile/pkg-plist
@@ -14,10 +14,9 @@ include/meanwhile/mw_srvc_place.h
 include/meanwhile/mw_srvc_resolve.h
 include/meanwhile/mw_srvc_store.h
 include/meanwhile/mw_st_list.h
-lib/libmeanwhile.a
 lib/libmeanwhile.so
 lib/libmeanwhile.so.1
-lib/libmeanwhile.so.1.0.2
+lib/libmeanwhile.so.1.1.1
 libdata/pkgconfig/meanwhile.pc
 %%DOCSDIR%%/samples/README
 %%DOCSDIR%%/samples/build


### PR DESCRIPTION
Updates Meanwhile to 1.1.1.

- migrates from the obsolete SourceForge release to the maintained upstream GitHub tag
- adds autoreconf required by the source release
- removes PORTREVISION and the obsolete static-archive plist entry
- refreshes the installed shared-library filename

Validated: bmake makesum, patch, build, fake, package, test, check-license, portlint -C (0 fatal errors), and git diff --check.

## Summary by Sourcery

Update the Meanwhile port to release 1.1.1 using the maintained upstream source.

Enhancements:
- Update the Meanwhile port to upstream release 1.1.1 from GitHub and refresh its packaged shared-library files.

Build:
- Add autoreconf support required to build the updated source release.

Chores:
- Remove obsolete port revision and static-archive packaging metadata.