### PR TITLE
sysutils/plasma6-systemsettings: bump revision for accountsservice ABI

### DIFF
--- a/sysutils/plasma6-systemsettings/Makefile
+++ b/sysutils/plasma6-systemsettings/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	systemsettings
 DISTVERSION=	${KDE_PLASMA_VERSION}
+PORTREVISION=	1
 CATEGORIES=	sysutils kde kde-plasma
 
 MAINTAINER=	ports@MidnightBSD.org


### PR DESCRIPTION
Rebuild for the pending AccountsService libaccountsservice.so.0 -> .so.1 ABI transition in PR #1052.

Validated: bmake -V PORTREVISION and diff check. portlint -C retains a pre-existing Makefile layout fatal outside this revision-only change.

## Summary by Sourcery

Enhancements:
- Bump the port revision to trigger a rebuild for the upcoming AccountsService ABI transition.