### PR TITLE
net/glib-networking: update to 2.80.1

### DIFF
--- a/net/glib-networking/Makefile
+++ b/net/glib-networking/Makefile
@@ -1,37 +1,48 @@
 PORTNAME=	glib-networking
-PORTVERSION=	2.72.0
-PORTREVISION=	0
+PORTVERSION=	2.80.1
 CATEGORIES=	net
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Network-related giomodules for glib
+WWW=		https://gitlab.gnome.org/GNOME/glib-networking
 
 LICENSE=	lgpl2.1
 LICENSE_FILE=	${WRKSRC}/COPYING
-
-BUILD_DEPENDS=	ca_root_nss>=0:security/ca_root_nss \
-		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
-LIB_DEPENDS=	libgnutls.so:security/gnutls \
-		libp11-kit.so:security/p11-kit \
-		libdbus-1.so:devel/dbus \
-		libproxy.so:net/libproxy
-RUN_DEPENDS=	ca_root_nss>=0:security/ca_root_nss \
-		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
-
-PORTSCOUT=	limitw:1,even
 
 USES=		compiler:c11 gettext gnome localbase meson pkgconfig \
 		python:build tar:xz
 USE_GNOME=	glib20
 
-NO_TEST=	yes
+BUILD_DEPENDS=	ca_root_nss>=0:security/ca_root_nss \
+		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
+RUN_DEPENDS=	ca_root_nss>=0:security/ca_root_nss \
+		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
+
+PORTSCOUT=	limitw:1,even
 
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 
+OPTIONS_DEFINE=	OPENSSL PROXY
+PROXY_DESC=	Proxy configuration support via libproxy
+OPTIONS_SUB=	yes
+OPTIONS_DEFAULT=	PROXY
+
+OPENSSL_LIB_DEPENDS_OFF=	libgnutls.so:security/gnutls \
+				libp11-kit.so:security/p11-kit
+OPENSSL_USES=			ssl
+OPENSSL_MESON_ENABLED=		openssl
+OPENSSL_MESON_DISABLED=		gnutls
+
+PROXY_LIB_DEPENDS=	libdbus-1.so:devel/dbus \
+			libproxy.so:net/libproxy
+PROXY_MESON_ENABLED=		libproxy
+PROXY_MESON_DISABLED=		environment_proxy
+
 post-install:
 	${RM} -r ${PREFIX}/lib/systemd
-	-${RM} -r ${PREFIX}/share/installed-tests
+
+OPENSSL_DESC+=	(instead of GnuTLS)
 
 .include <bsd.port.mk>

--- a/net/glib-networking/distinfo
+++ b/net/glib-networking/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1654265699
-SHA256 (gnome/glib-networking-2.72.0.tar.xz) = 100aaebb369285041de52da422b6b716789d5e4d7549a3a71ba587b932e0823b
-SIZE (gnome/glib-networking-2.72.0.tar.xz) = 265060
+TIMESTAMP = 1788986066
+SHA256 (gnome/glib-networking-2.80.1.tar.xz) = b80e2874157cd55071f1b6710fa0b911d5ac5de106a9ee2a4c9c7bee61782f8e
+SIZE (gnome/glib-networking-2.80.1.tar.xz) = 290828

--- a/net/glib-networking/pkg-plist
+++ b/net/glib-networking/pkg-plist
@@ -1,9 +1,11 @@
-lib/gio/modules/libgioenvironmentproxy.so
+%%NO_PROXY%%lib/gio/modules/libgioenvironmentproxy.so
 lib/gio/modules/libgiognomeproxy.so
-lib/gio/modules/libgiognutls.so
-lib/gio/modules/libgiolibproxy.so
-libexec/glib-pacrunner
-share/dbus-1/services/org.gtk.GLib.PACRunner.service
+%%NO_OPENSSL%%lib/gio/modules/libgiognutls.so
+%%PROXY%%lib/gio/modules/libgiolibproxy.so
+%%OPENSSL%%lib/gio/modules/libgioopenssl.so
+%%PROXY%%libexec/glib-pacrunner
+%%PROXY%%share/dbus-1/services/org.gtk.GLib.PACRunner.service
+share/locale/ab/LC_MESSAGES/glib-networking.mo
 share/locale/an/LC_MESSAGES/glib-networking.mo
 share/locale/ar/LC_MESSAGES/glib-networking.mo
 share/locale/as/LC_MESSAGES/glib-networking.mo
@@ -37,6 +39,8 @@ share/locale/hu/LC_MESSAGES/glib-networking.mo
 share/locale/id/LC_MESSAGES/glib-networking.mo
 share/locale/it/LC_MESSAGES/glib-networking.mo
 share/locale/ja/LC_MESSAGES/glib-networking.mo
+share/locale/ka/LC_MESSAGES/glib-networking.mo
+share/locale/kab/LC_MESSAGES/glib-networking.mo
 share/locale/kk/LC_MESSAGES/glib-networking.mo
 share/locale/km/LC_MESSAGES/glib-networking.mo
 share/locale/kn/LC_MESSAGES/glib-networking.mo


### PR DESCRIPTION
Updates glib-networking to 2.80.1, adds current OpenSSL/libproxy option handling, and preserves the mport gio-querymodules package hooks.

Default configuration validation: bmake makesum, patch, build, fake, package, test (6/6), check-license, portlint -C, and git diff --check. The default proxy test was also revalidated after updating the local libproxy dependency to 0.5.10.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Update glib-networking to 2.80.1 with current TLS and proxy configuration options.

New Features:
- Add configurable OpenSSL and libproxy support for glib-networking, with proxy support enabled by default.

Enhancements:
- Update glib-networking to version 2.80.1 and refresh its package metadata and installed files.

Chores:
- Preserve the existing gio-querymodules package hooks while adapting the port configuration.