### PR TITLE
editors/gedit-plugins: update to 50.0

### DIFF
--- a/editors/gedit-plugins/Makefile
+++ b/editors/gedit-plugins/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gedit-plugins
-DISTVERSION=	49.0
+DISTVERSION=	50.0
 CATEGORIES=	editors gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -11,12 +11,12 @@ WWW=		https://gitlab.gnome.org/World/gedit/gedit-plugins
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	gedit=49.0:editors/gedit \
+BUILD_DEPENDS=	gedit>=50.0:editors/gedit \
 		itstool:textproc/itstool
 LIB_DEPENDS=	libpeas-1.0.so:devel/libpeas1 \
 		libgedit-tepl-6.so:x11-toolkits/tepl6 \
 		libgedit-gtksourceview-300.so:x11-toolkits/libgedit-gtksourceview
-RUN_DEPENDS=	gedit=49.0:editors/gedit
+RUN_DEPENDS=	gedit>=50.0:editors/gedit
 
 USES=		compiler:c11 gettext gnome localbase meson pkgconfig \
 		tar:bz2
@@ -26,8 +26,6 @@ USE_CSTD=	c11
 USE_GITLAB=	yes
 GL_SITE=	https://gitlab.gnome.org
 GL_ACCOUNT=	World/gedit
-
-PORTSCOUT=	limit:^48\.
 
 GLIB_SCHEMAS=	org.gnome.gedit.plugins.drawspaces.gschema.xml \
 		org.gnome.gedit.plugins.wordcompletion.gschema.xml

--- a/editors/gedit-plugins/distinfo
+++ b/editors/gedit-plugins/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1771073913
-SHA256 (gnome/gedit-plugins-49.0.tar.bz2) = 7f73580bdbe47c20d1d1d5a47c77264ae1ef44f5af1231040c4ceec16f1ad318
-SIZE (gnome/gedit-plugins-49.0.tar.bz2) = 1014391
+TIMESTAMP = 1775149747
+SHA256 (gnome/gedit-plugins-50.0.tar.bz2) = ef9d0c2a50b6b7f90aa2342d64c9fed5fcea43388ffaf2e514d9ab0e6f88dc1d
+SIZE (gnome/gedit-plugins-50.0.tar.bz2) = 1023253


### PR DESCRIPTION
Updates gedit-plugins to 50.0 and aligns its gedit dependency with the 50.0 release.

Validation: bmake makesum, patch, build, fake, package, test (4/4), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Update the gedit plugins port for the 50.0 release.

Enhancements:
- Update the gedit plugins port to version 50.0 and align its gedit build and runtime dependencies with the newer release.

Chores:
- Remove the obsolete port version restriction for gedit plugins.