### PR TITLE
sysutils/xfce4-power-manager: update to 4.20.1

### DIFF
--- a/sysutils/xfce4-power-manager/Makefile
+++ b/sysutils/xfce4-power-manager/Makefile
@@ -21,6 +21,7 @@ USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
 USE_GNOME=	cairo gdkpixbuf glib20 gtk30
 USE_XFCE=	libmenu panel xfconf
 USE_XORG=	ice sm x11 xext xrandr xscrnsaver xtst
+USE_GNOME+=	gtk-update-icon-cache
 INSTALLS_ICONS=	yes
 
 GNU_CONFIGURE=	yes

--- a/sysutils/xfce4-power-manager/Makefile
+++ b/sysutils/xfce4-power-manager/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xfce4-power-manager
-PORTVERSION=	4.20.0
+PORTVERSION=	4.20.1
 CATEGORIES=	sysutils xfce
 MASTER_SITES=	XFCE
 DIST_SUBDIR=	xfce4
@@ -21,6 +21,7 @@ USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
 USE_GNOME=	cairo gdkpixbuf glib20 gtk30
 USE_XFCE=	libmenu panel xfconf
 USE_XORG=	ice sm x11 xext xrandr xscrnsaver xtst
+INSTALLS_ICONS=	yes
 
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS=	--disable-network-manager \

--- a/sysutils/xfce4-power-manager/distinfo
+++ b/sysutils/xfce4-power-manager/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1734293718
-SHA256 (xfce4/xfce4-power-manager-4.20.0.tar.bz2) = 971391cef63352833bdd92df28957392e17e1f2b3d486c0f57294fd204d6ed29
-SIZE (xfce4/xfce4-power-manager-4.20.0.tar.bz2) = 1523787
+TIMESTAMP = 1788998059
+SHA256 (xfce4/xfce4-power-manager-4.20.1.tar.bz2) = 4fe18ef5f89c5ca9b96dde84dbd88ca7e36af1caf70ddd6429dc72128007edf7
+SIZE (xfce4/xfce4-power-manager-4.20.1.tar.bz2) = 1536339


### PR DESCRIPTION
Updates the GTK/GNOME-dependent Xfce power manager to 4.20.1 and declares its staged icon-cache hooks.

Validation: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Enhancements:
- Update Xfce Power Manager to version 4.20.1 and enable staged icon-cache integration for its installed icons.