### PR TITLE
misc/cinnamon-translations: update to 6.4.2

### DIFF
--- a/misc/cinnamon-translations/Makefile
+++ b/misc/cinnamon-translations/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	cinnamon-translations
-PORTVERSION=	4.8.3
+PORTVERSION=	6.4.2
 CATEGORIES=	misc x11 gnome
 DIST_SUBDIR=	gnome
 
@@ -7,11 +7,13 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Translations for the cinnamon desktop
 
 LICENSE=	gpl2
+LICENSE_FILE=	${WRKSRC}/COPYING
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	linuxmint
 
 USES=		gettext-tools
+NO_BUILD=	yes
 INSTALL_TARGET=	all
 NO_ARCH=	yes
 

--- a/misc/cinnamon-translations/distinfo
+++ b/misc/cinnamon-translations/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1612567721
-SHA256 (gnome/linuxmint-cinnamon-translations-4.8.3_GH0.tar.gz) = 272b4e128b352f8a877bb57eaa4ed85ff72ad1cb25c4c58c8a35d0b093908f93
-SIZE (gnome/linuxmint-cinnamon-translations-4.8.3_GH0.tar.gz) = 12010514
+TIMESTAMP = 1788989558
+SHA256 (gnome/linuxmint-cinnamon-translations-6.4.2_GH0.tar.gz) = 7312137f0d3fc416108ae0e239b6ed81737412acd32abb7618e2b65fda3bd75f
+SIZE (gnome/linuxmint-cinnamon-translations-6.4.2_GH0.tar.gz) = 13903679

--- a/misc/cinnamon-translations/pkg-plist
+++ b/misc/cinnamon-translations/pkg-plist
@@ -1,3 +1,5 @@
+share/locale/aa/LC_MESSAGES/cinnamon.mo
+share/locale/aa/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/af/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/af/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/af/LC_MESSAGES/cinnamon-session.mo
@@ -19,17 +21,25 @@ share/locale/ar/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ar/LC_MESSAGES/cinnamon.mo
 share/locale/ar/LC_MESSAGES/nemo-extensions.mo
 share/locale/ar/LC_MESSAGES/nemo.mo
-share/locale/as/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/as/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/as/LC_MESSAGES/cinnamon-session.mo
+share/locale/ary/LC_MESSAGES/cinnamon.mo
 share/locale/as/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/as/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/as/LC_MESSAGES/nemo.mo
+share/locale/as/LC_MESSAGES/cinnamon-session.mo
+share/locale/as/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ast/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/ast/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ast/LC_MESSAGES/cinnamon-session.mo
-share/locale/ast/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ast/LC_MESSAGES/cinnamon.mo
 share/locale/ast/LC_MESSAGES/nemo.mo
+share/locale/ast/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/ast/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/ay/LC_MESSAGES/nemo-extensions.mo
+share/locale/ay/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/ay/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/ay/LC_MESSAGES/nemo.mo
+share/locale/ay/LC_MESSAGES/cinnamon-session.mo
+share/locale/ay/LC_MESSAGES/cinnamon.mo
+share/locale/ay/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/az/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/az/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/az/LC_MESSAGES/cinnamon-session.mo
@@ -60,15 +70,19 @@ share/locale/bn/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/bn/LC_MESSAGES/cinnamon-session.mo
 share/locale/bn/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/bn/LC_MESSAGES/cinnamon.mo
+share/locale/bn/LC_MESSAGES/nemo-extensions.mo
 share/locale/bn/LC_MESSAGES/nemo.mo
-share/locale/bn_IN/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/bn_IN/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/bn_IN/LC_MESSAGES/cinnamon-session.mo
 share/locale/bn_IN/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/bn_IN/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/bn_IN/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/br/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/br/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/br/LC_MESSAGES/cinnamon-session.mo
 share/locale/br/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/br/LC_MESSAGES/cinnamon.mo
+share/locale/br/LC_MESSAGES/nemo-extensions.mo
+share/locale/br/LC_MESSAGES/nemo.mo
 share/locale/bs/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/bs/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/bs/LC_MESSAGES/cinnamon-session.mo
@@ -83,17 +97,18 @@ share/locale/ca/LC_MESSAGES/cinnamon.mo
 share/locale/ca/LC_MESSAGES/nemo-extensions.mo
 share/locale/ca/LC_MESSAGES/nemo.mo
 share/locale/ca@valencia/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/ca@valencia/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/ca@valencia/LC_MESSAGES/cinnamon-session.mo
+share/locale/ca@valencia/LC_MESSAGES/nemo.mo
 share/locale/ca@valencia/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ca@valencia/LC_MESSAGES/cinnamon.mo
+share/locale/ca@valencia/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/ca@valencia/LC_MESSAGES/cinnamon-session.mo
 share/locale/ca@valencia/LC_MESSAGES/nemo-extensions.mo
-share/locale/ca@valencia/LC_MESSAGES/nemo.mo
-share/locale/crh/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/crh/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/crh/LC_MESSAGES/cinnamon-session.mo
-share/locale/crh/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/ckb/LC_MESSAGES/cinnamon.mo
 share/locale/crh/LC_MESSAGES/cinnamon.mo
