### PR TITLE
deskutils/xdg-terminal-exec: update to 0.14.3

### DIFF
--- a/deskutils/xdg-terminal-exec/Makefile
+++ b/deskutils/xdg-terminal-exec/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	xdg-terminal-exec
 DISTVERSIONPREFIX=v
-DISTVERSION=	0.14.1
+DISTVERSION=	0.14.3
 CATEGORIES=	deskutils
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -11,18 +11,20 @@ LICENSE=	gpl3
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
 BUILD_DEPENDS=	ginstall:sysutils/coreutils
+TEST_DEPENDS=	bats:devel/bats-core
 
 USES=		gmake
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	Vladimir-csp
 
-MAKE_ARGS=	prefix=${FAKE_DESTDIR}${TRUE_PREFIX}
+MAKE_ARGS=	prefix=${TRUE_PREFIX}
+TEST_ENV=	HOME=${WRKDIR}
+TEST_TARGET=	test
 
 BINARY_ALIAS=	install=ginstall
 OPTIONS_SUB=	yes
 NO_ARCH=	yes
-NO_TEST=	yes
 
 OPTIONS_DEFINE=	MANPAGES
 

--- a/deskutils/xdg-terminal-exec/distinfo
+++ b/deskutils/xdg-terminal-exec/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1765984984
-SHA256 (Vladimir-csp-xdg-terminal-exec-v0.14.1_GH0.tar.gz) = b96f7a4ac67a6fce78e92f14129183c06e517c2946c484851dc7bb473504ad47
-SIZE (Vladimir-csp-xdg-terminal-exec-v0.14.1_GH0.tar.gz) = 42972
+TIMESTAMP = 1788996530
+SHA256 (Vladimir-csp-xdg-terminal-exec-v0.14.3_GH0.tar.gz) = 82ac2dfdb357361d15f5163cdeb3cfd457bbb30bf5d2e14436393f493bd32afe
+SIZE (Vladimir-csp-xdg-terminal-exec-v0.14.3_GH0.tar.gz) = 43291


### PR DESCRIPTION
Updates xdg-terminal-exec to 0.14.3.

- Corrects the existing doubled fake-install prefix: the mports framework supplies the fake destination to the base install target.
- Restores the upstream Bats suite with an isolated HOME.
- Requires devel/bats-core from PR #1066 for tests.

Validation: bmake makesum, patch, build, fake, package, bmake -DNO_DEPENDS test (24/24 upstream tests), check-license, portlint -C (0 fatal), and git diff --check. The NO_DEPENDS test invocation is only needed in this isolated worktree until #1066 supplies the declared origin.

## Summary by Sourcery

Update xdg-terminal-exec to 0.14.3 and restore automated upstream testing.

Bug Fixes:
- Correct the package installation prefix handling to avoid duplicating the fake-install destination.

Enhancements:
- Update xdg-terminal-exec to version 0.14.3.
- Enable the upstream Bats test suite with an isolated HOME environment.

Tests:
- Add bats-core as a test dependency and run the upstream test target.