### PR TITLE
sysutils/polkit-qt-1: update to 0.201.1

### DIFF
--- a/sysutils/polkit-qt-1/Makefile
+++ b/sysutils/polkit-qt-1/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	polkit-qt-1
-DISTVERSION=	0.200.0
+DISTVERSION=	0.201.1
 CATEGORIES=	sysutils
 MASTER_SITES=	KDE/stable/${PORTNAME}/
 PKGNAMESUFFIX=	-${FLAVOR}
@@ -13,8 +13,6 @@ LICENSE=	lgpl2.1
 FLAVORS=	qt5 qt6
 FLAVOR?=	qt5
 
-LIB_DEPENDS=	libpolkit-agent-1.so:sysutils/polkit
-
 USES=		cmake compiler:c++11-lang gnome pkgconfig qt:${FLAVOR:C/qt//} \
 		tar:xz
 USE_GNOME=	glib20
@@ -23,6 +21,8 @@ CMAKE_OFF=	BUILD_EXAMPLES BUILD_TEST
 CMAKE_ARGS=	-DQT_MAJOR_VERSION=${FLAVOR:C/qt//}
 _USE_QT_qt5=	core dbus gui widgets buildtools:build qmake:build
 _USE_QT_qt6=	base
+
+LIB_DEPENDS=	libpolkit-agent-1.so:sysutils/polkit
 
 USE_LDCONFIG=	yes
 PLIST_SUB=	QT_VER=${FLAVOR:C/qt//}

--- a/sysutils/polkit-qt-1/distinfo
+++ b/sysutils/polkit-qt-1/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1709230056
-SHA256 (polkit-qt-1-0.200.0.tar.xz) = 5d3b611c062d2b76a93750bb10c907bfd21d1ff08d0a15dc2cf63e278e1677fb
-SIZE (polkit-qt-1-0.200.0.tar.xz) = 58216
+TIMESTAMP = 1788994586
+SHA256 (polkit-qt-1-0.201.1.tar.xz) = 95d8e2cae530c546d9437459deb8a1bea38d572f0f9772cc2860dc143637f256
+SIZE (polkit-qt-1-0.201.1.tar.xz) = 58492

--- a/sysutils/polkit-qt-1/pkg-plist
+++ b/sysutils/polkit-qt-1/pkg-plist
@@ -30,13 +30,13 @@ lib/cmake/PolkitQt%%QT_VER%%-1/PolkitQt%%QT_VER%%-1Targets-%%CMAKE_BUILD_TYPE%%.
 lib/cmake/PolkitQt%%QT_VER%%-1/PolkitQt%%QT_VER%%-1Targets.cmake
 lib/libpolkit-qt%%QT_VER%%-agent-1.so
 lib/libpolkit-qt%%QT_VER%%-agent-1.so.1
-lib/libpolkit-qt%%QT_VER%%-agent-1.so.1.200.0
+lib/libpolkit-qt%%QT_VER%%-agent-1.so.1.201.1
 lib/libpolkit-qt%%QT_VER%%-core-1.so
 lib/libpolkit-qt%%QT_VER%%-core-1.so.1
-lib/libpolkit-qt%%QT_VER%%-core-1.so.1.200.0
+lib/libpolkit-qt%%QT_VER%%-core-1.so.1.201.1
 lib/libpolkit-qt%%QT_VER%%-gui-1.so
 lib/libpolkit-qt%%QT_VER%%-gui-1.so.1
-lib/libpolkit-qt%%QT_VER%%-gui-1.so.1.200.0
+lib/libpolkit-qt%%QT_VER%%-gui-1.so.1.201.1
 libdata/pkgconfig/polkit-qt%%QT_VER%%-1.pc
 libdata/pkgconfig/polkit-qt%%QT_VER%%-agent-1.pc
 libdata/pkgconfig/polkit-qt%%QT_VER%%-core-1.pc


### PR DESCRIPTION
Updates Polkit-Qt to 0.201.1 for both Qt5 and Qt6 flavors.

Validation: bmake makesum, patch, build, fake, package, test for both flavors; check-license; git diff --check. Source-only portlint found no Makefile ordering issue; generated work/package artifacts caused its broad scan diagnostics.

AI-Assisted-by: Codex <noreply@openai.com>

## Summary by Sourcery

Enhancements:
- Update the polkit-qt-1 port to release 0.201.1 for both Qt5 and Qt6 flavors.