+share/locale/crh/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/crh/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/crh/LC_MESSAGES/cinnamon-session.mo
+share/locale/crh/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/cs/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/cs/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/cs/LC_MESSAGES/cinnamon-session.mo
@@ -124,10 +139,10 @@ share/locale/de/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/de/LC_MESSAGES/cinnamon.mo
 share/locale/de/LC_MESSAGES/nemo-extensions.mo
 share/locale/de/LC_MESSAGES/nemo.mo
-share/locale/dz/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/dz/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/dz/LC_MESSAGES/cinnamon-session.mo
 share/locale/dz/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/dz/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/dz/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/el/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/el/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/el/LC_MESSAGES/cinnamon-session.mo
@@ -135,10 +150,10 @@ share/locale/el/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/el/LC_MESSAGES/cinnamon.mo
 share/locale/el/LC_MESSAGES/nemo-extensions.mo
 share/locale/el/LC_MESSAGES/nemo.mo
-share/locale/en@shaw/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/en@shaw/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/en@shaw/LC_MESSAGES/cinnamon-session.mo
+share/locale/en@shaw/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/en@shaw/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/en@shaw/LC_MESSAGES/cinnamon-session.mo
 share/locale/en_AU/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/en_AU/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/en_AU/LC_MESSAGES/cinnamon-session.mo
@@ -147,6 +162,7 @@ share/locale/en_AU/LC_MESSAGES/nemo.mo
 share/locale/en_CA/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/en_CA/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/en_CA/LC_MESSAGES/cinnamon-session.mo
+share/locale/en_CA/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/en_CA/LC_MESSAGES/cinnamon.mo
 share/locale/en_CA/LC_MESSAGES/nemo.mo
 share/locale/en_GB/LC_MESSAGES/cinnamon-control-center.mo
@@ -193,6 +209,7 @@ share/locale/fa/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/fa/LC_MESSAGES/cinnamon-session.mo
 share/locale/fa/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/fa/LC_MESSAGES/cinnamon.mo
+share/locale/fa/LC_MESSAGES/nemo-extensions.mo
 share/locale/fa/LC_MESSAGES/nemo.mo
 share/locale/fi/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/fi/LC_MESSAGES/cinnamon-screensaver.mo
@@ -201,11 +218,12 @@ share/locale/fi/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/fi/LC_MESSAGES/cinnamon.mo
 share/locale/fi/LC_MESSAGES/nemo-extensions.mo
 share/locale/fi/LC_MESSAGES/nemo.mo
+share/locale/fil/LC_MESSAGES/cinnamon.mo
 share/locale/fil/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/fil/LC_MESSAGES/cinnamon-session.mo
-share/locale/fil/LC_MESSAGES/cinnamon.mo
 share/locale/fil/LC_MESSAGES/nemo.mo
 share/locale/fo/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/fo/LC_MESSAGES/nemo.mo
 share/locale/fo/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/fo/LC_MESSAGES/cinnamon.mo
 share/locale/fr/LC_MESSAGES/cinnamon-control-center.mo
@@ -215,24 +233,24 @@ share/locale/fr/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/fr/LC_MESSAGES/cinnamon.mo
 share/locale/fr/LC_MESSAGES/nemo-extensions.mo
 share/locale/fr/LC_MESSAGES/nemo.mo
+share/locale/fr_CA/LC_MESSAGES/nemo.mo
+share/locale/fr_CA/LC_MESSAGES/cinnamon-session.mo
 share/locale/fr_CA/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/fr_CA/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/fr_CA/LC_MESSAGES/cinnamon-session.mo
 share/locale/fr_CA/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/fr_CA/LC_MESSAGES/cinnamon.mo
 share/locale/fr_CA/LC_MESSAGES/nemo-extensions.mo
-share/locale/fr_CA/LC_MESSAGES/nemo.mo
-share/locale/frp/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/frp/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/fr_CA/LC_MESSAGES/cinnamon.mo
 share/locale/frp/LC_MESSAGES/cinnamon-session.mo
+share/locale/frp/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/frp/LC_MESSAGES/cinnamon.mo
+share/locale/frp/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/frp/LC_MESSAGES/nemo.mo
-share/locale/fur/LC_MESSAGES/cinnamon-session.mo
 share/locale/fur/LC_MESSAGES/cinnamon.mo
-share/locale/fy/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/fy/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/fur/LC_MESSAGES/cinnamon-session.mo
 share/locale/fy/LC_MESSAGES/cinnamon-session.mo
+share/locale/fy/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/fy/LC_MESSAGES/cinnamon.mo
+share/locale/fy/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/fy/LC_MESSAGES/nemo.mo
 share/locale/ga/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ga/LC_MESSAGES/cinnamon-screensaver.mo
@@ -240,11 +258,11 @@ share/locale/ga/LC_MESSAGES/cinnamon-session.mo
 share/locale/ga/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ga/LC_MESSAGES/cinnamon.mo
 share/locale/ga/LC_MESSAGES/nemo.mo
