### PR TITLE
graphics/ristretto: update to 0.14.0

### DIFF
--- a/graphics/ristretto/Makefile
+++ b/graphics/ristretto/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	ristretto
-PORTVERSION=	0.13.4
+PORTVERSION=	0.14.0
 CATEGORIES=	graphics xfce
 MASTER_SITES=	XFCE/apps
 DIST_SUBDIR=	xfce4
@@ -8,14 +8,15 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Image viewer with Xfce integration
 WWW=		https://docs.xfce.org/apps/ristretto/start
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 LIB_DEPENDS=	libexif.so:graphics/libexif
 
 USES=		cmake:indirect compiler:c11 desktop-file-utils gettext-tools gnome \
 		meson pkgconfig tar:xz xfce xorg
-USE_GNOME=	cairo gdkpixbuf glib20 gtk30
+USE_GNOME=	cairo gdkpixbuf glib20 gtk-update-icon-cache gtk30
+INSTALLS_ICONS=	yes
 USE_XFCE=	libexo libmenu xfconf
 USE_XORG=	ice sm x11
 

--- a/graphics/ristretto/distinfo
+++ b/graphics/ristretto/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1743023968
-SHA256 (xfce4/ristretto-0.13.4.tar.xz) = a84ef8cb80638681d9b9ef09cddff86a5d7a0e028603b4a601cf0ff6c2869ce8
-SIZE (xfce4/ristretto-0.13.4.tar.xz) = 277320
+TIMESTAMP = 1773041139
+SHA256 (xfce4/ristretto-0.14.0.tar.xz) = 502cf1577de14b38132dc89e56884c5e10f86f6a028d8dde379a8839110fda55
+SIZE (xfce4/ristretto-0.14.0.tar.xz) = 284296


### PR DESCRIPTION
Updates Ristretto to 0.14.0.

- Corrects license metadata to GPLv2-or-later based on upstream source headers.
- Adds gtk-update-icon-cache and INSTALLS_ICONS for the staged icon payload.

Validated: makesum, patch, build, fake, package, test (no upstream tests), check-license, and git diff --check. portlint has no source diagnostics; its only fatal is the retained generated local package artifact.

## Summary by Sourcery

Update the Ristretto port to 0.14.0 with corrected licensing metadata and icon installation support.

Enhancements:
- Update Ristretto to version 0.14.0 and correctly identify its license as GPLv2-or-later.
- Install and refresh the application icon cache for the staged icon assets.