### PR TITLE
japanese/skk-tools: update to 1.3.4.40

### DIFF
--- a/japanese/skk-tools/Makefile
+++ b/japanese/skk-tools/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	skk-tools
-DISTVERSION=	1.3.4-28
-PORTREVISION=	1
-DISTVERSIONSUFFIX=	-g1e8c457
+DISTVERSION=	1.3.4-40
+DISTVERSIONSUFFIX=	-g7bfccbc
 PORTEPOCH=	1
 CATEGORIES=	japanese
 
@@ -34,9 +33,6 @@ DIFF_RUN_DEPENDS=	gosh:lang/gauche
 DIFF_PLIST_FILES=	bin/skkdic-diff
 DIFF_PORTDOCS=		README.skkdic-diff.md
 DIFF_VARS=		SHEBANG_FILES+=skkdic-diff.scm SHEBANG_LANG=gosh
-
-post-extract:
-	@${REINPLACE_CMD} -e 's|skk2cdb.py|skk2cdb|' ${WRKSRC}/skk2cdb.py
 
 post-install:
 	${INSTALL_SCRIPT} ${WRKSRC}/skk2cdb.py ${PREFIX}/bin/skk2cdb

--- a/japanese/skk-tools/distinfo
+++ b/japanese/skk-tools/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1716072620
-SHA256 (skk-dev-skktools-1.3.4-28-g1e8c457_GH0.tar.gz) = ead6bf5d601370048357d05c37d21b6c6b05be36633c8a02fbfed2be13f1adb7
-SIZE (skk-dev-skktools-1.3.4-28-g1e8c457_GH0.tar.gz) = 498683
+TIMESTAMP = 1788993415
+SHA256 (skk-dev-skktools-1.3.4-40-g7bfccbc_GH0.tar.gz) = 2fa40c38872297e3274682d89c398bb1bf7363cd2329e8cf191d74074f3674c6
+SIZE (skk-dev-skktools-1.3.4-40-g7bfccbc_GH0.tar.gz) = 500093


### PR DESCRIPTION
Updates skk-tools to upstream snapshot 1.3.4-40-g7bfccbc.

The obsolete post-extract comment rewrite is removed: the installed command derives its usage name from argv[0], so it was not needed for runtime or staging. MidnightBSD fake-install semantics remain unchanged; no UCL scripts were imported.

Validated: makesum, patch, build, fake, package, test target, check-license, portlint -C, and diff check. The isolated worktree retains only the generated local package artifact.

## Summary by Sourcery

Update the Japanese skk-tools port to the latest upstream snapshot and remove obsolete staging logic.

Enhancements:
- Update skk-tools to the upstream 1.3.4-40 snapshot.
- Remove the obsolete post-extract command-name rewrite.