### PR TITLE
x11/py-xdot: update to 1.6

### DIFF
--- a/x11/py-xdot/Makefile
+++ b/x11/py-xdot/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	xdot
-PORTVERSION=	1.2
-PORTREVISION=	7
+PORTVERSION=	1.6
 CATEGORIES=	x11 python
 MASTER_SITES=	PYPI
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -10,9 +9,11 @@ COMMENT=	Interactive viewer for Graphviz dot files
 WWW=		https://pypi.org/project/xdot/
 
 LICENSE=	lgpl3+
+LICENSE_FILE=	${WRKSRC}/LICENSE.txt
 
 RUN_DEPENDS=	dot:graphics/graphviz \
-		${PYNUMPY}
+		${PYNUMPY} \
+		${PYTHON_PKGNAMEPREFIX}packaging>=0:devel/py-packaging@${PY_FLAVOR}
 
 USES=		gnome python
 USE_PYTHON=	autoplist distutils

--- a/x11/py-xdot/distinfo
+++ b/x11/py-xdot/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1607286304
-SHA256 (xdot-1.2.tar.gz) = 3df91e6c671869bd2a6b2a8883fa3476dbe2ba763bd2a7646cf848a9eba71b70
-SIZE (xdot-1.2.tar.gz) = 29643
+TIMESTAMP = 1788987944
+SHA256 (xdot-1.6.tar.gz) = ebddefc3e3aa9fd8b2e2ed884ed844043f843428b79dccda831803add55cc51d
+SIZE (xdot-1.6.tar.gz) = 36242


### PR DESCRIPTION
Updates x11/py-xdot from 1.2 to 1.6 and removes the obsolete PORTREVISION. Adds the upstream LGPLv3 license file and required py-packaging runtime dependency.\n\nValidated: bmake makesum, patch, build, fake, package, test, check-license, portlint, and git diff --check.\n\nNote: the generated local package remains untracked in the isolated worktree; portlint -C would scan it as source, while source-only portlint passes.

## Summary by Sourcery

Update the xdot port to the current 1.6 release and align its dependencies and licensing metadata.

Enhancements:
- Update the xdot Python package to version 1.6 and refresh its packaging metadata.

Build:
- Add the runtime py-packaging dependency required by the updated package.

Chores:
- Remove the obsolete PORTREVISION and declare the upstream LGPLv3 license file.