### PR TITLE
devel/libpeas1: update to 1.38.1

### DIFF
--- a/devel/libpeas1/Makefile
+++ b/devel/libpeas1/Makefile
@@ -12,6 +12,12 @@ WWW=		https://gitlab.gnome.org/GNOME/libpeas
 LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
+LIBPEAS_SLAVE?=	no
+
+.if ${LIBPEAS_SLAVE} == no
+TEST_DEPENDS=	Xvfb:x11-servers/xorg-server@xvfb
+.endif
+
 USES=		cpe gettext gnome meson pathfix pkgconfig tar:xz \
 		vala:build
 USE_GNOME=	introspection libxml2
@@ -20,13 +26,22 @@ CPE_VENDOR=	gnome
 MESON_ARGS=	-Dglade_catalog=false \
 		-Dlua51=false
 
-NO_TEST=	yes
-
-LIBPEAS_SLAVE?=	no
-
 .if ${LIBPEAS_SLAVE} == no
+LIBPEAS_TEST_DISPLAY?=	:100
+
+do-test:
+	@${LOCALBASE}/bin/Xvfb ${LIBPEAS_TEST_DISPLAY} -screen 0 1280x1024x24 \
+		>${WRKDIR}/xvfb.log 2>&1 & \
+		xvfb_pid=$$!; \
+		trap 'kill $$xvfb_pid' EXIT INT TERM; \
+		sleep 1; \
+		cd ${TEST_WRKSRC} && ${SETENVI} ${WRK_ENV} ${TEST_ENV} \
+		DISPLAY=${LIBPEAS_TEST_DISPLAY} ${MAKE_CMD} ${MAKE_FLAGS} \
+		${MAKEFILE} ${TEST_ARGS:C,^${DESTDIRNAME}=.*,,g} ${TEST_TARGET}
+
 USE_GNOME+=	gtk30
 USE_LDCONFIG=	yes
+INSTALLS_ICONS=	yes
 
 MESON_ARGS+=	-Dvapi=true \
 		-Dpython3=false
@@ -50,6 +65,7 @@ pre-build:
 
 .if ${LIBPEAS_SLAVE} == python
 LIB_DEPENDS+=	libpeas-1.0.so:devel/libpeas1
+NO_TEST=	yes
 
 USES+=		python
 USE_PYTHON=	flavors

--- a/devel/libpeas1/pkg-plist
+++ b/devel/libpeas1/pkg-plist
@@ -83,6 +83,7 @@ libdata/pkgconfig/libpeas-gtk-1.0.pc
 %%DOCS%%%%DOCSDIR%%-1.0/func.DEPRECATED_FOR.html
 %%DOCS%%%%DOCSDIR%%-1.0/func.DEPRECATED_IN_1_22_FOR.html
 %%DOCS%%%%DOCSDIR%%-1.0/func.DEPRECATED_IN_1_24_FOR.html
+%%DOCS%%%%DOCSDIR%%-1.0/func.DEPRECATED_IN_1_38_FOR.html
 %%DOCS%%%%DOCSDIR%%-1.0/func.EXTENSION.html
 %%DOCS%%%%DOCSDIR%%-1.0/func.UNAVAILABLE.html
 %%DOCS%%%%DOCSDIR%%-1.0/fzy.js
@@ -284,6 +285,7 @@ share/locale/is/LC_MESSAGES/libpeas-1.0.mo
 share/locale/it/LC_MESSAGES/libpeas-1.0.mo
 share/locale/ja/LC_MESSAGES/libpeas-1.0.mo
 share/locale/ka/LC_MESSAGES/libpeas-1.0.mo
+share/locale/kab/LC_MESSAGES/libpeas-1.0.mo
 share/locale/kk/LC_MESSAGES/libpeas-1.0.mo
 share/locale/kn/LC_MESSAGES/libpeas-1.0.mo
 share/locale/ko/LC_MESSAGES/libpeas-1.0.mo


### PR DESCRIPTION
Updates the Peas 1.0 plugin-engine port to 1.38.1.

- Refreshes staged documentation and Kabyle locale entries
- Restores the primary port test suite: all 7 upstream tests run under a port-owned Xvfb server
- Keeps the Python loader slave no-test because its loader-only build target cannot produce the full upstream test executables
- Preserves LGPL-2.1-or-later metadata and the ABI major

Validated main port: bmake makesum, patch, build, fake, clean package, test (7/7), check-license, portlint -C, and git diff --check.

Validated Python slave: bmake clean package, test (NO_TEST), and check-license.

## Summary by Sourcery

Update libpeas1 to 1.38.1 and restore reliable testing for the main plugin-engine port.

Bug Fixes:
- Restore the primary libpeas1 port test suite with all upstream tests running under an isolated Xvfb display.

Enhancements:
- Preserve the Python loader slave's no-test configuration while enabling tests for the main port.
- Refresh staged package metadata and documentation entries.

Tests:
- Add Xvfb as a test dependency and support running the seven upstream tests for the main port.

Chores:
- Update the libpeas1 port to version 1.38.1 while retaining its ABI major and licensing metadata.