### PR TITLE
x11-clocks/xfce4-stopwatch-plugin: update to 0.6.0

### DIFF
--- a/x11-clocks/xfce4-stopwatch-plugin/Makefile
+++ b/x11-clocks/xfce4-stopwatch-plugin/Makefile
@@ -1,29 +1,28 @@
 PORTNAME=	xfce4-stopwatch-plugin
-PORTVERSION=	0.5.0
-PORTREVISION=	1
+PORTVERSION=	0.6.0
 CATEGORIES=	x11-clocks xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	XFCE panel plugin to keep track of elapsed time
+WWW=		https://docs.xfce.org/panel-plugins/xfce4-stopwatch-plugin/start
 
 LICENSE=	bsd2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
-		tar:bzip2 xfce
-USE_GNOME=	cairo gtk30 intltool
-USE_XFCE=	panel
+USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce
+USE_GNOME=	gtk30
+USE_XFCE=	libutil panel
 
-GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-INSTALL_TARGET=	install-strip
 
 OPTIONS_DEFINE=		NLS
 OPTIONS_SUB=		yes
 
 NLS_USES=		gettext-runtime
-NLS_CONFIGURE_ENABLE=	nls
+
+post-patch-NLS-off:
+	@${REINPLACE_CMD} -e "/^subdir('po')/d" ${WRKSRC}/meson.build
 
 .include <bsd.port.mk>

--- a/x11-clocks/xfce4-stopwatch-plugin/Makefile
+++ b/x11-clocks/xfce4-stopwatch-plugin/Makefile
@@ -12,7 +12,7 @@ LICENSE=	bsd2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce
-USE_GNOME=	gtk30
+USE_GNOME=	gtk-update-icon-cache gtk30
 USE_XFCE=	libutil panel
 
 INSTALLS_ICONS=	yes

--- a/x11-clocks/xfce4-stopwatch-plugin/distinfo
+++ b/x11-clocks/xfce4-stopwatch-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1611063825
-SHA256 (xfce4/xfce4-stopwatch-plugin-0.5.0.tar.bz2) = 7c1b5e3401874daa0bc6c9ecfdd85f16b6dfc5c089709a18a4b87d89920004e1
-SIZE (xfce4/xfce4-stopwatch-plugin-0.5.0.tar.bz2) = 308214
+TIMESTAMP = 1788998645
+SHA256 (xfce4/xfce4-stopwatch-plugin-0.6.0.tar.xz) = 9be4825f6dc3b5227ba3c71b345da4159ac3364f659784b57845bb06cf31ef43
+SIZE (xfce4/xfce4-stopwatch-plugin-0.6.0.tar.xz) = 23836

--- a/x11-clocks/xfce4-stopwatch-plugin/pkg-descr
+++ b/x11-clocks/xfce4-stopwatch-plugin/pkg-descr
@@ -1,3 +1,1 @@
 This plugin keeps track of elapsed time - right on your panel.
-
-WWW: https://goodies.xfce.org/projects/panel-plugins/xfce4-stopwatch-plugin

--- a/x11-clocks/xfce4-stopwatch-plugin/pkg-plist
+++ b/x11-clocks/xfce4-stopwatch-plugin/pkg-plist
@@ -1,6 +1,4 @@
 lib/xfce4/panel/plugins/libstopwatch.so
-lib/xfce4/panel/plugins/libstopwatch.so.0
-lib/xfce4/panel/plugins/libstopwatch.so.0.0.0
 share/icons/hicolor/16x16/apps/xfce4-stopwatch-plugin.png
 share/icons/hicolor/22x22/apps/xfce4-stopwatch-plugin.png
 share/icons/hicolor/24x24/apps/xfce4-stopwatch-plugin.png
@@ -44,6 +42,7 @@ share/icons/hicolor/scalable/apps/xfce4-stopwatch-plugin.svg
 %%NLS%%share/locale/pl/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/pt/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/pt_BR/LC_MESSAGES/xfce4-stopwatch-plugin.mo
+%%NLS%%share/locale/ro/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/ru/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/sk/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/sl/LC_MESSAGES/xfce4-stopwatch-plugin.mo
@@ -53,6 +52,7 @@ share/icons/hicolor/scalable/apps/xfce4-stopwatch-plugin.svg
 %%NLS%%share/locale/tr/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/ug/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/uk/LC_MESSAGES/xfce4-stopwatch-plugin.mo
+%%NLS%%share/locale/vi/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 %%NLS%%share/locale/zh_TW/LC_MESSAGES/xfce4-stopwatch-plugin.mo
 share/xfce4/panel/plugins/xfce4-stopwatch-plugin.desktop


### PR DESCRIPTION
Updates the GTK/GNOME-dependent Xfce stopwatch panel plugin to 0.6.0 and migrates it from Autotools to Meson.

Validation: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Update the Xfce stopwatch plugin port to 0.6.0 and modernize its build configuration.

Enhancements:
- Update the Xfce stopwatch panel plugin port to version 0.6.0 and migrate its build system from Autotools to Meson.
- Refresh the port metadata, dependencies, archive format, and packaging files for the new upstream release.
- Preserve optional NLS support while adapting the port configuration to the Meson build.

Build:
- Replace the Autotools-based port configuration with Meson and update related build dependencies.