### PR TITLE
x11-toolkits/gtk-layer-shell: update to 0.10.1

### DIFF
--- a/x11-toolkits/gtk-layer-shell/Makefile
+++ b/x11-toolkits/gtk-layer-shell/Makefile
@@ -1,14 +1,16 @@
 PORTNAME=	gtk-layer-shell
 DISTVERSIONPREFIX=	v
-DISTVERSION=	0.10.0
+DISTVERSION=	0.10.1
 CATEGORIES=	x11-toolkits
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GTK3 library for the Wayland layer-shell protocol
 WWW=		https://github.com/wmww/gtk-layer-shell
 
-LICENSE=	lgpl3 mit
+LICENSE=	lgpl3+ mit
 LICENSE_COMB=	multi
+LICENSE_FILE_lgpl3+ =	${WRKSRC}/LICENSE_LGPL.txt
+LICENSE_FILE_mit=	${WRKSRC}/LICENSE_MIT.txt
 
 BUILD_DEPENDS=	wayland-protocols>=1.16:graphics/wayland-protocols
 LIB_DEPENDS=	libwayland-client.so:graphics/wayland
@@ -27,8 +29,6 @@ DOCS_BUILD_DEPENDS=	gtk-doc>0:textproc/gtk-doc
 DOCS_MESON_TRUE=	docs
 
 EXAMPLES_MESON_TRUE=	examples
-
-NO_TEST=yes
 
 pre-configure:
 # .if !exists() evaluates too early before gtk3 has a chance to be installed

--- a/x11-toolkits/gtk-layer-shell/distinfo
+++ b/x11-toolkits/gtk-layer-shell/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1761770634
-SHA256 (wmww-gtk-layer-shell-v0.10.0_GH0.tar.gz) = ed9bb801d6d9252defba41104820ace595dac824dc8972a758ee2ad134e10505
-SIZE (wmww-gtk-layer-shell-v0.10.0_GH0.tar.gz) = 139247
+TIMESTAMP = 1789016502
+SHA256 (wmww-gtk-layer-shell-v0.10.1_GH0.tar.gz) = 88c3a3e0a5300532f3d368d5df64838a87f1fb85273f22d41df0a6b8d0ec59c6
+SIZE (wmww-gtk-layer-shell-v0.10.1_GH0.tar.gz) = 140575


### PR DESCRIPTION
Updates gtk-layer-shell to 0.10.1.

- Correctly declares LGPLv3-or-later and MIT license files.
- Restores the upstream test suite: 41 passed, 2 expected failures.
- Validated makesum, patch, build, fake, package, test, check-license, portlint (source clean; generated local archive is the sole fatal), and git diff --check.

## Summary by Sourcery

Update gtk-layer-shell to 0.10.1 with accurate license metadata and upstream test coverage.

Enhancements:
- Update gtk-layer-shell to version 0.10.1 and declare its LGPLv3-or-later and MIT license files.
- Re-enable the upstream test suite for the port.

Tests:
- Restore upstream testing, with 41 tests passing and 2 expected failures.