### PR TITLE
japanese/libskk: update to 1.1.1

### DIFF
--- a/japanese/libskk/Makefile
+++ b/japanese/libskk/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	libskk
-DISTVERSION=	1.0.5
-PORTREVISION=	1
+DISTVERSION=	1.1.1
 CATEGORIES=	japanese
+MASTER_SITES=	https://github.com/ueno/${PORTNAME}/releases/download/${DISTVERSION}/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Library to deal with Japanese Kana-to-Kanji conversion method
@@ -15,9 +15,7 @@ LIB_DEPENDS=	libgee-0.8.so:devel/libgee \
 		libjson-glib-1.0.so:devel/json-glib \
 		libxkbcommon.so:x11/libxkbcommon
 
-USES=		autoreconf gmake gnome libtool pathfix pkgconfig vala:build
-USE_GITHUB=	yes
-GH_ACCOUNT=	ueno
+USES=		autoreconf gmake gnome libtool pathfix pkgconfig tar:xz vala:build
 GNU_CONFIGURE=	yes
 GNU_CONFIGURE_MANPREFIX=${PREFIX}/share
 USE_GNOME=	introspection:build

--- a/japanese/libskk/distinfo
+++ b/japanese/libskk/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1546059395
-SHA256 (ueno-libskk-1.0.5_GH0.tar.gz) = a298e9726b784dd9a6ce8dcb76ff8fbe633037756795d75cfd77d3aeab4f50ed
-SIZE (ueno-libskk-1.0.5_GH0.tar.gz) = 189203
+TIMESTAMP = 1788987251
+SHA256 (libskk-1.1.1.tar.xz) = 2d4c15976d459ef0004ce1c0e47506c7859d0b6f4fb104ed837f3326d235bb56
+SIZE (libskk-1.1.1.tar.xz) = 588640


### PR DESCRIPTION
Updates libskk to 1.1.1.

- Removes stale PORTREVISION and uses the upstream release tarball.
- Retains MidnightBSD build dependencies, options, compiler flags, and fake-install handling.
- Upstream COPYING is GPLv3 exactly, matching existing metadata.
- SONAME remains libskk.so.0; no dependent revision bumps are needed.

Validated: bmake makesum, patch, build, fake, package, test, upstream gmake check (8/8), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the Japanese libskk port to version 1.1.1.

Enhancements:
- Update the Japanese libskk port to the 1.1.1 upstream release while preserving its existing build configuration and package metadata.

Build:
- Switch the port to the upstream release tarball and add XZ archive support.

Chores:
- Remove the obsolete PORTREVISION and refresh the distribution checksum.