### PR TITLE
audio/audacity: update to 3.7.9

### DIFF
--- a/audio/audacity/Makefile
+++ b/audio/audacity/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	audacity
 DISTVERSIONPREFIX=	Audacity-
-DISTVERSION=	3.7.1
+DISTVERSION=	3.7.9
 CATEGORIES=	audio
 MASTER_SITES+=	https://github.com/${PORTNAME}/${PORTNAME}-manual/releases/download/v${DISTVERSION}/:manual
 DISTFILES+=	${PORTNAME}-manual-${DISTVERSION}.tar.gz:manual
@@ -11,6 +11,8 @@ WWW=		https://www.audacityteam.org/
 
 LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/LICENSE.txt
+
+INSTALLS_ICONS=	yes
 
 BUILD_DEPENDS=	conan:sysutils/conan \
 		rapidjson>0:devel/rapidjson \
@@ -41,7 +43,7 @@ USES=		cmake compiler:c++20-lang cpe desktop-file-utils gettext \
 CPE_VENDOR=	audacityteam
 
 USE_GITHUB=	yes
-USE_GNOME=	cairo gdkpixbuf gtk30
+USE_GNOME=	cairo gdkpixbuf gtk-update-icon-cache gtk30
 USE_WX=		3.2+
 WX_COMPS=	wx
 
@@ -73,9 +75,10 @@ CMAKE_OFF=	audacity_has_audiocom_upload audacity_conan_enabled audacity_conan_fo
 		audacity_has_crashreports audacity_has_networking audacity_has_updates_check audacity_has_url_schemes_support \
 		audacity_has_tests audacity_has_vst3 audacity_perform_codesign audacity_use_pch
 
-# TODO: fix NLS support properly
-PLIST_SUB+=	NLS=""
 PORTDOCS=	README.md
+
+# TODO: fix NLS support properly; upstream unconditionally builds locale.
+PLIST_SUB+=	NLS=""
 
 OPTIONS_DEFINE=		DEBUG DOCS FFMPEG FLAC ID3TAG LADSPA MANUAL \
 			OGG SBSMS SOUNDTOUCH TWOLAME VAMP VORBIS VST

--- a/audio/audacity/distinfo
+++ b/audio/audacity/distinfo
@@ -1,5 +1,5 @@
-TIMESTAMP = 1734081098
-SHA256 (audacity-manual-3.7.1.tar.gz) = c73a786c9fe925e91241ed61fc8999c6c1f763b5482bea850051ad42c842acf8
-SIZE (audacity-manual-3.7.1.tar.gz) = 26204232
-SHA256 (audacity-audacity-Audacity-3.7.1_GH0.tar.gz) = 02457fe0ae1dab3a9a50ce54836cdd78a2d3ab51650d42696cab417210f03906
-SIZE (audacity-audacity-Audacity-3.7.1_GH0.tar.gz) = 61647475
+TIMESTAMP = 1789019812
+SHA256 (audacity-manual-3.7.9.tar.gz) = 890a416172ddf6e34e6b2b49b062be3130202a4d5ad359c95d6d271118c5fb89
+SIZE (audacity-manual-3.7.9.tar.gz) = 26577174
+SHA256 (audacity-audacity-Audacity-3.7.9_GH0.tar.gz) = cd19ac5e252d5b3e96cab204ed0b4890cadb5d19d28b26833990e20fa8b33c63
+SIZE (audacity-audacity-Audacity-3.7.9_GH0.tar.gz) = 67471744

