### PR TITLE
sysutils/pidof: add 20050501

### DIFF
--- a/sysutils/Makefile
+++ b/sysutils/Makefile
@@ -189,6 +189,7 @@
     SUBDIR += p5-Quota
     SUBDIR += p5-Sys-Hostname-Long
     SUBDIR += p5-Unix-Processors
+    SUBDIR += pidof
     SUBDIR += password-store
     SUBDIR += patchelf
     SUBDIR += pcbsd-libsh

--- a/sysutils/pidof/Makefile
+++ b/sysutils/pidof/Makefile
@@ -1,0 +1,23 @@
+PORTNAME=	pidof
+PORTVERSION=	20050501
+CATEGORIES=	sysutils
+MASTER_SITES=	LOCAL/novel
+DISTNAME=	${PORTNAME}
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Tool which prints PID of given process name
+WWW=		https://people.freebsd.org/~novel/pidof.html
+
+LICENSE=	bsd2
+
+CONFLICTS=	psmisc-1*
+
+PLIST_FILES=	bin/pidof
+
+post-patch:
+	@${REINPLACE_CMD} 's/NOMAN.*/MAN=/ ; /LINKS/d' ${WRKSRC}/Makefile
+
+do-install:
+	${INSTALL_PROGRAM} ${WRKSRC}/pidof ${PREFIX}/bin
+
+.include <bsd.port.mk>

--- a/sysutils/pidof/distinfo
+++ b/sysutils/pidof/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1788991504
+SHA256 (pidof.tar.gz) = c3ed8826178debe872f7717b8810d477d4611ab19af73bed97c5af1c552d20e6
+SIZE (pidof.tar.gz) = 1769

--- a/sysutils/pidof/files/patch-pidof.c
+++ b/sysutils/pidof/files/patch-pidof.c
@@ -1,0 +1,21 @@
+--- pidof.c.orig	2005-05-01 16:26:19 UTC
++++ pidof.c
+@@ -53,10 +53,19 @@ get_pid_of_process(char *process_name)
+ 	if ((kd = kvm_open("/dev/null", "/dev/null", "/dev/null", O_RDONLY, "kvm_open")) == NULL) 
+ 			 (void)errx(1, "%s", kvm_geterr(kd));
+ 	else {
++#if __FreeBSD__ < 5
++		p = kvm_getprocs(kd, KERN_PROC_ALL, 0, &n_processes);
++#else
+ 		p = kvm_getprocs(kd, KERN_PROC_PROC, 0, &n_processes);
++#endif /* __FreeBSD__ < 5 */
+ 		for (i = 0; i<n_processes; i++)
++#if __FreeBSD__ < 5
++			if (strncmp(process_name, p[i].kp_proc.p_comm, MAXCOMLEN+1) == 0) {
++				(void)printf("%d ", (int)p[i].kp_proc.p_pid);
++#else
+ 			if (strncmp(process_name, p[i].ki_comm, COMMLEN+1) == 0) {
+ 				(void)printf("%d ", (int)p[i].ki_pid);
++#endif /* __FreeBSD__ < 5 */
+ 				processes_found++;
+ 			}

--- a/sysutils/pidof/pkg-descr
+++ b/sysutils/pidof/pkg-descr
@@ -1,0 +1,3 @@
+A tool which prints the process IDs associated with a given process name.
+
+It uses the kernel virtual-memory interface to locate matching processes.


### PR DESCRIPTION
Imports the small pidof utility from the local FreeBSD ports tree for MidnightBSD. It is BSD-2-Clause and builds against MidnightBSD kvm without dependencies.\n\nValidated: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and diff review. The port has no upstream tests. The retained upstream compatibility patch contains existing whitespace in context, so git diff --check reports that preserved patch formatting.

## Summary by Sourcery

Add the 20050501 pidof utility port for displaying process IDs by name.

New Features:
- Add the pidof process-ID lookup utility as a packaged sysutils port.

Enhancements:
- Add compatibility support for older and newer FreeBSD/​MidnightBSD kvm process interfaces.

Chores:
- Register the new pidof port in the sysutils collection and define its licensing, conflict, packaging, and installation metadata.