-share/locale/gd/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/gd/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/gd/LC_MESSAGES/cinnamon-session.mo
+share/locale/gd/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/gd/LC_MESSAGES/cinnamon.mo
 share/locale/gd/LC_MESSAGES/nemo.mo
+share/locale/gd/LC_MESSAGES/cinnamon-session.mo
 share/locale/gl/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/gl/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/gl/LC_MESSAGES/cinnamon-session.mo
@@ -278,6 +296,7 @@ share/locale/hr/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/hr/LC_MESSAGES/cinnamon.mo
 share/locale/hr/LC_MESSAGES/nemo-extensions.mo
 share/locale/hr/LC_MESSAGES/nemo.mo
+share/locale/hsb/LC_MESSAGES/cinnamon.mo
 share/locale/hu/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/hu/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/hu/LC_MESSAGES/cinnamon-session.mo
@@ -288,13 +307,13 @@ share/locale/hu/LC_MESSAGES/nemo.mo
 share/locale/hy/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/hy/LC_MESSAGES/cinnamon-session.mo
 share/locale/hy/LC_MESSAGES/cinnamon.mo
+share/locale/ia/LC_MESSAGES/cinnamon.mo
+share/locale/ia/LC_MESSAGES/nemo.mo
+share/locale/ia/LC_MESSAGES/nemo-extensions.mo
+share/locale/ia/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ia/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ia/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ia/LC_MESSAGES/cinnamon-session.mo
-share/locale/ia/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/ia/LC_MESSAGES/cinnamon.mo
-share/locale/ia/LC_MESSAGES/nemo-extensions.mo
-share/locale/ia/LC_MESSAGES/nemo.mo
 share/locale/id/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/id/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/id/LC_MESSAGES/cinnamon-session.mo
@@ -302,12 +321,12 @@ share/locale/id/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/id/LC_MESSAGES/cinnamon.mo
 share/locale/id/LC_MESSAGES/nemo-extensions.mo
 share/locale/id/LC_MESSAGES/nemo.mo
-share/locale/ie/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/ie/LC_MESSAGES/cinnamon-session.mo
-share/locale/ie/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/ie/LC_MESSAGES/cinnamon.mo
 share/locale/ie/LC_MESSAGES/nemo-extensions.mo
 share/locale/ie/LC_MESSAGES/nemo.mo
+share/locale/ie/LC_MESSAGES/cinnamon.mo
+share/locale/ie/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/ie/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/ie/LC_MESSAGES/cinnamon-session.mo
 share/locale/ig/LC_MESSAGES/cinnamon-session.mo
 share/locale/is/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/is/LC_MESSAGES/cinnamon-screensaver.mo
@@ -340,24 +359,24 @@ share/locale/ka/LC_MESSAGES/cinnamon.mo
 share/locale/ka/LC_MESSAGES/nemo.mo
 share/locale/kab/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/kab/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/kab/LC_MESSAGES/nemo.mo
 share/locale/kab/LC_MESSAGES/cinnamon-session.mo
-share/locale/kab/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/kab/LC_MESSAGES/cinnamon.mo
 share/locale/kab/LC_MESSAGES/nemo-extensions.mo
-share/locale/kab/LC_MESSAGES/nemo.mo
-share/locale/kk/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/kk/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/kk/LC_MESSAGES/cinnamon-session.mo
+share/locale/kab/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/kk/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/kk/LC_MESSAGES/cinnamon.mo
+share/locale/kk/LC_MESSAGES/cinnamon-session.mo
 share/locale/kk/LC_MESSAGES/nemo-extensions.mo
 share/locale/kk/LC_MESSAGES/nemo.mo
+share/locale/kk/LC_MESSAGES/cinnamon.mo
+share/locale/kk/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/kk/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/km/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/km/LC_MESSAGES/nemo.mo
 share/locale/km/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/km/LC_MESSAGES/cinnamon-session.mo
 share/locale/km/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/km/LC_MESSAGES/cinnamon.mo
-share/locale/km/LC_MESSAGES/nemo.mo
+share/locale/km/LC_MESSAGES/cinnamon-session.mo
 share/locale/kn/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/kn/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/kn/LC_MESSAGES/cinnamon-session.mo
@@ -373,25 +392,29 @@ share/locale/ko/LC_MESSAGES/nemo-extensions.mo
 share/locale/ko/LC_MESSAGES/nemo.mo
 share/locale/ksw/LC_MESSAGES/cinnamon.mo
 share/locale/ksw/LC_MESSAGES/nemo.mo
-share/locale/ku/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/ku/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ku/LC_MESSAGES/cinnamon-session.mo
+share/locale/ku/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ku/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/ku/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ku/LC_MESSAGES/cinnamon.mo
 share/locale/ku/LC_MESSAGES/nemo.mo
-share/locale/ky/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ky/LC_MESSAGES/cinnamon.mo
+share/locale/ky/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ky/LC_MESSAGES/nemo.mo
-share/locale/la/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/la/LC_MESSAGES/cinnamon.mo
+share/locale/la/LC_MESSAGES/cinnamon-session.mo
 share/locale/la/LC_MESSAGES/nemo-extensions.mo
+share/locale/la/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/la/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/la/LC_MESSAGES/cinnamon.mo
 share/locale/la/LC_MESSAGES/nemo.mo
