### PR TITLE
x11/cinnamon-session: update to 6.4.2

### DIFF
--- a/x11/cinnamon-session/Makefile
+++ b/x11/cinnamon-session/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	cinnamon-session
-PORTVERSION=	5.4.0
-PORTREVISION=	6
+PORTVERSION=	6.4.2
 CATEGORIES=	x11 gnome
 DIST_SUBDIR=	gnome
 
@@ -10,20 +9,21 @@ WWW=		https://github.com/linuxmint/cinnamon-session
 
 LICENSE=	gpl2
 
-LIB_DEPENDS=	libdbus-1.so:devel/dbus \
-		libdbus-glib-1.so:devel/dbus-glib \
-		libxapp.so:x11/xapp \
+LIB_DEPENDS=	libxapp.so:x11/xapp \
+		libcinnamon-desktop.so:x11/cinnamon-desktop \
 		libcanberra.so:audio/libcanberra
-RUN_DEPENDS=	console-kit-daemon:sysutils/consolekit2
+RUN_DEPENDS=	console-kit-daemon:sysutils/consolekit2 \
+		${PYTHON_PKGNAMEPREFIX}setproctitle>0:devel/py-setproctitle@${PY_FLAVOR}
 
 USES=		gl gnome meson pkgconfig python:build shebangfix xorg
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	linuxmint
 
-SHEBANG_FILES=	data/meson_install_schemas.py
+SHEBANG_GLOB=	*.py
 
-USE_GNOME=	cairo gdkpixbuf gtk30
+USE_GNOME=	cairo gdkpixbuf glib20 gtk30
+INSTALLS_ICONS=	yes
 USE_XORG=	ice sm x11 xau xcomposite xext xrender xtrans xtst
 USE_GL=		gl
 

--- a/x11/cinnamon-session/Makefile
+++ b/x11/cinnamon-session/Makefile
@@ -22,7 +22,7 @@ GH_ACCOUNT=	linuxmint
 
 SHEBANG_GLOB=	*.py
 
-USE_GNOME=	cairo gdkpixbuf glib20 gtk30
+USE_GNOME=	cairo gdkpixbuf glib20 gtk-update-icon-cache gtk30 pygobject3
 INSTALLS_ICONS=	yes
 USE_XORG=	ice sm x11 xau xcomposite xext xrender xtrans xtst
 USE_GL=		gl

--- a/x11/cinnamon-session/distinfo
+++ b/x11/cinnamon-session/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1656715196
-SHA256 (gnome/linuxmint-cinnamon-session-5.4.0_GH0.tar.gz) = c3c9351aecebe2abbb5d61663ad19af56fc6413ad6cddb5d753a614b23ec547d
-SIZE (gnome/linuxmint-cinnamon-session-5.4.0_GH0.tar.gz) = 199698
+TIMESTAMP = 1763860795
+SHA256 (gnome/linuxmint-cinnamon-session-6.4.2_GH0.tar.gz) = e4f0380ef45be08366fcdfbda431c6b0b20760d251ea78b810b4e0e223134690
+SIZE (gnome/linuxmint-cinnamon-session-6.4.2_GH0.tar.gz) = 166012

--- a/x11/cinnamon-session/pkg-plist
+++ b/x11/cinnamon-session/pkg-plist
@@ -1,10 +1,13 @@
 bin/cinnamon-session
 bin/cinnamon-session-quit
+libexec/cinnamon-session-binary
 libexec/cinnamon-session-check-accelerated
 libexec/cinnamon-session-check-accelerated-helper
 share/man/man1/cinnamon-session-quit.1.gz
 share/man/man1/cinnamon-session.1.gz
-%%DATADIR%%/csm-inhibit-dialog.glade
+%%DATADIR%%/cinnamon-session-quit.glade
+%%DATADIR%%/cinnamon-session-quit.py
+%%DATADIR%%/config.py
 %%DATADIR%%/hardware-compatibility
 share/icons/hicolor/16x16/apps/cinnamon-session-properties.png
 share/icons/hicolor/22x22/apps/cinnamon-session-properties.png


### PR DESCRIPTION
Updates Cinnamon Session to 6.4.2, removes the obsolete PORTREVISION, and aligns dependencies/plist with the current source while retaining the ConsoleKit fallback used on MidnightBSD. Adds icon-cache handling for the staged hicolor icons.\n\nLICENSE remains GPLv2. Validated: bmake makesum, patch, build, fake, package, test, check-license, portlint (port-content warnings only), and git diff --check. Upstream defines no tests.

## Summary by Sourcery

Update the cinnamon-session port to the 6.4.2 release and synchronize its packaging metadata with the upstream source.

Enhancements:
- Update Cinnamon Session to version 6.4.2 and align its dependencies, Python integration, icon handling, and package contents with the current release while retaining the ConsoleKit runtime dependency.

Chores:
- Remove the obsolete PORTREVISION.