### PR TITLE
editors/gedit: bump PORTREVISION for gspell

### DIFF
--- a/editors/gedit/Makefile
+++ b/editors/gedit/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gedit
 DISTVERSION=	50.0
+PORTREVISION=	1
 CATEGORIES=	editors gnome
 DIST_SUBDIR=	gnome
 


### PR DESCRIPTION
Rebuild after the gspell shared library ABI change.

## Summary by Sourcery

Rebuild gedit against the updated gspell shared library ABI.

Enhancements:
- Trigger a gedit rebuild after the gspell shared library ABI change.

Build:
- Bump gedit PORTREVISION to 1.