+share/locale/la/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/li/LC_MESSAGES/cinnamon.mo
+share/locale/lmo/LC_MESSAGES/cinnamon.mo
 share/locale/lo/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/lo/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/lo/LC_MESSAGES/cinnamon-session.mo
 share/locale/lo/LC_MESSAGES/cinnamon.mo
 share/locale/lo/LC_MESSAGES/nemo.mo
+share/locale/lo/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/lt/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/lt/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/lt/LC_MESSAGES/cinnamon-session.mo
@@ -405,16 +428,16 @@ share/locale/lv/LC_MESSAGES/cinnamon-session.mo
 share/locale/lv/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/lv/LC_MESSAGES/cinnamon.mo
 share/locale/lv/LC_MESSAGES/nemo.mo
-share/locale/mai/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/mai/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/mai/LC_MESSAGES/cinnamon.mo
 share/locale/mai/LC_MESSAGES/cinnamon-session.mo
 share/locale/mai/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/mai/LC_MESSAGES/cinnamon.mo
-share/locale/mg/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/mg/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/mg/LC_MESSAGES/cinnamon-session.mo
-share/locale/mg/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/mai/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/mg/LC_MESSAGES/nemo.mo
+share/locale/mg/LC_MESSAGES/cinnamon-session.mo
+share/locale/mg/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/mg/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/mg/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/mi/LC_MESSAGES/cinnamon-session.mo
 share/locale/mk/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/mk/LC_MESSAGES/cinnamon-screensaver.mo
@@ -431,22 +454,28 @@ share/locale/mn/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/mn/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/mn/LC_MESSAGES/cinnamon-session.mo
 share/locale/mn/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/mr/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/mnw/LC_MESSAGES/cinnamon.mo
+share/locale/mo/LC_MESSAGES/cinnamon.mo
+share/locale/mo/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/mo/LC_MESSAGES/nemo.mo
+share/locale/mo/LC_MESSAGES/cinnamon-session.mo
+share/locale/mo/LC_MESSAGES/nemo-extensions.mo
+share/locale/mr/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/mr/LC_MESSAGES/nemo.mo
+share/locale/mr/LC_MESSAGES/cinnamon.mo
 share/locale/mr/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/mr/LC_MESSAGES/cinnamon-session.mo
-share/locale/mr/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/mr/LC_MESSAGES/cinnamon.mo
-share/locale/mr/LC_MESSAGES/nemo.mo
+share/locale/mr/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ms/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ms/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ms/LC_MESSAGES/cinnamon-session.mo
 share/locale/ms/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ms/LC_MESSAGES/cinnamon.mo
 share/locale/ms/LC_MESSAGES/nemo.mo
-share/locale/my/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/my/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/my/LC_MESSAGES/cinnamon-session.mo
 share/locale/my/LC_MESSAGES/cinnamon.mo
+share/locale/my/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/my/LC_MESSAGES/cinnamon-session.mo
+share/locale/my/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/my/LC_MESSAGES/nemo.mo
 share/locale/nap/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/nap/LC_MESSAGES/cinnamon.mo
@@ -455,12 +484,13 @@ share/locale/nb/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/nb/LC_MESSAGES/cinnamon-session.mo
 share/locale/nb/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/nb/LC_MESSAGES/cinnamon.mo
+share/locale/nb/LC_MESSAGES/nemo-extensions.mo
 share/locale/nb/LC_MESSAGES/nemo.mo
+share/locale/nds/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/nds/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/nds/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/nds/LC_MESSAGES/cinnamon-session.mo
-share/locale/nds/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/nds/LC_MESSAGES/cinnamon.mo
+share/locale/nds/LC_MESSAGES/cinnamon-session.mo
 share/locale/nds/LC_MESSAGES/nemo.mo
 share/locale/ne/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ne/LC_MESSAGES/cinnamon-screensaver.mo
@@ -484,18 +514,19 @@ share/locale/nn/LC_MESSAGES/cinnamon.mo
 share/locale/nn/LC_MESSAGES/nemo.mo
 share/locale/no/LC_MESSAGES/cinnamon.mo
 share/locale/nso/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/nso/LC_MESSAGES/cinnamon-session.mo
 share/locale/nso/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/nso/LC_MESSAGES/cinnamon-session.mo
 share/locale/oc/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/oc/LC_MESSAGES/nemo-extensions.mo
 share/locale/oc/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/oc/LC_MESSAGES/cinnamon-session.mo
-share/locale/oc/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/oc/LC_MESSAGES/cinnamon.mo
+share/locale/oc/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/oc/LC_MESSAGES/cinnamon-session.mo
 share/locale/oc/LC_MESSAGES/nemo.mo
-share/locale/om/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/om/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/om/LC_MESSAGES/cinnamon.mo
 share/locale/om/LC_MESSAGES/nemo.mo
+share/locale/om/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/om/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/or/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/or/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/or/LC_MESSAGES/cinnamon-session.mo
@@ -532,6 +563,12 @@ share/locale/pt_BR/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/pt_BR/LC_MESSAGES/cinnamon.mo
 share/locale/pt_BR/LC_MESSAGES/nemo-extensions.mo
 share/locale/pt_BR/LC_MESSAGES/nemo.mo
