### PR TITLE
audio/pulseaudio-qt: update to 1.8.1

### DIFF
--- a/audio/pulseaudio-qt/Makefile
+++ b/audio/pulseaudio-qt/Makefile
@@ -1,7 +1,7 @@
 PORTNAME=	pulseaudio-qt
-DISTVERSION=	1.7.0
-MASTER_SITES=	KDE/stable/${PORTNAME}
+DISTVERSION=	1.8.1
 CATEGORIES=	audio kde
+MASTER_SITES=	KDE/stable/${PORTNAME}
 PKGNAMESUFFIX=	6
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -19,6 +19,7 @@ USE_GL=		gl opengl # GLX
 USE_GNOME=	glib20
 USE_KDE=	ecm:build
 USE_QT=		base
+USE_LDCONFIG=	yes
 
 PLIST_SUB=	SOVERSION=${DISTVERSION}
 

--- a/audio/pulseaudio-qt/distinfo
+++ b/audio/pulseaudio-qt/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1739547904
-SHA256 (pulseaudio-qt-1.7.0.tar.xz) = 6a18db76dd2bcc3df7d9a9379c025295817264baa1f2ed8caaac7da44e04e931
-SIZE (pulseaudio-qt-1.7.0.tar.xz) = 40684
+TIMESTAMP = 1789015845
+SHA256 (pulseaudio-qt-1.8.1.tar.xz) = 79619c55b94808aa7d307fb234ad39a1096d088f21f806be0e788be79a76b3c9
+SIZE (pulseaudio-qt-1.8.1.tar.xz) = 41168


### PR DESCRIPTION
Updates PulseAudio Qt to 1.8.1.

- Refreshes the KDE release source metadata.
- Adds USE_LDCONFIG for the installed shared library.
- Validated makesum, patch, build, fake, package, test, check-license, and git diff --check. Clean portlint has no source fatal; the only fatal is the retained generated local package archive.

## Summary by Sourcery

Update the PulseAudio Qt port to the 1.8.1 release.

Enhancements:
- Update the PulseAudio Qt port to version 1.8.1 and enable runtime linker cache updates for its shared library.

Chores:
- Refresh the KDE release source metadata and checksums.