### PR TITLE
x11/xfce4-screenshooter-plugin: update to 1.11.3

### DIFF
--- a/x11/xfce4-screenshooter-plugin/Makefile
+++ b/x11/xfce4-screenshooter-plugin/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xfce4-screenshooter-plugin
-PORTVERSION=	1.11.2
+PORTVERSION=	1.11.3
 CATEGORIES=	x11 xfce
 MASTER_SITES=	XFCE/apps
 DISTNAME=	xfce4-screenshooter-${DISTVERSIONFULL}

--- a/x11/xfce4-screenshooter-plugin/distinfo
+++ b/x11/xfce4-screenshooter-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1747940424
-SHA256 (xfce4/xfce4-screenshooter-1.11.2.tar.xz) = 6ae5bc4823d43e770b3a11700d048d56bdcaafdef37de7deacb8970b55fc1565
-SIZE (xfce4/xfce4-screenshooter-1.11.2.tar.xz) = 178440
+TIMESTAMP = 1788997940
+SHA256 (xfce4/xfce4-screenshooter-1.11.3.tar.xz) = 1f6a14f7d1b0c440f31e24a8cc4fe2996185357fa786f0c2cdfe564ef673a710
+SIZE (xfce4/xfce4-screenshooter-1.11.3.tar.xz) = 180120


### PR DESCRIPTION
Updates the GTK/GNOME-dependent XFCE screenshooter plugin to 1.11.3.

Validation: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Enhancements:
- Update the XFCE screenshooter plugin port to release 1.11.3.