+share/locale/qu/LC_MESSAGES/nemo.mo
+share/locale/qu/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/qu/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/qu/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/qu/LC_MESSAGES/cinnamon-session.mo
+share/locale/qu/LC_MESSAGES/cinnamon.mo
 share/locale/ro/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ro/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ro/LC_MESSAGES/cinnamon-session.mo
@@ -546,30 +583,35 @@ share/locale/ru/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ru/LC_MESSAGES/cinnamon.mo
 share/locale/ru/LC_MESSAGES/nemo-extensions.mo
 share/locale/ru/LC_MESSAGES/nemo.mo
+share/locale/rue/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/rue/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/rue/LC_MESSAGES/nemo.mo
+share/locale/rue/LC_MESSAGES/cinnamon-session.mo
+share/locale/rue/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/rue/LC_MESSAGES/cinnamon.mo
-share/locale/rw/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/rw/LC_MESSAGES/cinnamon-session.mo
+share/locale/rw/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/rw/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/sa/LC_MESSAGES/cinnamon.mo
+share/locale/sc/LC_MESSAGES/cinnamon.mo
+share/locale/sc/LC_MESSAGES/nemo.mo
 share/locale/sc/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/sc/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sc/LC_MESSAGES/cinnamon-session.mo
 share/locale/sc/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/sc/LC_MESSAGES/cinnamon.mo
-share/locale/sc/LC_MESSAGES/nemo.mo
-share/locale/sco/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sco/LC_MESSAGES/cinnamon-session.mo
+share/locale/sco/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sco/LC_MESSAGES/cinnamon.mo
-share/locale/shn/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/shn/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/shn/LC_MESSAGES/cinnamon.mo
 share/locale/shn/LC_MESSAGES/nemo.mo
-share/locale/si/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/si/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/si/LC_MESSAGES/cinnamon-session.mo
-share/locale/si/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/shn/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/shn/LC_MESSAGES/cinnamon.mo
+share/locale/shn/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/si/LC_MESSAGES/cinnamon.mo
 share/locale/si/LC_MESSAGES/nemo.mo
+share/locale/si/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/si/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/si/LC_MESSAGES/cinnamon-session.mo
+share/locale/si/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sk/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/sk/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sk/LC_MESSAGES/cinnamon-session.mo
@@ -584,8 +626,11 @@ share/locale/sl/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/sl/LC_MESSAGES/cinnamon.mo
 share/locale/sl/LC_MESSAGES/nemo-extensions.mo
 share/locale/sl/LC_MESSAGES/nemo.mo
+share/locale/so/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/so/LC_MESSAGES/cinnamon.mo
+share/locale/so/LC_MESSAGES/cinnamon-session.mo
 share/locale/so/LC_MESSAGES/nemo.mo
+share/locale/so/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sq/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/sq/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sq/LC_MESSAGES/cinnamon-session.mo
@@ -599,14 +644,15 @@ share/locale/sr/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/sr/LC_MESSAGES/cinnamon.mo
 share/locale/sr/LC_MESSAGES/nemo-extensions.mo
 share/locale/sr/LC_MESSAGES/nemo.mo
+share/locale/sr@ijekavian/LC_MESSAGES/cinnamon.mo
 share/locale/sr@ijekavianlatin/LC_MESSAGES/cinnamon.mo
+share/locale/sr@latin/LC_MESSAGES/nemo-extensions.mo
+share/locale/sr@latin/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/sr@latin/LC_MESSAGES/cinnamon.mo
+share/locale/sr@latin/LC_MESSAGES/nemo.mo
 share/locale/sr@latin/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/sr@latin/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sr@latin/LC_MESSAGES/cinnamon-session.mo
-share/locale/sr@latin/LC_MESSAGES/cinnamon-settings-daemon.mo
-share/locale/sr@latin/LC_MESSAGES/cinnamon.mo
-share/locale/sr@latin/LC_MESSAGES/nemo-extensions.mo
-share/locale/sr@latin/LC_MESSAGES/nemo.mo
 share/locale/sv/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/sv/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/sv/LC_MESSAGES/cinnamon-session.mo
@@ -616,8 +662,11 @@ share/locale/sv/LC_MESSAGES/nemo-extensions.mo
 share/locale/sv/LC_MESSAGES/nemo.mo
 share/locale/sw/LC_MESSAGES/cinnamon.mo
 share/locale/sw/LC_MESSAGES/nemo.mo
-share/locale/szl/LC_MESSAGES/cinnamon.mo
+share/locale/szl/LC_MESSAGES/cinnamon-session.mo
 share/locale/szl/LC_MESSAGES/nemo.mo
+share/locale/szl/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/szl/LC_MESSAGES/cinnamon.mo
+share/locale/szl/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ta/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ta/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ta/LC_MESSAGES/cinnamon-session.mo
@@ -625,11 +674,11 @@ share/locale/ta/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ta/LC_MESSAGES/cinnamon.mo
 share/locale/ta/LC_MESSAGES/nemo-extensions.mo
 share/locale/ta/LC_MESSAGES/nemo.mo
