### PR TITLE
net/libmateweather: update to 1.28.1

### DIFF
--- a/net/libmateweather/Makefile
+++ b/net/libmateweather/Makefile
@@ -1,9 +1,7 @@
 PORTNAME=	libmateweather
-PORTVERSION=	1.28.0
-PORTREVISION=	1
+DISTVERSIONPREFIX=	v
+DISTVERSION=	1.28.1
 CATEGORIES=	net mate
-MASTER_SITES=	MATE
-DIST_SUBDIR=	mate
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Library to access online weather information
@@ -16,8 +14,10 @@ LIB_DEPENDS=	libsoup-2.4.so:devel/libsoup
 
 PORTSCOUT=	limitw:1,even
 
-USES=		gettext gmake gnome libtool localbase pathfix pkgconfig tar:xz
-USE_GNOME=	cairo gnomeprefix gtk30 intltool libxml2
+USES=		autoreconf gettext gmake gnome libtool localbase pathfix pkgconfig
+USE_GITHUB=	yes
+GH_ACCOUNT=	mate-desktop
+USE_GNOME=	cairo gtk30 intltool libxml2
 USE_LDCONFIG=	yes
 GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
@@ -26,5 +26,8 @@ INSTALL_TARGET=	install-strip
 GLIB_SCHEMAS=	org.mate.weather.gschema.xml
 
 OPTIONS_DEFINE=	DOCS
+
+DOCS_BUILD_DEPENDS=	gtk-doc>=0:textproc/gtk-doc
+DOCS_CONFIGURE_ON=	--enable-gtk-doc --with-html-dir=${PREFIX}/share/doc
 
 .include <bsd.port.mk>

--- a/net/libmateweather/distinfo
+++ b/net/libmateweather/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1710689060
-SHA256 (mate/libmateweather-1.28.0.tar.xz) = 554373deb5b393b9d84b275dd2ca66c9a4a2d0e6ec92044fab8aa53e3032d2b5
-SIZE (mate/libmateweather-1.28.0.tar.xz) = 2221808
+TIMESTAMP = 1788981239
+SHA256 (mate-desktop-libmateweather-v1.28.1_GH0.tar.gz) = dfd0de546afda06e2a4d6837748910fa2074ab6fd76361fa67f642f456e184c1
+SIZE (mate-desktop-libmateweather-v1.28.1_GH0.tar.gz) = 6965691


### PR DESCRIPTION
Updates libmateweather from 1.28.0 to 1.28.1 using the upstream MATE GitHub tag.

- Removes the stale PORTREVISION for the release bump.
- Adds autoreconf and the DOCS option build/configure support required by the current release.
- Removes gnomeprefix because it forces --disable-gtk-doc and conflicts with the enabled DOCS option.

Validation: bmake makesum, patch, build, fake, package, test, check-license; portlint -C (0 fatals); git diff --check.

## Summary by Sourcery

Update the libmateweather port to the 1.28.1 release with compatible source retrieval and documentation build support.

Enhancements:
- Update libmateweather to the 1.28.1 upstream release and fetch it from the MATE GitHub repository.
- Add optional gtk-doc documentation support and required autoreconf integration while removing the conflicting gnomeprefix configuration.