### PR TITLE
x11-clocks/xfce4-time-out-plugin: update to 1.2.0

### DIFF
--- a/x11-clocks/xfce4-time-out-plugin/Makefile
+++ b/x11-clocks/xfce4-time-out-plugin/Makefile
@@ -1,31 +1,30 @@
-# Created by: Martin Wilke (miwi@FreeBSD.org)
-
 PORTNAME=	xfce4-time-out-plugin
-PORTVERSION=	1.1.2
-PORTREVISION=	1
+PORTVERSION=	1.2.0
 CATEGORIES=	x11-clocks xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Time out plugin for Xfce
+WWW=		https://docs.xfce.org/panel-plugins/xfce4-time-out-plugin/start
 
 LICENSE=	gpl2
 
-USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
-		tar:bzip2 xfce xorg
-USE_GNOME=	cairo gtk30 intltool
-USE_XFCE=	panel
+USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce \
+		xorg
+USE_GNOME=	gtk30
+USE_XFCE=	libmenu panel
 USE_XORG=	x11
-
-GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-INSTALL_TARGET=	install-strip
+
+MESON_ARGS=	-Dx11=enabled
 
 OPTIONS_DEFINE=		NLS
 OPTIONS_SUB=		yes
 
-NLS_CONFIGURE_ENABLE=	nls
 NLS_USES=		gettext-runtime
+
+post-patch-NLS-off:
+	@${REINPLACE_CMD} -e "/^subdir('po')/d" ${WRKSRC}/meson.build
 
 .include <bsd.port.mk>

--- a/x11-clocks/xfce4-time-out-plugin/distinfo
+++ b/x11-clocks/xfce4-time-out-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1614549710
-SHA256 (xfce4/xfce4-time-out-plugin-1.1.2.tar.bz2) = 3dd8eba694ff3ba5c25bd7f5cd70dc22175fb2c0a759213f05ab8f0e629d82d4
-SIZE (xfce4/xfce4-time-out-plugin-1.1.2.tar.bz2) = 409221
+TIMESTAMP = 1788998248
+SHA256 (xfce4/xfce4-time-out-plugin-1.2.0.tar.xz) = e344d9f82a8acd23d44e7cf9b2efe9599ffff856d9ba1a9be0e67b022c0d2eb2
+SIZE (xfce4/xfce4-time-out-plugin-1.2.0.tar.xz) = 65520

--- a/x11-clocks/xfce4-time-out-plugin/pkg-descr
+++ b/x11-clocks/xfce4-time-out-plugin/pkg-descr
@@ -1,5 +1,3 @@
 This plugin makes it possible to take periodical breaks from the computer every
 X minutes. During breaks it locks your screen. It optionally allows you to
 postpone breaks for a certain time.
-
-WWW: https://goodies.xfce.org/projects/panel-plugins/xfce4-time-out-plugin

--- a/x11-clocks/xfce4-time-out-plugin/pkg-plist
+++ b/x11-clocks/xfce4-time-out-plugin/pkg-plist
@@ -12,6 +12,7 @@ share/icons/hicolor/scalable/apps/xfce4-time-out-plugin.svg
 %%NLS%%share/locale/el/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/en_AU/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/en_CA/LC_MESSAGES/xfce4-time-out-plugin.mo
+%%NLS%%share/locale/en_GB/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/eo/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/es/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/et/LC_MESSAGES/xfce4-time-out-plugin.mo
@@ -40,6 +41,7 @@ share/icons/hicolor/scalable/apps/xfce4-time-out-plugin.svg
 %%NLS%%share/locale/pl/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/pt/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/pt_BR/LC_MESSAGES/xfce4-time-out-plugin.mo
+%%NLS%%share/locale/ro/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/ru/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/sk/LC_MESSAGES/xfce4-time-out-plugin.mo
 %%NLS%%share/locale/sl/LC_MESSAGES/xfce4-time-out-plugin.mo


### PR DESCRIPTION
Updates the GTK/GNOME-dependent Xfce time-out panel plugin to 1.2.0 and migrates it from Autotools to Meson.

Validation: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Update the Xfce time-out plugin port to 1.2.0 with Meson-based build support and refreshed dependencies and packaging metadata.

Enhancements:
- Update the Xfce time-out panel plugin to version 1.2.0 and migrate its port to Meson-based builds.
- Refresh the port metadata and dependencies for the updated release, including Xfce libmenu support and the project website.
- Preserve optional NLS support while adapting its build configuration to Meson.

Build:
- Switch the port from Autotools to Meson and update the source archive format and packaging metadata.