-share/locale/te/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/te/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/te/LC_MESSAGES/cinnamon-session.mo
 share/locale/te/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/te/LC_MESSAGES/cinnamon.mo
+share/locale/te/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/te/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/te/LC_MESSAGES/cinnamon-session.mo
 share/locale/tg/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/tg/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/tg/LC_MESSAGES/cinnamon-session.mo
@@ -644,12 +693,14 @@ share/locale/th/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/th/LC_MESSAGES/cinnamon.mo
 share/locale/th/LC_MESSAGES/nemo-extensions.mo
 share/locale/th/LC_MESSAGES/nemo.mo
+share/locale/ti/LC_MESSAGES/cinnamon.mo
 share/locale/tk/LC_MESSAGES/cinnamon-session.mo
+share/locale/tk/LC_MESSAGES/cinnamon.mo
+share/locale/tl/LC_MESSAGES/nemo.mo
+share/locale/tl/LC_MESSAGES/cinnamon-session.mo
 share/locale/tl/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/tl/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/tl/LC_MESSAGES/cinnamon-session.mo
 share/locale/tl/LC_MESSAGES/cinnamon.mo
-share/locale/tl/LC_MESSAGES/nemo.mo
 share/locale/tlh/LC_MESSAGES/cinnamon.mo
 share/locale/tlh/LC_MESSAGES/nemo.mo
 share/locale/tpi/LC_MESSAGES/cinnamon.mo
@@ -661,16 +712,17 @@ share/locale/tr/LC_MESSAGES/cinnamon.mo
 share/locale/tr/LC_MESSAGES/nemo-extensions.mo
 share/locale/tr/LC_MESSAGES/nemo.mo
 share/locale/ts/LC_MESSAGES/cinnamon.mo
-share/locale/tt/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/tt/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/tt/LC_MESSAGES/cinnamon-session.mo
-share/locale/tt/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/tt/LC_MESSAGES/cinnamon.mo
+share/locale/tt/LC_MESSAGES/nemo.mo
+share/locale/tt/LC_MESSAGES/cinnamon-session.mo
+share/locale/tt/LC_MESSAGES/cinnamon-screensaver.mo
+share/locale/tt/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/tt/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ug/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/ug/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/ug/LC_MESSAGES/cinnamon-session.mo
 share/locale/ug/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/ug/LC_MESSAGES/cinnamon.mo
+share/locale/ug/LC_MESSAGES/cinnamon-session.mo
 share/locale/uk/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/uk/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/uk/LC_MESSAGES/cinnamon-session.mo
@@ -678,19 +730,20 @@ share/locale/uk/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/uk/LC_MESSAGES/cinnamon.mo
 share/locale/uk/LC_MESSAGES/nemo-extensions.mo
 share/locale/uk/LC_MESSAGES/nemo.mo
-share/locale/ur/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/ur/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/ur/LC_MESSAGES/cinnamon-session.mo
 share/locale/ur/LC_MESSAGES/cinnamon.mo
+share/locale/ur/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/ur/LC_MESSAGES/nemo.mo
+share/locale/ur/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/ur/LC_MESSAGES/cinnamon-session.mo
 share/locale/uz/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/uz/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/uz/LC_MESSAGES/cinnamon-session.mo
 share/locale/uz/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/uz/LC_MESSAGES/cinnamon.mo
+share/locale/uz/LC_MESSAGES/nemo-extensions.mo
 share/locale/uz/LC_MESSAGES/nemo.mo
-share/locale/uz@cyrillic/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/uz@cyrillic/LC_MESSAGES/cinnamon-session.mo
+share/locale/uz@cyrillic/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/vi/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/vi/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/vi/LC_MESSAGES/cinnamon-session.mo
@@ -702,20 +755,20 @@ share/locale/wa/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/wa/LC_MESSAGES/cinnamon-session.mo
 share/locale/wa/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/wa/LC_MESSAGES/cinnamon.mo
-share/locale/xh/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/xh/LC_MESSAGES/cinnamon-screensaver.mo
-share/locale/xh/LC_MESSAGES/cinnamon-session.mo
 share/locale/xh/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/xh/LC_MESSAGES/cinnamon.mo
+share/locale/xh/LC_MESSAGES/cinnamon-session.mo
+share/locale/xh/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/yi/LC_MESSAGES/cinnamon.mo
 share/locale/yo/LC_MESSAGES/cinnamon-session.mo
+share/locale/zgh/LC_MESSAGES/nemo.mo
 share/locale/zgh/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/zgh/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/zgh/LC_MESSAGES/nemo-extensions.mo
 share/locale/zgh/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/zgh/LC_MESSAGES/cinnamon-session.mo
-share/locale/zgh/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/zgh/LC_MESSAGES/cinnamon.mo
-share/locale/zgh/LC_MESSAGES/nemo-extensions.mo
-share/locale/zgh/LC_MESSAGES/nemo.mo
 share/locale/zh_CN/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/zh_CN/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/zh_CN/LC_MESSAGES/cinnamon-session.mo
