### PR TITLE
japanese/kasumi-unicode: update to 2.7

### DIFF
--- a/japanese/kasumi-unicode/Makefile
+++ b/japanese/kasumi-unicode/Makefile
@@ -1,20 +1,20 @@
 PORTNAME=	kasumi-unicode
-DISTVERSION=	2.6
+DISTVERSION=	2.7
 CATEGORIES=	japanese
+MASTER_SITES=	https://github.com/fujiwarat/${PORTNAME}/releases/download/${DISTVERSION}/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Dictionary management tool for anthy-unicode
+WWW=		https://github.com/fujiwarat/kasumi-unicode/
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 LIB_DEPENDS=	libanthy-unicode.so:japanese/anthy-unicode
 
-USES=		autoreconf compiler:c++11-lang gmake gnome iconv:wchar_t \
+USES=		autoreconf compiler:c++14-lang gmake gnome iconv:wchar_t \
 		libtool pkgconfig
-USE_CXXSTD=	c++11
-USE_GITHUB=	yes
-GH_ACCOUNT=	fujiwarat
+USE_CXXSTD=	c++14
 USE_GNOME=	gtk30
 
 GNU_CONFIGURE=	yes

--- a/japanese/kasumi-unicode/distinfo
+++ b/japanese/kasumi-unicode/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1732499480
-SHA256 (fujiwarat-kasumi-unicode-2.6_GH0.tar.gz) = a7a416d7df1776dbf32be3c779627ad4061867b54b0f2b48bc29ea2c01959246
-SIZE (fujiwarat-kasumi-unicode-2.6_GH0.tar.gz) = 199232
+TIMESTAMP = 1788993417
+SHA256 (kasumi-unicode-2.7.tar.gz) = 8eb628ee97acffc2755851f857ec109c579d19811e1054baab57de67c7a26db6
+SIZE (kasumi-unicode-2.7.tar.gz) = 323498


### PR DESCRIPTION
Updates kasumi-unicode to 2.7.

- Switches to the upstream release archive and C++14 requirement.
- Corrects the source-backed GPLv2-or-later declaration.
- Validated makesum, patch, build, fake, package, test, check-license, portlint (0 fatals), and git diff --check.

## Summary by Sourcery

Update the kasumi-unicode port to the 2.7 release.

Enhancements:
- Update kasumi-unicode to version 2.7 using the upstream release archive and C++14.

Chores:
- Correct the port's GPLv2-or-later license declaration and add project metadata.