### PR TITLE
x11/xfce4-whiskermenu-plugin: bump revision for accountsservice ABI

### DIFF
--- a/x11/xfce4-whiskermenu-plugin/Makefile
+++ b/x11/xfce4-whiskermenu-plugin/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	xfce4-whiskermenu-plugin
 PORTVERSION=	2.10.0
+PORTREVISION=	1
 CATEGORIES=	x11 xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4


### PR DESCRIPTION
Rebuild for the pending AccountsService libaccountsservice.so.0 -> .so.1 ABI transition in PR #1052.

Validated: bmake -V PORTREVISION, portlint -C (0 fatal), and diff check.

## Summary by Sourcery

Enhancements:
- Bump the xfce4-whiskermenu-plugin port revision to rebuild it for the upcoming AccountsService ABI transition.