@@ -723,13 +776,13 @@ share/locale/zh_CN/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/zh_CN/LC_MESSAGES/cinnamon.mo
 share/locale/zh_CN/LC_MESSAGES/nemo-extensions.mo
 share/locale/zh_CN/LC_MESSAGES/nemo.mo
-share/locale/zh_HK/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/zh_HK/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/zh_HK/LC_MESSAGES/cinnamon-session.mo
+share/locale/zh_HK/LC_MESSAGES/nemo.mo
+share/locale/zh_HK/LC_MESSAGES/nemo-extensions.mo
 share/locale/zh_HK/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/zh_HK/LC_MESSAGES/cinnamon.mo
-share/locale/zh_HK/LC_MESSAGES/nemo-extensions.mo
-share/locale/zh_HK/LC_MESSAGES/nemo.mo
+share/locale/zh_HK/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/zh_HK/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/zh_TW/LC_MESSAGES/cinnamon-control-center.mo
 share/locale/zh_TW/LC_MESSAGES/cinnamon-screensaver.mo
 share/locale/zh_TW/LC_MESSAGES/cinnamon-session.mo
@@ -737,7 +790,179 @@ share/locale/zh_TW/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/zh_TW/LC_MESSAGES/cinnamon.mo
 share/locale/zh_TW/LC_MESSAGES/nemo-extensions.mo
 share/locale/zh_TW/LC_MESSAGES/nemo.mo
-share/locale/zu/LC_MESSAGES/cinnamon-control-center.mo
-share/locale/zu/LC_MESSAGES/cinnamon-session.mo
-share/locale/zu/LC_MESSAGES/cinnamon-settings-daemon.mo
 share/locale/zu/LC_MESSAGES/cinnamon.mo
