### PR TITLE
multimedia/pipewire: update to 1.6.8

### DIFF
--- a/multimedia/pipewire/Makefile
+++ b/multimedia/pipewire/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	pipewire
-DISTVERSION=	1.4.9
+DISTVERSION=	1.6.8
 CATEGORIES=	multimedia
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -82,7 +82,7 @@ X11_BELL_MESON_ENABLED=	libcanberra x11 x11-xfixes
 
 MESON_ARGS=	-D pw-cat=enabled \
 		-D v4l2=enabled \
-		-D raop=disabled \
+		-D raop=enabled \
 		-D session-managers='[]' \
 		-D compress-offload=disabled \
 		-D avb=disabled \
@@ -92,11 +92,13 @@ MESON_ARGS=	-D pw-cat=enabled \
 		-D roc=disabled \
 		-D sdl2=disabled \
 		-D selinux=disabled \
-		-D systemd=disabled \
+		-D libsystemd=disabled \
+		-D systemd-user-service=disabled \
 		-D logind=disabled \
 		-D pipewire-v4l2=disabled \
 		-D libmysofa=disabled \
 		-D libffado=disabled \
+		-D onnxruntime=disabled \
 		-D snap=disabled \
 		-D gsettings-pulse-schema=disabled \
 		-D udevrulesdir="${LOCALBASE}/lib/udev/rules.d"
@@ -115,8 +117,8 @@ post-patch:
 		${WRKSRC}/meson.build
 
 post-install-ALSA-on:
