### PR TITLE
graphics/gegl: update to 0.4.70

### DIFF
--- a/graphics/gegl/Makefile
+++ b/graphics/gegl/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gegl
-DISTVERSION=	0.4.64
-PORTREVISION=	0
+DISTVERSION=	0.4.70
 CATEGORIES=	graphics
 MASTER_SITES=	GIMP
 
@@ -35,11 +34,13 @@ MESON_ARGS=	-Ddocs=false \
 		-Dmrg=disabled \
 		-Dpygobject=disabled \
 		-Dlua=disabled
+# relocatable does not mean ELF relocation
+MESON_ARGS+=	-Drelocatable-bundle=no
 .if !exists(/usr/include/omp.h)
 MESON_ARGS+=	-Dopenmp=disabled
 .endif
 
-GEGL_SHLIB=	0.463.1
+GEGL_SHLIB=	0.469.1
 GEGL_VER=	0.4
 PLIST_SUB+=	GEGL_SHLIB=${GEGL_SHLIB} GEGL_VER=${GEGL_VER}
 

--- a/graphics/gegl/distinfo
+++ b/graphics/gegl/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1759928302
-SHA256 (gegl-0.4.64.tar.xz) = 0de1c9dd22c160d5e4bdfc388d292f03447cca6258541b9a12fed783d0cf7c60
-SIZE (gegl-0.4.64.tar.xz) = 6066976
+TIMESTAMP = 1788984674
+SHA256 (gegl-0.4.70.tar.xz) = 47f50d9c3aecd375deb48c11ebfead52d162e4fc162a4b3d44618277f1faec02
+SIZE (gegl-0.4.70.tar.xz) = 6164464

--- a/graphics/gegl/pkg-plist
+++ b/graphics/gegl/pkg-plist
@@ -175,8 +175,10 @@ share/locale/hr/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/id/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/is/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/it/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
+share/locale/ja/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/ka/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/kab/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
+share/locale/kk/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/ko/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/lv/LC_MESSAGES/gegl-%%GEGL_VER%%.mo
 share/locale/mr/LC_MESSAGES/gegl-%%GEGL_VER%%.mo


### PR DESCRIPTION
Updates GEGL to 0.4.70.

- Retains existing license metadata and existing NO_TEST behavior.
- Disables the relocatable bundle explicitly; this is unrelated to ELF relocation.
- SONAME remains libgegl-0.4.so.0, so dependent PORTREVISION bumps are not needed.

Validated: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the GEGL graphics port to 0.4.70 while retaining compatibility with existing consumers.

Enhancements:
- Update GEGL to version 0.4.70 and refresh its shared-library metadata and package contents.
- Explicitly disable relocatable bundles while preserving existing licensing and test behavior.