+share/locale/zu/LC_MESSAGES/cinnamon-control-center.mo
+share/locale/zu/LC_MESSAGES/cinnamon-settings-daemon.mo
+share/locale/zu/LC_MESSAGES/cinnamon-session.mo
+@dir share/locale/aa/LC_MESSAGES
+@dir share/locale/aa
+@dir share/locale/an/LC_MESSAGES
+@dir share/locale/an
+@dir share/locale/ary/LC_MESSAGES
+@dir share/locale/ary
+@dir share/locale/as/LC_MESSAGES
+@dir share/locale/as
+@dir share/locale/ast/LC_MESSAGES
+@dir share/locale/ast
+@dir share/locale/ay/LC_MESSAGES
+@dir share/locale/ay
+@dir share/locale/be@latin/LC_MESSAGES
+@dir share/locale/be@latin
+@dir share/locale/ber/LC_MESSAGES
+@dir share/locale/ber
+@dir share/locale/bn_IN/LC_MESSAGES
+@dir share/locale/bn_IN
+@dir share/locale/ca@valencia/LC_MESSAGES
+@dir share/locale/ca@valencia
+@dir share/locale/ckb/LC_MESSAGES
+@dir share/locale/ckb
+@dir share/locale/crh/LC_MESSAGES
+@dir share/locale/crh
+@dir share/locale/csb/LC_MESSAGES
+@dir share/locale/csb
+@dir share/locale/dz/LC_MESSAGES
+@dir share/locale/dz
+@dir share/locale/en@shaw/LC_MESSAGES
+@dir share/locale/en@shaw
+@dir share/locale/en_IE/LC_MESSAGES
+@dir share/locale/en_IE
+@dir share/locale/en_NZ/LC_MESSAGES
+@dir share/locale/en_NZ
+@dir share/locale/en_ZA/LC_MESSAGES
+@dir share/locale/en_ZA
+@dir share/locale/es_AR/LC_MESSAGES
+@dir share/locale/es_AR
+@dir share/locale/fil/LC_MESSAGES
+@dir share/locale/fil
+@dir share/locale/fo/LC_MESSAGES
+@dir share/locale/fo
+@dir share/locale/fr_CA/LC_MESSAGES
+@dir share/locale/fr_CA
+@dir share/locale/frp/LC_MESSAGES
+@dir share/locale/frp
+@dir share/locale/fur/LC_MESSAGES
+@dir share/locale/fur
+@dir share/locale/fy/LC_MESSAGES
+@dir share/locale/fy
+@dir share/locale/gd/LC_MESSAGES
+@dir share/locale/gd
+@dir share/locale/ha/LC_MESSAGES
+@dir share/locale/ha
+@dir share/locale/hsb/LC_MESSAGES
+@dir share/locale/hsb
+@dir share/locale/hy/LC_MESSAGES
+@dir share/locale/hy
+@dir share/locale/ia/LC_MESSAGES
+@dir share/locale/ia
+@dir share/locale/ie/LC_MESSAGES
+@dir share/locale/ie
+@dir share/locale/ig/LC_MESSAGES
+@dir share/locale/ig
+@dir share/locale/jv/LC_MESSAGES
+@dir share/locale/jv
+@dir share/locale/kab/LC_MESSAGES
+@dir share/locale/kab
+@dir share/locale/kk/LC_MESSAGES
+@dir share/locale/kk
+@dir share/locale/km/LC_MESSAGES
+@dir share/locale/km
+@dir share/locale/ksw/LC_MESSAGES
+@dir share/locale/ksw
+@dir share/locale/ku/LC_MESSAGES
+@dir share/locale/ku
+@dir share/locale/ky/LC_MESSAGES
+@dir share/locale/ky
+@dir share/locale/la/LC_MESSAGES
+@dir share/locale/la
+@dir share/locale/lmo/LC_MESSAGES
+@dir share/locale/lmo
+@dir share/locale/lo/LC_MESSAGES
+@dir share/locale/lo
+@dir share/locale/mai/LC_MESSAGES
+@dir share/locale/mai
+@dir share/locale/mg/LC_MESSAGES
+@dir share/locale/mg
+@dir share/locale/mi/LC_MESSAGES
+@dir share/locale/mi
+@dir share/locale/mnw/LC_MESSAGES
+@dir share/locale/mnw
+@dir share/locale/mo/LC_MESSAGES
+@dir share/locale/mo
+@dir share/locale/mr/LC_MESSAGES
+@dir share/locale/mr
+@dir share/locale/my/LC_MESSAGES
+@dir share/locale/my
+@dir share/locale/nap/LC_MESSAGES
+@dir share/locale/nap
+@dir share/locale/nds/LC_MESSAGES
+@dir share/locale/nds
+@dir share/locale/nso/LC_MESSAGES
+@dir share/locale/nso
+@dir share/locale/oc/LC_MESSAGES
+@dir share/locale/oc
+@dir share/locale/om/LC_MESSAGES
+@dir share/locale/om
+@dir share/locale/pap/LC_MESSAGES
+@dir share/locale/pap
+@dir share/locale/ps/LC_MESSAGES
+@dir share/locale/ps
+@dir share/locale/qu/LC_MESSAGES
+@dir share/locale/qu
+@dir share/locale/rue/LC_MESSAGES
+@dir share/locale/rue
+@dir share/locale/rw/LC_MESSAGES
+@dir share/locale/rw
+@dir share/locale/sa/LC_MESSAGES
+@dir share/locale/sa
+@dir share/locale/sc/LC_MESSAGES
+@dir share/locale/sc
+@dir share/locale/sco/LC_MESSAGES
+@dir share/locale/sco
+@dir share/locale/shn/LC_MESSAGES
+@dir share/locale/shn
+@dir share/locale/si/LC_MESSAGES
+@dir share/locale/si
+@dir share/locale/so/LC_MESSAGES
+@dir share/locale/so
+@dir share/locale/sr@ijekavian/LC_MESSAGES
+@dir share/locale/sr@ijekavian
+@dir share/locale/sr@ijekavianlatin/LC_MESSAGES
+@dir share/locale/sr@ijekavianlatin
+@dir share/locale/sr@latin/LC_MESSAGES
+@dir share/locale/sr@latin
+@dir share/locale/sw/LC_MESSAGES
+@dir share/locale/sw
+@dir share/locale/szl/LC_MESSAGES
+@dir share/locale/szl
+@dir share/locale/te/LC_MESSAGES
+@dir share/locale/te
+@dir share/locale/ti/LC_MESSAGES
+@dir share/locale/ti
+@dir share/locale/tl/LC_MESSAGES
+@dir share/locale/tl
+@dir share/locale/tlh/LC_MESSAGES
+@dir share/locale/tlh
+@dir share/locale/tpi/LC_MESSAGES
+@dir share/locale/tpi
+@dir share/locale/ts/LC_MESSAGES
+@dir share/locale/ts
+@dir share/locale/tt/LC_MESSAGES
+@dir share/locale/tt
+@dir share/locale/ug/LC_MESSAGES
+@dir share/locale/ug
+@dir share/locale/ur/LC_MESSAGES
+@dir share/locale/ur
+@dir share/locale/uz@cyrillic/LC_MESSAGES
+@dir share/locale/uz@cyrillic
+@dir share/locale/xh/LC_MESSAGES
+@dir share/locale/xh
+@dir share/locale/yi/LC_MESSAGES
+@dir share/locale/yi
+@dir share/locale/yo/LC_MESSAGES
+@dir share/locale/yo
+@dir share/locale/zgh/LC_MESSAGES
+@dir share/locale/zgh
+@dir share/locale/zh_HK/LC_MESSAGES
+@dir share/locale/zh_HK
+@dir share/locale/zu/LC_MESSAGES
+@dir share/locale/zu


### PR DESCRIPTION
Updates Cinnamon Translations to 6.4.2 and regenerates the staged locale payload. Adds `NO_BUILD` and the upstream GPLv2 COPYING file reference while preserving MidnightBSD fake-destination staging.\n\nValidated: bmake makesum, patch, build, fake, package, test, check-license, and git diff --check. The port has no upstream test cases.\n\nThe isolated worktree retains generated artifacts, so portlint -C sees those as extra files; port-content warnings are non-fatal style advisories.

## Summary by Sourcery

Update the Cinnamon translations port to 6.4.2 with refreshed localization data and current packaging metadata.

Enhancements:
- Update Cinnamon translations to version 6.4.2 and refresh the packaged locale files.
- Mark the translation port as prebuilt and include the upstream license file for license compliance.