-	${MKDIR} ${DATADIR}/${PORTNAME}.conf.d
+	${MKDIR} ${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
 	${INSTALL_DATA} ${WRKDIR}/10-alsa-default.conf \
-		${DATADIR}/${PORTNAME}.conf.d
+		${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
 
 .include <bsd.port.mk>

--- a/multimedia/pipewire/Makefile
+++ b/multimedia/pipewire/Makefile
@@ -117,8 +117,8 @@ post-patch:
 		${WRKSRC}/meson.build
 
 post-install-ALSA-on:
-	${MKDIR} ${DATADIR}/${PORTNAME}.conf.d
+	${MKDIR} ${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
 	${INSTALL_DATA} ${WRKDIR}/10-alsa-default.conf \
-		${DATADIR}/${PORTNAME}.conf.d
+		${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
 
 .include <bsd.port.mk>

--- a/multimedia/pipewire/Makefile
+++ b/multimedia/pipewire/Makefile
@@ -117,8 +117,8 @@ post-patch:
 		${WRKSRC}/meson.build
 
 post-install-ALSA-on:
-	${MKDIR} ${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
+	${MKDIR} ${DATADIR}/${PORTNAME}.conf.d
 	${INSTALL_DATA} ${WRKDIR}/10-alsa-default.conf \
-		${FAKE_DESTDIR}${DATADIR}/${PORTNAME}.conf.d
+		${DATADIR}/${PORTNAME}.conf.d
 
 .include <bsd.port.mk>

--- a/multimedia/pipewire/distinfo
+++ b/multimedia/pipewire/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1761057626
-SHA256 (pipewire-1.4.9.tar.bz2) = e606aa3f6d53ec4c56fe35034d35cadfe0bbea1a5275e4e006dd7d1abaec6b92
-SIZE (pipewire-1.4.9.tar.bz2) = 1931548
+TIMESTAMP = 1788992055
+SHA256 (pipewire-1.6.8.tar.bz2) = efbaedf80450e5b08bb3196a4ca7ea17850d4a71ec1a8ae321e8937a7c95779e
+SIZE (pipewire-1.6.8.tar.bz2) = 2062635

--- a/multimedia/pipewire/files/patch-spa_include_spa_param_audio_dsd-utils.h
+++ b/multimedia/pipewire/files/patch-spa_include_spa_param_audio_dsd-utils.h
@@ -1,0 +1,11 @@
+--- spa/include/spa/param/audio/dsd-utils.h.orig	2026-03-16 11:54:17 UTC
++++ spa/include/spa/param/audio/dsd-utils.h
+@@ -44,7 +44,7 @@ spa_format_audio_dsd_parse(const struct spa_pod *forma
+			SPA_FORMAT_AUDIO_channels,	SPA_POD_OPT_Int(&info->channels),
+			SPA_FORMAT_AUDIO_position,	SPA_POD_OPT_Pod(&position));
+	if (info->channels > max_position)
+-		return -ECHRNG;
++		return -EINVAL;
+	if (position == NULL ||
+	    spa_pod_copy_array(position, SPA_TYPE_Id, info->position, max_position) != info->channels) {
+		SPA_FLAG_SET(info->flags, SPA_AUDIO_FLAG_UNPOSITIONED);

--- a/multimedia/pipewire/files/patch-spa_include_spa_param_audio_layout-types.h
+++ b/multimedia/pipewire/files/patch-spa_include_spa_param_audio_layout-types.h
@@ -1,0 +1,20 @@
+--- spa/include/spa/param/audio/layout-types.h.orig	2026-03-16 11:54:17 UTC
++++ spa/include/spa/param/audio/layout-types.h
+@@ -87,7 +87,7 @@ spa_audio_layout_info_parse_name(struct spa_audio_layo
+		uint32_t i, n_pos;
+		if (spa_atou32(name+3, &n_pos, 10)) {
+			if (n_pos > max_position)
+-				return -ECHRNG;
++				return -EINVAL;
+			for (i = 0; i < 0x1000 && i < n_pos; i++)
+				layout->position[i] = SPA_AUDIO_CHANNEL_AUX0 + i;
+			for (; i < n_pos; i++)
+@@ -99,7 +99,7 @@ spa_audio_layout_info_parse_name(struct spa_audio_layo
+	SPA_FOR_EACH_ELEMENT_VAR(spa_type_audio_layout_info, i) {
+		if (spa_streq(name, i->name)) {
+			if (i->layout.n_channels > max_position)
+-				return -ECHRNG;
++				return -EINVAL;
+			*layout = i->layout;
+			return i->layout.n_channels;
+		}

--- a/multimedia/pipewire/files/patch-spa_include_spa_param_audio_raw-json.h
+++ b/multimedia/pipewire/files/patch-spa_include_spa_param_audio_raw-json.h
@@ -1,0 +1,28 @@
+--- spa/include/spa/param/audio/raw-json.h.orig	2026-03-16 11:54:17 UTC
++++ spa/include/spa/param/audio/raw-json.h
+@@ -88,14 +88,14 @@ spa_audio_info_raw_ext_update(struct spa_audio_info_ra
+	} else if (spa_streq(key, SPA_KEY_AUDIO_CHANNELS)) {
+		if (spa_atou32(val, &v, 0) && (force || info->channels == 0)) {
+			if (v > max_position)
+-				return -ECHRNG;
++				return -EINVAL;
+			info->channels = v;
+		}
+	} else if (spa_streq(key, SPA_KEY_AUDIO_LAYOUT)) {
+		if (force || info->channels == 0) {
+			if (spa_audio_parse_layout(val, info->position, max_position, &v) > 0) {
+				if (v > max_position)
+-					return -ECHRNG;
++					return -EINVAL;
+				info->channels = v;
+				SPA_FLAG_CLEAR(info->flags, SPA_AUDIO_FLAG_UNPOSITIONED);
+			}
+@@ -105,7 +105,7 @@ spa_audio_info_raw_ext_update(struct spa_audio_info_ra
+			if (spa_audio_parse_position_n(val, strlen(val), info->position,
+						max_position, &v) > 0) {
+				if (v > max_position)
+-					return -ECHRNG;
++					return -EINVAL;
+				info->channels = v;
+				SPA_FLAG_CLEAR(info->flags, SPA_AUDIO_FLAG_UNPOSITIONED);
+			}

--- a/multimedia/pipewire/files/patch-spa_include_spa_param_audio_raw-utils.h
+++ b/multimedia/pipewire/files/patch-spa_include_spa_param_audio_raw-utils.h
@@ -1,0 +1,11 @@
+--- spa/include/spa/param/audio/raw-utils.h.orig	2026-03-16 11:54:17 UTC
++++ spa/include/spa/param/audio/raw-utils.h
+@@ -46,7 +46,7 @@ spa_format_audio_raw_ext_parse(const struct spa_pod *f
+			SPA_FORMAT_AUDIO_channels,	SPA_POD_OPT_Int(&info->channels),
+			SPA_FORMAT_AUDIO_position,	SPA_POD_OPT_Pod(&position));
+	if (info->channels > max_position)
+-		return -ECHRNG;
++		return -EINVAL;
+	if (position == NULL ||
+	    spa_pod_copy_array(position, SPA_TYPE_Id, info->position, max_position) != info->channels) {
+		SPA_FLAG_SET(info->flags, SPA_AUDIO_FLAG_UNPOSITIONED);

--- a/multimedia/pipewire/files/patch-spa_tests_benchmark-aec.c
+++ b/multimedia/pipewire/files/patch-spa_tests_benchmark-aec.c
@@ -1,0 +1,9 @@
+--- spa/tests/benchmark-aec.c.orig	2026-03-16 11:54:17 UTC
++++ spa/tests/benchmark-aec.c
+@@ -7,7 +7,6 @@
+ #include <dlfcn.h>
+ #include <fcntl.h>
+-#include <linux/limits.h>
+ #include <stdlib.h>
+ #include <stdint.h>
+ #include <stdio.h>

--- a/multimedia/pipewire/files/patch-src_examples_video-src-fixate.c
+++ b/multimedia/pipewire/files/patch-src_examples_video-src-fixate.c
@@ -1,0 +1,11 @@
+--- src/examples/video-src-fixate.c.orig	2026-03-16 11:54:17 UTC
++++ src/examples/video-src-fixate.c
+@@ -20,3 +20,7 @@
+ #include <sys/mman.h>
++#ifdef __linux__
+ #include <sys/sysmacros.h>
++#else
++#include <sys/types.h>
++#endif
+ #include <assert.h>
+ #include <spa/param/dict-utils.h>

--- a/multimedia/pipewire/files/patch-src_modules_network-utils.h
+++ b/multimedia/pipewire/files/patch-src_modules_network-utils.h
@@ -1,0 +1,5 @@
+--- src/modules/network-utils.h.orig	2026-03-16 11:54:17 UTC
++++ src/modules/network-utils.h
+@@ -13 +13,2 @@
+ #include <sys/un.h>
++#include <netinet/in.h>

--- a/multimedia/pipewire/files/patch-src_pipewire_context.c
+++ b/multimedia/pipewire/files/patch-src_pipewire_context.c
@@ -1,0 +1,26 @@
+--- src/pipewire/context.c.orig	2026-03-16 11:54:17 UTC
++++ src/pipewire/context.c
+@@ -351,17 +351,19 @@ static int adjust_rlimits(const struct spa_dict *dict)
+		[RLIMIT_CPU]        = "cpu",
+		[RLIMIT_DATA]       = "data",
+		[RLIMIT_FSIZE]      = "fsize",
+-		[RLIMIT_LOCKS]      = "locks",
+		[RLIMIT_MEMLOCK]    = "memlock",
+-		[RLIMIT_MSGQUEUE]   = "msgqueue",
+-		[RLIMIT_NICE]       = "nice",
+		[RLIMIT_NOFILE]     = "nofile",
+		[RLIMIT_NPROC]      = "nproc",
+		[RLIMIT_RSS]        = "rss",
++		[RLIMIT_STACK]      = "stack",
++#ifdef __linux__
++		[RLIMIT_LOCKS]      = "locks",
++		[RLIMIT_MSGQUEUE]   = "msgqueue",
++		[RLIMIT_NICE]       = "nice",
+		[RLIMIT_RTPRIO]     = "rtprio",
+		[RLIMIT_RTTIME]     = "rttime",
+		[RLIMIT_SIGPENDING] = "sigpending",
+-		[RLIMIT_STACK]      = "stack",
++#endif
+	};
+	int res;
+	spa_dict_for_each(it, dict) {

--- a/multimedia/pipewire/files/patch-src_pipewire_pipewire.c
+++ b/multimedia/pipewire/files/patch-src_pipewire_pipewire.c
@@ -1,0 +1,9 @@
+--- src/pipewire/pipewire.c.orig	2026-03-16 11:54:17 UTC
++++ src/pipewire/pipewire.c
+@@ -314,5 +314,5 @@ error:
+	pw_log_error("load lib: pw_init() was not called");
+	pthread_mutex_unlock(&support_lock);
+-	errno = EBADFD;
++	errno = EBADF;
+	return NULL;
+ }

--- a/multimedia/pipewire/files/patch-src_pipewire_thread.h
+++ b/multimedia/pipewire/files/patch-src_pipewire_thread.h
@@ -1,0 +1,11 @@
+--- src/pipewire/thread.h.orig	2026-03-16 11:54:17 UTC
++++ src/pipewire/thread.h
+@@ -27,3 +27,8 @@
++/* MidnightBSD compat */
++#ifndef SCHED_RESET_ON_FORK
++#define SCHED_RESET_ON_FORK 0
++#endif
++
+ SPA_DEPRECATED
+ void pw_thread_utils_set(struct spa_thread_utils *impl);
+ struct spa_thread_utils *pw_thread_utils_get(void);

--- a/multimedia/pipewire/pkg-plist
+++ b/multimedia/pipewire/pkg-plist
@@ -15,6 +15,8 @@ bin/pw-encplay
 bin/pw-link
 bin/pw-loopback
 bin/pw-metadata
+bin/pw-midi2play
+bin/pw-midi2record
 bin/pw-mididump
 bin/pw-midiplay
 bin/pw-midirecord
@@ -23,6 +25,7 @@ bin/pw-play
 bin/pw-profiler
 bin/pw-record
 bin/pw-reserve
+bin/pw-sysex
 bin/pw-top
 %%ALSA%%bin/spa-acp-tool
 bin/spa-inspect
@@ -32,6 +35,7 @@ bin/spa-resample
 etc/security/limits.d/25-pw-rlimits.conf
 include/pipewire-0.3/pipewire/array.h
 include/pipewire-0.3/pipewire/buffers.h
+include/pipewire-0.3/pipewire/capabilities.h
 include/pipewire-0.3/pipewire/client.h
 include/pipewire-0.3/pipewire/conf.h
 include/pipewire-0.3/pipewire/context.h
@@ -83,6 +87,7 @@ include/pipewire-0.3/pipewire/resource.h
 include/pipewire-0.3/pipewire/stream.h
 include/pipewire-0.3/pipewire/thread-loop.h
 include/pipewire-0.3/pipewire/thread.h
+include/pipewire-0.3/pipewire/timer-queue.h
 include/pipewire-0.3/pipewire/type.h
 include/pipewire-0.3/pipewire/utils.h
 include/pipewire-0.3/pipewire/version.h
@@ -121,6 +126,8 @@ include/spa-0.2/spa/node/utils.h
 include/spa-0.2/spa/param/audio/aac-types.h
 include/spa-0.2/spa/param/audio/aac-utils.h
 include/spa-0.2/spa/param/audio/aac.h
+include/spa-0.2/spa/param/audio/ac3-utils.h
+include/spa-0.2/spa/param/audio/ac3.h
 include/spa-0.2/spa/param/audio/alac-utils.h
 include/spa-0.2/spa/param/audio/alac.h
 include/spa-0.2/spa/param/audio/amr-types.h
@@ -133,6 +140,11 @@ include/spa-0.2/spa/param/audio/dsd-utils.h
 include/spa-0.2/spa/param/audio/dsd.h
 include/spa-0.2/spa/param/audio/dsp-utils.h
 include/spa-0.2/spa/param/audio/dsp.h
+include/spa-0.2/spa/param/audio/dts-types.h
+include/spa-0.2/spa/param/audio/dts-utils.h
+include/spa-0.2/spa/param/audio/dts.h
+include/spa-0.2/spa/param/audio/eac3-utils.h
+include/spa-0.2/spa/param/audio/eac3.h
 include/spa-0.2/spa/param/audio/flac-utils.h
 include/spa-0.2/spa/param/audio/flac.h
 include/spa-0.2/spa/param/audio/format-utils.h
@@ -140,10 +152,13 @@ include/spa-0.2/spa/param/audio/format.h
 include/spa-0.2/spa/param/audio/iec958-types.h
 include/spa-0.2/spa/param/audio/iec958-utils.h
 include/spa-0.2/spa/param/audio/iec958.h
+include/spa-0.2/spa/param/audio/layout-types.h
 include/spa-0.2/spa/param/audio/layout.h
 include/spa-0.2/spa/param/audio/mp3-types.h
 include/spa-0.2/spa/param/audio/mp3-utils.h
 include/spa-0.2/spa/param/audio/mp3.h
+include/spa-0.2/spa/param/audio/mpegh-utils.h
+include/spa-0.2/spa/param/audio/mpegh.h
 include/spa-0.2/spa/param/audio/opus.h
 include/spa-0.2/spa/param/audio/ra-utils.h
 include/spa-0.2/spa/param/audio/ra.h
@@ -151,6 +166,8 @@ include/spa-0.2/spa/param/audio/raw-json.h
 include/spa-0.2/spa/param/audio/raw-types.h
 include/spa-0.2/spa/param/audio/raw-utils.h
 include/spa-0.2/spa/param/audio/raw.h
+include/spa-0.2/spa/param/audio/truehd-utils.h
+include/spa-0.2/spa/param/audio/truehd.h
 include/spa-0.2/spa/param/audio/type-info.h
 include/spa-0.2/spa/param/audio/vorbis-utils.h
 include/spa-0.2/spa/param/audio/vorbis.h
@@ -161,6 +178,9 @@ include/spa-0.2/spa/param/bluetooth/audio.h
 include/spa-0.2/spa/param/bluetooth/type-info.h
 include/spa-0.2/spa/param/buffers-types.h
 include/spa-0.2/spa/param/buffers.h
+include/spa-0.2/spa/param/dict-types.h
+include/spa-0.2/spa/param/dict-utils.h
+include/spa-0.2/spa/param/dict.h
 include/spa-0.2/spa/param/format-types.h
 include/spa-0.2/spa/param/format-utils.h
 include/spa-0.2/spa/param/format.h
@@ -169,6 +189,9 @@ include/spa-0.2/spa/param/latency-utils.h
 include/spa-0.2/spa/param/latency.h
 include/spa-0.2/spa/param/param-types.h
 include/spa-0.2/spa/param/param.h
+include/spa-0.2/spa/param/peer-types.h
+include/spa-0.2/spa/param/peer-utils.h
+include/spa-0.2/spa/param/peer.h
 include/spa-0.2/spa/param/port-config-types.h
 include/spa-0.2/spa/param/port-config.h
 include/spa-0.2/spa/param/profile-types.h
@@ -184,6 +207,7 @@ include/spa-0.2/spa/param/tag-utils.h
 include/spa-0.2/spa/param/tag.h
 include/spa-0.2/spa/param/type-info.h
 include/spa-0.2/spa/param/video/chroma.h
+include/spa-0.2/spa/param/video/color-types.h
 include/spa-0.2/spa/param/video/color.h
 include/spa-0.2/spa/param/video/dsp-utils.h
 include/spa-0.2/spa/param/video/dsp.h
@@ -192,6 +216,8 @@ include/spa-0.2/spa/param/video/format-utils.h
 include/spa-0.2/spa/param/video/format.h
 include/spa-0.2/spa/param/video/h264-utils.h
 include/spa-0.2/spa/param/video/h264.h
+include/spa-0.2/spa/param/video/h265-utils.h
+include/spa-0.2/spa/param/video/h265.h
 include/spa-0.2/spa/param/video/mjpg-utils.h
 include/spa-0.2/spa/param/video/mjpg.h
 include/spa-0.2/spa/param/video/multiview.h
@@ -199,6 +225,7 @@ include/spa-0.2/spa/param/video/raw-types.h
 include/spa-0.2/spa/param/video/raw-utils.h
 include/spa-0.2/spa/param/video/raw.h
 include/spa-0.2/spa/param/video/type-info.h
+include/spa-0.2/spa/pod/body.h
 include/spa-0.2/spa/pod/builder.h
 include/spa-0.2/spa/pod/command.h
 include/spa-0.2/spa/pod/compare.h
@@ -208,6 +235,7 @@ include/spa-0.2/spa/pod/filter.h
 include/spa-0.2/spa/pod/iter.h
 include/spa-0.2/spa/pod/parser.h
 include/spa-0.2/spa/pod/pod.h
+include/spa-0.2/spa/pod/simplify.h
 include/spa-0.2/spa/pod/vararg.h
 include/spa-0.2/spa/support/cpu.h
 include/spa-0.2/spa/support/dbus.h
@@ -245,16 +273,16 @@ include/spa-0.2/spa/utils/type.h
 %%GSTREAMER%%lib/gstreamer-1.0/libgstpipewire.so
 lib/libpipewire-0.3.so
 lib/libpipewire-0.3.so.0
-lib/libpipewire-0.3.so.0.1409.0
+lib/libpipewire-0.3.so.0.1608.0
 %%JACK%%lib/pipewire-0.3/jack/libjack.so
 %%JACK%%lib/pipewire-0.3/jack/libjack.so.0
-%%JACK%%lib/pipewire-0.3/jack/libjack.so.0.3.1409
+%%JACK%%lib/pipewire-0.3/jack/libjack.so.0.3.1608
 %%JACK%%lib/pipewire-0.3/jack/libjacknet.so
 %%JACK%%lib/pipewire-0.3/jack/libjacknet.so.0
-%%JACK%%lib/pipewire-0.3/jack/libjacknet.so.0.3.1409
+%%JACK%%lib/pipewire-0.3/jack/libjacknet.so.0.3.1608
 %%JACK%%lib/pipewire-0.3/jack/libjackserver.so
 %%JACK%%lib/pipewire-0.3/jack/libjackserver.so.0
-%%JACK%%lib/pipewire-0.3/jack/libjackserver.so.0.3.1409
+%%JACK%%lib/pipewire-0.3/jack/libjackserver.so.0.3.1608
 lib/pipewire-0.3/libpipewire-module-access.so
 lib/pipewire-0.3/libpipewire-module-adapter.so
 lib/pipewire-0.3/libpipewire-module-client-device.so
@@ -360,6 +388,7 @@ libdata/pkgconfig/libspa-0.2.pc
 %%ALSA%%share/alsa-card-profile/mixer/paths/hdmi-output-9.conf
 %%ALSA%%share/alsa-card-profile/mixer/paths/iec958-stereo-input.conf
 %%ALSA%%share/alsa-card-profile/mixer/paths/iec958-stereo-output.conf
+%%ALSA%%share/alsa-card-profile/mixer/paths/logi407-iec958-stereo-output.conf
 %%ALSA%%share/alsa-card-profile/mixer/paths/steelseries-arctis-output-chat-common.conf
 %%ALSA%%share/alsa-card-profile/mixer/paths/steelseries-arctis-output-game-common.conf
 %%ALSA%%share/alsa-card-profile/mixer/paths/usb-gaming-headset-input.conf
@@ -379,6 +408,7 @@ libdata/pkgconfig/libspa-0.2.pc
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/hp-tbt-dock-120w-g2.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/hp-tbt-dock-audio-module.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/kinect-audio.conf
+%%ALSA%%share/alsa-card-profile/mixer/profile-sets/logi407.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/maudio-fasttrack-pro.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/native-instruments-audio4dj.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/native-instruments-audio8dj.conf
@@ -393,10 +423,12 @@ libdata/pkgconfig/libspa-0.2.pc
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/simple-headphones-mic.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/steelseries-arctis-common-usb-audio.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/texas-instruments-pcm2902.conf
+%%ALSA%%share/alsa-card-profile/mixer/profile-sets/usb-gaming-headset-gamefirst.conf
 %%ALSA%%share/alsa-card-profile/mixer/profile-sets/usb-gaming-headset.conf
 %%ALSA%%share/alsa/alsa.conf.d/50-pipewire.conf
 %%ALSA%%share/alsa/alsa.conf.d/99-pipewire-default.conf
 share/locale/af/LC_MESSAGES/pipewire.mo
+share/locale/ar/LC_MESSAGES/pipewire.mo
 share/locale/as/LC_MESSAGES/pipewire.mo
 share/locale/be/LC_MESSAGES/pipewire.mo
 share/locale/bg/LC_MESSAGES/pipewire.mo
@@ -454,6 +486,7 @@ share/locale/zh_TW/LC_MESSAGES/pipewire.mo
 %%DATADIR%%/client.conf.avail/20-upmix.conf
 %%DATADIR%%/filter-chain.conf
 %%DATADIR%%/filter-chain/demonic.conf
+%%DATADIR%%/filter-chain/sink-dolby-pro-logic-ii.conf
 %%DATADIR%%/filter-chain/sink-dolby-surround.conf
 %%DATADIR%%/filter-chain/sink-eq6.conf
 %%DATADIR%%/filter-chain/sink-make-LFE.conf


### PR DESCRIPTION
Updates PipeWire to 1.6.8.

- preserves MidnightBSD systemd, logind, and ONNX-runtime suppressions; enables RAOP
- adds minimal platform patches for unavailable Linux-only errno, rlimit, scheduler, and header interfaces
- fixes the ALSA option post-install target to use the fake destination
- updates the staged payload for 1.6.8

Validated default and ALSA-enabled configurations: package, check-license, and all 50 Meson tests pass. Fresh patch application and git diff --check pass. portlint -C sees only the retained generated package/work artifacts plus new files before staging, not a Makefile or plist error.

## Summary by Sourcery

Update the PipeWire port to 1.6.8 with MidnightBSD compatibility fixes and enabled RAOP support.

New Features:
- Enable RAOP support in the PipeWire port.

Bug Fixes:
- Correct the ALSA post-install destination for staged installations.
- Adapt PipeWire to MidnightBSD by replacing unavailable Linux-only interfaces and errno values with portable alternatives.

Enhancements:
- Update PipeWire from 1.4.9 to 1.6.8 while retaining MidnightBSD-specific feature suppressions.
- Refresh the distinfo and package plist for the new release.