--- a/audio/audacity/pkg-plist
+++ b/audio/audacity/pkg-plist
@@ -328,6 +328,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/39/x2ushureoverdub_phones_mic.jpg
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3a/spectrogramview_08.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3b/envelope2.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3b/focus_versus_selection.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3b/labeltrack6.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3b/share_audio_dialog.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/3/3c/audio_track_dropdown_menu_3_6_0_mult_view_selection.png
@@ -389,6 +390,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/48/waveform_colorway_3_1_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/export_wav_3_4_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/extra_devicemenu.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/front_page_3_7_3_78_numbered.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/glitch_repair_after.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/spectrogramview_11.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/4/49/uca202tolaptop.jpg
@@ -450,6 +452,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/57/status_bar_disc_space_remaining.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/58/multi_view_stereo_default_50_50.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/58/splitting_and_joining_stereo_tracks_04.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/5/59/horizontal_scrollbar.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/59/spectraledit_01.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/59/toolstoolbarmulti.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/5/5a/regular_interval_labels_3_5_0.png
@@ -554,7 +557,6 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/74/editmenuclipboundaries_split_01.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/74/label_menu_delete_highlighted.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/74/mono_track_for_add_new.png
-%%MANUAL%%%%DATADIR%%/help/manual/m/images/7/75/manage_plugins_dialog_3_5_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/75/sltg_edits_15.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/75/sltg_stretching_2.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/7/76/audio_stereo_1_8_small.jpg
@@ -720,6 +722,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a3/low_pass_filter_3_5_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a3/splitting_and_joining_stereo_tracks_02.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a4/compressor_parameters_smoothing_waveform_attack_1ms_%%CMAKE_BUILD_TYPE%%_10ms.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a4/effect_menu_3_7_4.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a5/message.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a5/move_cursor_to_selection_end_post.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/a5/render_clip_speed.png
@@ -752,6 +755,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ac/tutorial3labelsinplace.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/compressor_parameters_smoothing_spectrum_lookahead.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/ex2b_before.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/manage_plugins_dialog_3_7_4.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/samsongtrackconnections.jpg
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/smartclip_03.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/a/ad/timeshift.png
@@ -884,7 +888,6 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cb/wahwah_3_5_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cc/labelregionmove1after_w10.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cc/playback_meter_in_use_clipped_signal.png
-%%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cd/front_page_3_6_0_78_numbered.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cd/importrawdata.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cd/preferences_shortcuts.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/c/cd/toolstoolbarsamples.png
@@ -916,6 +919,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d4/pro_fade_out.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d4/status_bar_disk_space_remaining_for_recording_3_6_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d5/extra_transportmenu.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d5/get_effects_dialog_3_7_3.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d5/loop_button.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d5/savepresetmacdialog.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/d/d6/ex2c_before.png
@@ -959,11 +963,13 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e1/edit_labeled_audio_3_7_0.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e1/exportmultipleexample02.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e1/sltg_edits_11.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e2/vertical_scrollbar.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e2/waveform_digital.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/earbud_by_mic.jpg
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/ex1b_before.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/exponential_fade_in.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/select_region_menu_3_2_3.png
+%%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/sharing_effects_toolbar_3_7_3.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/spectraleditnotch02.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e3/warning_save_empty_project.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/e4/clip_pitch_and_speed.png
@@ -1001,7 +1007,6 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/appended_recording_in_beats_and_bars_mode.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/clicky_example_waveform_view_click_labelled_and_zoomed_red_arrows.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/connect_dots_stem_plot_examples.png
-%%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/effect_menu_3_6_2.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/error_for_locked_configuration_files.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/spectrogramview_05a.png
 %%MANUAL%%%%DATADIR%%/help/manual/m/images/e/ef/spectrogramview_07.png
@@ -1353,6 +1358,7 @@ share/applications/audacity.desktop
 %%MANUAL%%%%DATADIR%%/help/manual/man/saving.html
 %%MANUAL%%%%DATADIR%%/help/manual/man/scripting.html
 %%MANUAL%%%%DATADIR%%/help/manual/man/scripting_reference.html
+%%MANUAL%%%%DATADIR%%/help/manual/man/scrollbars.html
 %%MANUAL%%%%DATADIR%%/help/manual/man/scrubbing_and_seeking.html
 %%MANUAL%%%%DATADIR%%/help/manual/man/searching_the_manual.html
 %%MANUAL%%%%DATADIR%%/help/manual/man/select_menu.html


### PR DESCRIPTION
Updates Audacity to 3.7.9 and refreshes the optional manual manifest.  Adds the required icon-cache metadata.

Validation: bmake makesum, patch, build, fake, package, test (existing test configuration is a no-op), check-license, portlint -C (0 fatals), and git diff --check.

The source unconditionally builds locale catalogs, so the existing non-functional NLS handling remains documented rather than being exposed as an option.

## Summary by Sourcery

Update the Audacity port to 3.7.9 with refreshed packaging metadata and icon-cache support.

Enhancements:
- Update Audacity to version 3.7.9 and refresh its optional manual resources.
- Enable icon-cache integration and retain documentation for upstream’s unconditional locale catalog generation.