### PR TITLE
x11-clocks/xfce4-timer-plugin: update to 1.8.0

### DIFF
--- a/x11-clocks/xfce4-timer-plugin/Makefile
+++ b/x11-clocks/xfce4-timer-plugin/Makefile
@@ -1,30 +1,27 @@
-# Created by: Martin Wilke (miwi@FreeBSD.org)
-
 PORTNAME=	xfce4-timer-plugin
-PORTVERSION=	1.7.1
-PORTREVISION=	1
+PORTVERSION=	1.8.0
 CATEGORIES=	x11-clocks xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Timer plugin for Xfce
+WWW=		https://docs.xfce.org/panel-plugins/xfce4-timer-plugin/start
 
 LICENSE=	gpl2
 
-USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
-		tar:bzip2 xfce
-USE_GNOME=	cairo gtk30 intltool
-USE_XFCE=	panel
+USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce
+USE_GNOME=	gtk30
+USE_XFCE=	libmenu panel
 
-GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-INSTALL_TARGET=	install-strip
 
 OPTIONS_DEFINE=		NLS
 OPTIONS_SUB=		yes
 
 NLS_USES=		gettext-runtime
-NLS_CONFIGURE_ENABLE=	nls
+
+post-patch-NLS-off:
+	@${REINPLACE_CMD} -e "/^subdir('po')/d" ${WRKSRC}/meson.build
 
 .include <bsd.port.mk>

--- a/x11-clocks/xfce4-timer-plugin/Makefile
+++ b/x11-clocks/xfce4-timer-plugin/Makefile
@@ -11,7 +11,7 @@ WWW=		https://docs.xfce.org/panel-plugins/xfce4-timer-plugin/start
 LICENSE=	gpl2
 
 USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce
-USE_GNOME=	gtk30
+USE_GNOME=	gtk-update-icon-cache gtk30
 USE_XFCE=	libmenu panel
 
 INSTALLS_ICONS=	yes

--- a/x11-clocks/xfce4-timer-plugin/distinfo
+++ b/x11-clocks/xfce4-timer-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1595625273
-SHA256 (xfce4/xfce4-timer-plugin-1.7.1.tar.bz2) = 4b52d2911b1949e945971be6533155ee6ba99c77078eac7fd43b0f2aeca824e3
-SIZE (xfce4/xfce4-timer-plugin-1.7.1.tar.bz2) = 405053
+TIMESTAMP = 1788999045
+SHA256 (xfce4/xfce4-timer-plugin-1.8.0.tar.xz) = 1d3ac3aa2c4345400c025642778e7643aab41047622baf9cdc00bbac78e89f99
+SIZE (xfce4/xfce4-timer-plugin-1.8.0.tar.xz) = 65196

--- a/x11-clocks/xfce4-timer-plugin/pkg-descr
+++ b/x11-clocks/xfce4-timer-plugin/pkg-descr
@@ -7,5 +7,3 @@ time. By default a simple dialog pops up at the end of the countdown. The user
 can choose an external command to be run as the alarm and may also choose to
 have this repeated a specified number of times with a given interval between
 repetitions.
-
-WWW: https://goodies.xfce.org/projects/panel-plugins/xfce4-timer-plugin

--- a/x11-clocks/xfce4-timer-plugin/pkg-plist
+++ b/x11-clocks/xfce4-timer-plugin/pkg-plist
@@ -13,8 +13,11 @@ share/icons/hicolor/scalable/apps/xfce4-timer-plugin.svg
 %%NLS%%share/locale/el/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/en_AU/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/en_GB/LC_MESSAGES/xfce4-timer-plugin.mo
+%%NLS%%share/locale/eo/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/es/LC_MESSAGES/xfce4-timer-plugin.mo
+%%NLS%%share/locale/et/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/eu/LC_MESSAGES/xfce4-timer-plugin.mo
+%%NLS%%share/locale/fa_IR/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/fi/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/fr/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/gl/LC_MESSAGES/xfce4-timer-plugin.mo
@@ -23,6 +26,7 @@ share/icons/hicolor/scalable/apps/xfce4-timer-plugin.svg
 %%NLS%%share/locale/hu/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/hye/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/id/LC_MESSAGES/xfce4-timer-plugin.mo
+%%NLS%%share/locale/ie/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/is/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/it/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/ja/LC_MESSAGES/xfce4-timer-plugin.mo
@@ -36,6 +40,7 @@ share/icons/hicolor/scalable/apps/xfce4-timer-plugin.svg
 %%NLS%%share/locale/pl/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/pt/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/pt_BR/LC_MESSAGES/xfce4-timer-plugin.mo
+%%NLS%%share/locale/ro/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/ru/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/sk/LC_MESSAGES/xfce4-timer-plugin.mo
 %%NLS%%share/locale/sl/LC_MESSAGES/xfce4-timer-plugin.mo


### PR DESCRIPTION
Updates the GTK/GNOME-dependent Xfce timer panel plugin to 1.8.0 and migrates it from Autotools to Meson.

Validation: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Update the Xfce timer plugin port to 1.8.0 with Meson-based packaging and refreshed dependencies and metadata.

Enhancements:
- Update the Xfce timer plugin port to version 1.8.0 and migrate its build system from Autotools to Meson.
- Refresh the port’s Xfce, GTK, icon, localization, metadata, and packaging configuration for the new release.

Build:
- Switch the port to the Meson build framework and update the source archive format.