### PR TITLE
math/gnumeric: update to 1.12.61

### DIFF
--- a/math/gnumeric/Makefile
+++ b/math/gnumeric/Makefile
@@ -1,33 +1,31 @@
 PORTNAME=	gnumeric
-PORTVERSION=	1.12.52
-PORTREVISION=	2
+PORTVERSION=	1.12.61
 CATEGORIES=	math gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GNOME spreadsheet program
-WWW=		http://www.gnumeric.org
+WWW=		https://gnome.pages.gitlab.gnome.org/gnumeric-web/
 
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	itstool:textproc/itstool \
 		ginstall:sysutils/coreutils
-LIB_DEPENDS=	libgoffice-0.10.so:devel/goffice \
-		libfribidi.so:converters/fribidi \
-		libpsiconv.so:converters/psiconv
+LIB_DEPENDS=	libgoffice-0.10.so:devel/goffice
 
 USES=		cpe desktop-file-utils gettext gmake gnome libtool \
 		localbase pathfix pkgconfig python shebangfix tar:xz
-USE_GNOME=	cairo intlhack gtk30 libgsf pygobject3
+USE_GNOME=	cairo gdkpixbuf glib20 intltool:build introspection gtk-update-icon-cache gtk30 \
+		libgsf libxml2 pango pygobject3
 USE_LDCONFIG=	yes
 INSTALLS_ICONS=	yes
 GNU_CONFIGURE=	yes
-CONFIGURE_ARGS=	\
+CONFIGURE_ARGS=	--without-gda \
 		--without-paradox \
-		--without-python \
-		--enable-introspection
+		--without-psiconv \
+		--enable-introspection=yes
 INSTALL_TARGET=	install-strip
 
 CPE_VENDOR=	gnome
@@ -45,26 +43,16 @@ PLIST_SUB=	VERSION=${PORTVERSION} \
 		GOFFICE=0.10 \
 		SHORT_VER=${PORTVERSION:R}
 
-OPTIONS_SUB=	yes
-OPTIONS_DEFINE=	PERL GDA
+OPTIONS_DEFINE=	PERL
 OPTIONS_DEFAULT=PERL
-GDA_DESC=	Gnome Database Access plugin
 PERL_DESC=	Support Perl as extension language
+OPTIONS_SUB=	yes
 
 PERL_USES=	perl5
 PERL_CONFIGURE_WITH=	perl
 
-GDA_CONFIGURE_WITH=	gda
-GDA_USE=	GNOME=libgda5-ui
-
 post-patch:
 	@${REINPLACE_CMD} -e 's|^GETTEXT_PACKAGE=gnumeric-$${VERSION}|GETTEXT_PACKAGE=gnumeric|g' \
 		${WRKSRC}/configure
-
-post-install:
-	${PYTHON_CMD} -O ${PYTHON_LIBDIR}/compileall.py -d \
-		${PREFIX}/${dir}/gnumeric -f ${PREFIX}/lib/gnumeric/${PORTVERSION}
-	${PYTHON_CMD} ${PYTHON_LIBDIR}/compileall.py -d \
-		${PREFIX}/${dir}/gnumeric -f ${PREFIX}/lib/gnumeric/${PORTVERSION}
 
 .include <bsd.port.mk>

--- a/math/gnumeric/distinfo
+++ b/math/gnumeric/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1651006576
-SHA256 (gnome/gnumeric-1.12.52.tar.xz) = 73cf73049a22a1d828506275b2c9378ec37c5ff37b68bb1f2f494f0d6400823b
-SIZE (gnome/gnumeric-1.12.52.tar.xz) = 18115444
+TIMESTAMP = 1777576340
+SHA256 (gnome/gnumeric-1.12.61.tar.xz) = 2ac135d856572713c1a408b76b50a59f2a9769ed21f1213446b5af255df20a12
+SIZE (gnome/gnumeric-1.12.61.tar.xz) = 17921384

--- a/math/gnumeric/pkg-plist
+++ b/math/gnumeric/pkg-plist
@@ -129,15 +129,19 @@ include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-auto-expression.
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-chi-squared.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-exp-smoothing.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-frequency.h
+include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-ftest.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-histogram.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-kaplan-meier.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-normality.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-one-mean-test.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-principal-components.h
+include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-regression.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-sign-test.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-signed-rank-test.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-tools.h
+include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-ttest.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-wilcoxon-mann-whitney.h
+include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/analysis-ztest.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/auto-correct.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/dao.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/data-shuffling.h
@@ -150,7 +154,6 @@ include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/random-generator.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/scenarios.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/simulation.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/tabulate.h
-include/libspreadsheet-%%SHORT_VER%%/spreadsheet/tools/tools.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/undo.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/validation-combo.h
 include/libspreadsheet-%%SHORT_VER%%/spreadsheet/validation.h
@@ -191,9 +194,6 @@ lib/gnumeric/%%VERSION%%/plugins/dif/dif.so
 lib/gnumeric/%%VERSION%%/plugins/dif/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/excel/excel.so
 lib/gnumeric/%%VERSION%%/plugins/excel/plugin.xml
-lib/gnumeric/%%VERSION%%/plugins/excelplugins/plugin.so
-lib/gnumeric/%%VERSION%%/plugins/excelplugins/plugin.xml
-lib/gnumeric/%%VERSION%%/plugins/excelplugins/xlcall32.so
 lib/gnumeric/%%VERSION%%/plugins/fn-christian-date/plugin.so
 lib/gnumeric/%%VERSION%%/plugins/fn-christian-date/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/fn-complex/plugin.so
@@ -210,6 +210,8 @@ lib/gnumeric/%%VERSION%%/plugins/fn-erlang/erlang.so
 lib/gnumeric/%%VERSION%%/plugins/fn-erlang/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/fn-financial/plugin.so
 lib/gnumeric/%%VERSION%%/plugins/fn-financial/plugin.xml
+lib/gnumeric/%%VERSION%%/plugins/fn-flt/plugin.so
+lib/gnumeric/%%VERSION%%/plugins/fn-flt/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/fn-hebrew-date/plugin.so
 lib/gnumeric/%%VERSION%%/plugins/fn-hebrew-date/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/fn-info/plugin.so
@@ -234,6 +236,9 @@ lib/gnumeric/%%VERSION%%/plugins/fn-tsa/plugin.so
 lib/gnumeric/%%VERSION%%/plugins/fn-tsa/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/glpk/glpk.so
 lib/gnumeric/%%VERSION%%/plugins/glpk/plugin.xml
+lib/gnumeric/%%VERSION%%/plugins/gnome-glossary/glossary-po-header
+lib/gnumeric/%%VERSION%%/plugins/gnome-glossary/gnome_glossary.py
+lib/gnumeric/%%VERSION%%/plugins/gnome-glossary/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/html/html.so
 lib/gnumeric/%%VERSION%%/plugins/html/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/lotus/lotus.so
@@ -254,8 +259,11 @@ lib/gnumeric/%%VERSION%%/plugins/perl-loader/perl_loader.so
 lib/gnumeric/%%VERSION%%/plugins/perl-loader/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/plan_perfect/plan_perfect.so
 lib/gnumeric/%%VERSION%%/plugins/plan_perfect/plugin.xml
-lib/gnumeric/%%VERSION%%/plugins/psiconv/plugin.xml
-lib/gnumeric/%%VERSION%%/plugins/psiconv/psiconv.so
+lib/gnumeric/%%VERSION%%/plugins/py-func/plugin.xml
+lib/gnumeric/%%VERSION%%/plugins/py-func/py_func.py
+lib/gnumeric/%%VERSION%%/plugins/python-loader/plugin.xml
+lib/gnumeric/%%VERSION%%/plugins/python-loader/python_loader.so
+lib/gnumeric/%%VERSION%%/plugins/python-loader/ui-console-menu.xml
 lib/gnumeric/%%VERSION%%/plugins/qpro/plugin.xml
 lib/gnumeric/%%VERSION%%/plugins/qpro/qpro.so
 lib/gnumeric/%%VERSION%%/plugins/sample_datasource/plugin.xml
@@ -275,12 +283,7 @@ lib/libspreadsheet-%%VERSION%%.so
 lib/libspreadsheet.so
 %%PYTHON_SITELIBDIR%%/gi/overrides/Gnm.py
 libdata/pkgconfig/libspreadsheet-%%SHORT_VER%%.pc
-share/man/man1/gnumeric.1.gz
-share/man/man1/ssconvert.1.gz
-share/man/man1/ssdiff.1.gz
-share/man/man1/ssgrep.1.gz
-share/man/man1/ssindex.1.gz
-share/applications/gnumeric.desktop
+share/applications/org.gnumeric.gnumeric.desktop
 share/gir-1.0/Gnm-%%SHORT_VER%%.gir
 %%DATADIR%%/%%VERSION%%/Gnumeric-embed.xml
 %%DATADIR%%/%%VERSION%%/autoformat-templates/3D/.category
@@ -829,447 +832,447 @@ share/help/C/gnumeric/quick-start.xml
 share/help/C/gnumeric/welcome.xml
 share/help/C/gnumeric/workbooks.xml
 share/help/C/gnumeric/worksheets.xml
-share/help/de/gnumeric/figures/advanced-filter-1.png
-share/help/de/gnumeric/figures/advanced-filter-2.png
-share/help/de/gnumeric/figures/analysis-simulation-confidence-interval-equation.png
-share/help/de/gnumeric/figures/analysis-simulation-demand-ex1.png
-share/help/de/gnumeric/figures/analysis-simulation-demand-ex2.png
-share/help/de/gnumeric/figures/analysis-simulation-interations-equation1.png
-share/help/de/gnumeric/figures/analysis-simulation-interations-equation2.png
-share/help/de/gnumeric/figures/analysis-simulation-maximumtime-dialog.png
-share/help/de/gnumeric/figures/analysis-simulation-options-dialog.png
-share/help/de/gnumeric/figures/analysis-simulation-output-dialog.png
-share/help/de/gnumeric/figures/analysis-simulation-profit-ex1.png
-share/help/de/gnumeric/figures/analysis-simulation-profit-ex2.png
-share/help/de/gnumeric/figures/analysis-simulation-report-screen.png
-share/help/de/gnumeric/figures/analysis-simulation-simtable-screen.png
-share/help/de/gnumeric/figures/analysis-simulation-summary-dialog.png
-share/help/de/gnumeric/figures/analysis-simulation-variables-dialog.png
-share/help/de/gnumeric/figures/analysistools-ANOVA1-ex1.png
-share/help/de/gnumeric/figures/analysistools-ANOVA1-ex2.png
-share/help/de/gnumeric/figures/analysistools-ANOVA2w-ex1.png
-share/help/de/gnumeric/figures/analysistools-ANOVA2w-ex2.png
-share/help/de/gnumeric/figures/analysistools-ANOVA2wo-ex1.png
-share/help/de/gnumeric/figures/analysistools-ANOVA2wo-ex2.png
-share/help/de/gnumeric/figures/analysistools-correlation-ex1.png
-share/help/de/gnumeric/figures/analysistools-correlation-ex2.png
-share/help/de/gnumeric/figures/analysistools-correlation-ex3.png
-share/help/de/gnumeric/figures/analysistools-correlation.png
-share/help/de/gnumeric/figures/analysistools-covariance-ex1.png
-share/help/de/gnumeric/figures/analysistools-covariance-ex2.png
-share/help/de/gnumeric/figures/analysistools-covariance.png
-share/help/de/gnumeric/figures/analysistools-descstats-ex1-options.png
-share/help/de/gnumeric/figures/analysistools-descstats-ex1.png
-share/help/de/gnumeric/figures/analysistools-descstats-ex2.png
-share/help/de/gnumeric/figures/analysistools-descstats.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-a-holt-winters-formula.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-a-holt-winters-stderr.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-holt-formula.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-holt-stderr.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-hunter-formula.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-hunter-stderr.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-m-holt-winters-formula.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-m-holt-winters-stderr.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-roberts-formula.png
-share/help/de/gnumeric/figures/analysistools-exp-smoothing-roberts-stderr.png
-share/help/de/gnumeric/figures/analysistools-fourier-formula.png
-share/help/de/gnumeric/figures/analysistools-fourier.png
-share/help/de/gnumeric/figures/analysistools-frequency-cats.png
-share/help/de/gnumeric/figures/analysistools-frequency-graphs.png
-share/help/de/gnumeric/figures/analysistools-frequency-results.png
-share/help/de/gnumeric/figures/analysistools-frequency.png
-share/help/de/gnumeric/figures/analysistools-ftest-ex1.png
-share/help/de/gnumeric/figures/analysistools-ftest-ex2.png
-share/help/de/gnumeric/figures/analysistools-ftest.png
-share/help/de/gnumeric/figures/analysistools-histogram-bins.png
-share/help/de/gnumeric/figures/analysistools-histogram-cutoffs.png
-share/help/de/gnumeric/figures/analysistools-histogram-ex1.png
-share/help/de/gnumeric/figures/analysistools-histogram-ex2.png
-share/help/de/gnumeric/figures/analysistools-histogram-ex3.png
-share/help/de/gnumeric/figures/analysistools-histogram-ex4.png
-share/help/de/gnumeric/figures/analysistools-histogram-ex5.png
-share/help/de/gnumeric/figures/analysistools-histogram-graphs.png
-share/help/de/gnumeric/figures/analysistools-histogram.png
-share/help/de/gnumeric/figures/analysistools-kaplan-ex1.png
-share/help/de/gnumeric/figures/analysistools-kaplan-ex2.png
-share/help/de/gnumeric/figures/analysistools-kaplan-ex3.png
-share/help/de/gnumeric/figures/analysistools-kaplan-groups.png
-share/help/de/gnumeric/figures/analysistools-kaplan-options.png
-share/help/de/gnumeric/figures/analysistools-kaplan.png
-share/help/de/gnumeric/figures/analysistools-moving-average-ex1.png
-share/help/de/gnumeric/figures/analysistools-moving-average-ex2.png
-share/help/de/gnumeric/figures/analysistools-moving-average-ex3.png
-share/help/de/gnumeric/figures/analysistools-moving-average-formula-central.png
-share/help/de/gnumeric/figures/analysistools-moving-average-formula-spencer.png
-share/help/de/gnumeric/figures/analysistools-moving-average-formula-weighted.png
-share/help/de/gnumeric/figures/analysistools-moving-average-options.png
-share/help/de/gnumeric/figures/analysistools-moving-average.png
-share/help/de/gnumeric/figures/analysistools-normality-ex1.png
-share/help/de/gnumeric/figures/analysistools-normality-ex2.png
-share/help/de/gnumeric/figures/analysistools-normality-ex3.png
-share/help/de/gnumeric/figures/analysistools-normality-ex4.png
-share/help/de/gnumeric/figures/analysistools-normality-testspec.png
-share/help/de/gnumeric/figures/analysistools-normality.png
-share/help/de/gnumeric/figures/analysistools-outputoptions.png
-share/help/de/gnumeric/figures/analysistools-pcanalysis-ex1.png
-share/help/de/gnumeric/figures/analysistools-pcanalysis-ex2.png
-share/help/de/gnumeric/figures/analysistools-pcanalysis.png
-share/help/de/gnumeric/figures/analysistools-random-ex1.png
-share/help/de/gnumeric/figures/analysistools-random-ex2.png
-share/help/de/gnumeric/figures/analysistools-random.png
-share/help/de/gnumeric/figures/analysistools-ranges.png
-share/help/de/gnumeric/figures/analysistools-rank-ex1.png
-share/help/de/gnumeric/figures/analysistools-rank-ex2.png
-share/help/de/gnumeric/figures/analysistools-rank.png
-share/help/de/gnumeric/figures/analysistools-regression-ex1.png
-share/help/de/gnumeric/figures/analysistools-regression-ex2.png
-share/help/de/gnumeric/figures/analysistools-regression-ex3.png
-share/help/de/gnumeric/figures/analysistools-regression.png
-share/help/de/gnumeric/figures/analysistools-sampling-ex1.png
-share/help/de/gnumeric/figures/analysistools-sampling-ex2.png
-share/help/de/gnumeric/figures/analysistools-sampling.png
-share/help/de/gnumeric/figures/analysistools-signtest-ex1.png
-share/help/de/gnumeric/figures/analysistools-signtest-ex2.png
-share/help/de/gnumeric/figures/analysistools-signtest-ex3.png
-share/help/de/gnumeric/figures/analysistools-signtest.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex1.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex2.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex3.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex4.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex5.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex6.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex7.png
-share/help/de/gnumeric/figures/analysistools-smoothing-ex8.png
-share/help/de/gnumeric/figures/analysistools-smoothing.png
-share/help/de/gnumeric/figures/analysistools-tools.png
-share/help/de/gnumeric/figures/analysistools-ttest-equal-ex1.png
-share/help/de/gnumeric/figures/analysistools-ttest-equal-ex2.png
-share/help/de/gnumeric/figures/analysistools-ttest-equal.png
-share/help/de/gnumeric/figures/analysistools-ttest-paired-ex1.png
-share/help/de/gnumeric/figures/analysistools-ttest-paired-ex2.png
-share/help/de/gnumeric/figures/analysistools-ttest-paired.png
-share/help/de/gnumeric/figures/analysistools-ttest-unequal-ex1.png
-share/help/de/gnumeric/figures/analysistools-ttest-unequal-ex2.png
-share/help/de/gnumeric/figures/analysistools-ttest-unequal.png
-share/help/de/gnumeric/figures/analysistools-ttest.png
-share/help/de/gnumeric/figures/analysistools-ztest-ex1.png
-share/help/de/gnumeric/figures/analysistools-ztest-ex2.png
-share/help/de/gnumeric/figures/analysistools-ztest.png
-share/help/de/gnumeric/figures/arrowhead-dimensions.png
-share/help/de/gnumeric/figures/button-align-center.png
-share/help/de/gnumeric/figures/button-align-left.png
-share/help/de/gnumeric/figures/button-align-right.png
-share/help/de/gnumeric/figures/button-arrow.png
-share/help/de/gnumeric/figures/button-bold.png
-share/help/de/gnumeric/figures/button-borders.png
-share/help/de/gnumeric/figures/button-button.png
-share/help/de/gnumeric/figures/button-center-across-selection.png
-share/help/de/gnumeric/figures/button-checkbox.png
-share/help/de/gnumeric/figures/button-combo.png
-share/help/de/gnumeric/figures/button-copy.png
-share/help/de/gnumeric/figures/button-cut.png
-share/help/de/gnumeric/figures/button-decrease-indent.png
-share/help/de/gnumeric/figures/button-decrease-precision.png
-share/help/de/gnumeric/figures/button-equals.png
-share/help/de/gnumeric/figures/button-fill.png
-share/help/de/gnumeric/figures/button-font-size.png
-share/help/de/gnumeric/figures/button-font-type.png
-share/help/de/gnumeric/figures/button-frame.png
-share/help/de/gnumeric/figures/button-function.png
-share/help/de/gnumeric/figures/button-graph.png
-share/help/de/gnumeric/figures/button-graphEditor-add.png
-share/help/de/gnumeric/figures/button-increase-indent.png
-share/help/de/gnumeric/figures/button-increase-precision.png
-share/help/de/gnumeric/figures/button-insert-component.png
-share/help/de/gnumeric/figures/button-insert-hyperlink.png
-share/help/de/gnumeric/figures/button-insert-object.png
-share/help/de/gnumeric/figures/button-italic.png
-share/help/de/gnumeric/figures/button-label.png
-share/help/de/gnumeric/figures/button-line.png
-share/help/de/gnumeric/figures/button-list.png
-share/help/de/gnumeric/figures/button-merge.png
-share/help/de/gnumeric/figures/button-money.png
-share/help/de/gnumeric/figures/button-new.png
-share/help/de/gnumeric/figures/button-open.png
-share/help/de/gnumeric/figures/button-oval.png
-share/help/de/gnumeric/figures/button-paste.png
-share/help/de/gnumeric/figures/button-percent.png
-share/help/de/gnumeric/figures/button-preview.png
-share/help/de/gnumeric/figures/button-print.png
-share/help/de/gnumeric/figures/button-radio.png
-share/help/de/gnumeric/figures/button-rectangle.png
-share/help/de/gnumeric/figures/button-redo-and-history.png
-share/help/de/gnumeric/figures/button-save.png
-share/help/de/gnumeric/figures/button-scrollbar.png
-share/help/de/gnumeric/figures/button-slider.png
-share/help/de/gnumeric/figures/button-sort-az.png
-share/help/de/gnumeric/figures/button-sort-za.png
-share/help/de/gnumeric/figures/button-spin.png
-share/help/de/gnumeric/figures/button-split.png
-share/help/de/gnumeric/figures/button-subscript.png
-share/help/de/gnumeric/figures/button-sum.png
-share/help/de/gnumeric/figures/button-superscript.png
-share/help/de/gnumeric/figures/button-text-colour.png
-share/help/de/gnumeric/figures/button-thousands.png
-share/help/de/gnumeric/figures/button-underline.png
-share/help/de/gnumeric/figures/button-undo-and-history.png
-share/help/de/gnumeric/figures/button-zoom.png
-share/help/de/gnumeric/figures/cell-grid.png
-share/help/de/gnumeric/figures/cell-selected.png
-share/help/de/gnumeric/figures/cell-with-text.png
-share/help/de/gnumeric/figures/cells-1.png
-share/help/de/gnumeric/figures/cells-2.png
-share/help/de/gnumeric/figures/chart_area_1_1.png
-share/help/de/gnumeric/figures/chart_area_1_2.png
-share/help/de/gnumeric/figures/chart_area_1_3.png
-share/help/de/gnumeric/figures/chart_bar_1_1.png
-share/help/de/gnumeric/figures/chart_bar_1_2.png
-share/help/de/gnumeric/figures/chart_bar_1_3.png
-share/help/de/gnumeric/figures/chart_bubble_1_1.png
-share/help/de/gnumeric/figures/chart_column_1_1.png
-share/help/de/gnumeric/figures/chart_column_1_2.png
-share/help/de/gnumeric/figures/chart_column_1_3.png
-share/help/de/gnumeric/figures/chart_line_1_1.png
-share/help/de/gnumeric/figures/chart_line_1_2.png
-share/help/de/gnumeric/figures/chart_line_1_3.png
-share/help/de/gnumeric/figures/chart_line_2_1.png
-share/help/de/gnumeric/figures/chart_line_2_2.png
-share/help/de/gnumeric/figures/chart_line_2_3.png
-share/help/de/gnumeric/figures/chart_pie_1_1.png
-share/help/de/gnumeric/figures/chart_pie_2_1.png
-share/help/de/gnumeric/figures/chart_radar_1_1.png
-share/help/de/gnumeric/figures/chart_radar_1_2.png
-share/help/de/gnumeric/figures/chart_radar_1_3.png
-share/help/de/gnumeric/figures/chart_ring_1_1.png
-share/help/de/gnumeric/figures/chart_ring_1_2.png
-share/help/de/gnumeric/figures/chart_scatter_1_1.png
-share/help/de/gnumeric/figures/chart_scatter_3_1.png
-share/help/de/gnumeric/figures/chart_scatter_3_2.png
-share/help/de/gnumeric/figures/chart_surface_1.png
-share/help/de/gnumeric/figures/chart_surface_2.png
-share/help/de/gnumeric/figures/dialog-auto-correct.png
-share/help/de/gnumeric/figures/dialog-autosave.png
-share/help/de/gnumeric/figures/dialog-fileopen-withTags.png
-share/help/de/gnumeric/figures/dialog-filesave-compact-withTags.png
-share/help/de/gnumeric/figures/dialog-filesave-expanded-withTags.png
-share/help/de/gnumeric/figures/dialog-filter.png
-share/help/de/gnumeric/figures/dialog-insert-object.png
-share/help/de/gnumeric/figures/dialog-properties-arrow.png
-share/help/de/gnumeric/figures/dialog-properties-checkbox.png
-share/help/de/gnumeric/figures/dialog-properties-frame.png
-share/help/de/gnumeric/figures/dialog-properties-label.png
-share/help/de/gnumeric/figures/dialog-properties-line.png
-share/help/de/gnumeric/figures/dialog-properties-oval.png
-share/help/de/gnumeric/figures/dialog-properties-rectangle.png
-share/help/de/gnumeric/figures/dialog-properties-scrollbar.png
-share/help/de/gnumeric/figures/drawing-arrow.png
-share/help/de/gnumeric/figures/drawing-line.png
-share/help/de/gnumeric/figures/drawing-oval.png
-share/help/de/gnumeric/figures/drawing-rectangle.png
-share/help/de/gnumeric/figures/example-colGraph-modified.png
-share/help/de/gnumeric/figures/example-colGraph.png
-share/help/de/gnumeric/figures/example-columnSelect.png
-share/help/de/gnumeric/figures/example-data.png
-share/help/de/gnumeric/figures/files-html-example.png
-share/help/de/gnumeric/figures/files-html32-example.png
-share/help/de/gnumeric/figures/files-html40-example.png
-share/help/de/gnumeric/figures/formula-dmedian.png
-share/help/de/gnumeric/figures/gnumeric-empty.png
-share/help/de/gnumeric/figures/gnumeric-icon-24.png
-share/help/de/gnumeric/figures/gnumeric-labelled.png
-share/help/de/gnumeric/figures/gnumeric-power-example.png
-share/help/de/gnumeric/figures/graph-axes-grid.png
-share/help/de/gnumeric/figures/graph-components.png
-share/help/de/gnumeric/figures/graph-example-area.png
-share/help/de/gnumeric/figures/graph-example-bar.png
-share/help/de/gnumeric/figures/graph-example-bubble.png
-share/help/de/gnumeric/figures/graph-example-column.png
-share/help/de/gnumeric/figures/graph-example-line.png
-share/help/de/gnumeric/figures/graph-example-pie.png
-share/help/de/gnumeric/figures/graph-example-radar.png
-share/help/de/gnumeric/figures/graph-example-ring.png
-share/help/de/gnumeric/figures/graph-example-surface-t1.png
-share/help/de/gnumeric/figures/graph-example-surface-t2.png
-share/help/de/gnumeric/figures/graph-example-xyplot.png
-share/help/de/gnumeric/figures/graph-hierarchy.png
-share/help/de/gnumeric/figures/graphguru-axes-category-bounds.png
-share/help/de/gnumeric/figures/graphguru-axes-category-details.png
-share/help/de/gnumeric/figures/graphguru-axes-category-style.png
-share/help/de/gnumeric/figures/graphguru-axes-continuous-bounds.png
-share/help/de/gnumeric/figures/graphguru-axes-continuous-format.png
-share/help/de/gnumeric/figures/graphguru-backPanels-gradient.png
-share/help/de/gnumeric/figures/graphguru-backPanels-image.png
-share/help/de/gnumeric/figures/graphguru-backPanels-none.png
-share/help/de/gnumeric/figures/graphguru-backPanels-pattern.png
-share/help/de/gnumeric/figures/graphguru-components.png
-share/help/de/gnumeric/figures/graphguru-plot-barCol.png
-share/help/de/gnumeric/figures/graphguru-plot-bubble.png
-share/help/de/gnumeric/figures/graphguru-plot-pie.png
-share/help/de/gnumeric/figures/graphguru-plot-radar.png
-share/help/de/gnumeric/figures/graphguru-plot-ring.png
-share/help/de/gnumeric/figures/graphguru-series-data-bubble.png
-share/help/de/gnumeric/figures/graphguru-series-data-single.png
-share/help/de/gnumeric/figures/graphguru-series-data-xy.png
-share/help/de/gnumeric/figures/graphguru-series-error.png
-share/help/de/gnumeric/figures/graphguru-series-style-filled.png
-share/help/de/gnumeric/figures/graphguru-series-style-line.png
-share/help/de/gnumeric/figures/graphguru-title-font.png
-share/help/de/gnumeric/figures/graphical-elements-selected.png
-share/help/de/gnumeric/figures/graphical-elements-stacked.png
-share/help/de/gnumeric/figures/graphical-elements.png
-share/help/de/gnumeric/figures/graphs-types-area.png
-share/help/de/gnumeric/figures/graphs-types-bar.png
-share/help/de/gnumeric/figures/graphs-types-bubble.png
-share/help/de/gnumeric/figures/graphs-types-column.png
-share/help/de/gnumeric/figures/graphs-types-line.png
-share/help/de/gnumeric/figures/graphs-types-pie.png
-share/help/de/gnumeric/figures/graphs-types-radar.png
-share/help/de/gnumeric/figures/graphs-types-ring.png
-share/help/de/gnumeric/figures/graphs-types-stock.png
-share/help/de/gnumeric/figures/graphs-types-surface.png
-share/help/de/gnumeric/figures/graphs-types-xyplot.png
-share/help/de/gnumeric/figures/icon-locked.png
-share/help/de/gnumeric/figures/icon-unlocked.png
-share/help/de/gnumeric/figures/icon-visible.png
-share/help/de/gnumeric/figures/info-area.png
-share/help/de/gnumeric/figures/menu-context-col-row-header.png
-share/help/de/gnumeric/figures/menu-context-graph-order.png
-share/help/de/gnumeric/figures/menu-context-graph.png
-share/help/de/gnumeric/figures/menu-context-grid.png
-share/help/de/gnumeric/figures/menu-context-object-order.png
-share/help/de/gnumeric/figures/menu-context-object.png
-share/help/de/gnumeric/figures/menu-context-sheet-tabs.png
-share/help/de/gnumeric/figures/menu-context-tabs.png
-share/help/de/gnumeric/figures/menu-context-toolbars.png
-share/help/de/gnumeric/figures/menu-data-export.png
-share/help/de/gnumeric/figures/menu-data-import.png
-share/help/de/gnumeric/figures/menu-data-labelled.png
-share/help/de/gnumeric/figures/menu-edit-delete-cells.png
-share/help/de/gnumeric/figures/menu-edit-labelled.png
-share/help/de/gnumeric/figures/menu-edit-modify-names.png
-share/help/de/gnumeric/figures/menu-edit-paste-special.png
-share/help/de/gnumeric/figures/menu-edit-select.png
-share/help/de/gnumeric/figures/menu-file-labelled.png
-share/help/de/gnumeric/figures/menu-file-printarea.png
-share/help/de/gnumeric/figures/menu-format-column.png
-share/help/de/gnumeric/figures/menu-format-labelled.png
-share/help/de/gnumeric/figures/menu-format-sheet.png
-share/help/de/gnumeric/figures/menu-help-labelled.png
-share/help/de/gnumeric/figures/menu-insert-comment.png
-share/help/de/gnumeric/figures/menu-insert-fw.png
-share/help/de/gnumeric/figures/menu-insert-hyperlink.png
-share/help/de/gnumeric/figures/menu-insert-labelled.png
-share/help/de/gnumeric/figures/menu-insert-names.png
-share/help/de/gnumeric/figures/menu-statistics-labelled.png
-share/help/de/gnumeric/figures/menu-tools-labelled.png
-share/help/de/gnumeric/figures/menu-torn-off.png
-share/help/de/gnumeric/figures/menu-view-labelled.png
-share/help/de/gnumeric/figures/menu-view-properties-dialog-cm.png
-share/help/de/gnumeric/figures/menu-view-properties-dialog.png
-share/help/de/gnumeric/figures/menubar.png
-share/help/de/gnumeric/figures/number-format-border-dialog.png
-share/help/de/gnumeric/figures/number-format-color-dialog.png
-share/help/de/gnumeric/figures/number-format-dialog.png
-share/help/de/gnumeric/figures/number-format-font-dialog.png
-share/help/de/gnumeric/figures/number-format-justification-dialog-2.png
-share/help/de/gnumeric/figures/number-format-protection.png
-share/help/de/gnumeric/figures/number-format-validation-warning.png
-share/help/de/gnumeric/figures/number-format-validation.png
-share/help/de/gnumeric/figures/pointer_arrow_left_std.png
-share/help/de/gnumeric/figures/pointer_cross_hair.png
-share/help/de/gnumeric/figures/pointer_cross_wide.png
-share/help/de/gnumeric/figures/pointer_diagonal_resize.png
-share/help/de/gnumeric/figures/pointer_double_horizontal_arrow.png
-share/help/de/gnumeric/figures/pointer_double_vertical_arrow.png
-share/help/de/gnumeric/figures/pointer_four_way_arrow.png
-share/help/de/gnumeric/figures/pointer_hand_left.png
-share/help/de/gnumeric/figures/pointer_left.png
-share/help/de/gnumeric/figures/pointer_resize_multiple.png
-share/help/de/gnumeric/figures/pointer_right.png
-share/help/de/gnumeric/figures/pointer_text_edit.png
-share/help/de/gnumeric/figures/pointer_zoom_in.png
-share/help/de/gnumeric/figures/pointer_zoom_out.png
-share/help/de/gnumeric/figures/preferences-copypaste.png
-share/help/de/gnumeric/figures/preferences-files.png
-share/help/de/gnumeric/figures/preferences-font-header.png
-share/help/de/gnumeric/figures/preferences-font.png
-share/help/de/gnumeric/figures/preferences-screen.png
-share/help/de/gnumeric/figures/preferences-sorting.png
-share/help/de/gnumeric/figures/preferences-tools.png
-share/help/de/gnumeric/figures/preferences-undo.png
-share/help/de/gnumeric/figures/preferences-windows.png
-share/help/de/gnumeric/figures/print-large.png
-share/help/de/gnumeric/figures/print-preview-back.png
-share/help/de/gnumeric/figures/print-preview-first.png
-share/help/de/gnumeric/figures/print-preview-fit.png
-share/help/de/gnumeric/figures/print-preview-fitonetoone.png
-share/help/de/gnumeric/figures/print-preview-last.png
-share/help/de/gnumeric/figures/print-preview-next.png
-share/help/de/gnumeric/figures/print-preview-zoomin.png
-share/help/de/gnumeric/figures/print-preview-zoomout.png
-share/help/de/gnumeric/figures/print-worksheet-file-general.png
-share/help/de/gnumeric/figures/print-worksheet-job.png
-share/help/de/gnumeric/figures/print-worksheet-page_setup.png
-share/help/de/gnumeric/figures/print-worksheet-paper.png
-share/help/de/gnumeric/figures/print-worksheet-print_range.png
-share/help/de/gnumeric/figures/print-worksheet-printer-advanced.png
-share/help/de/gnumeric/figures/print-worksheet-printer-finishing.png
-share/help/de/gnumeric/figures/print-worksheet-printer-general.png
-share/help/de/gnumeric/figures/print-worksheet-printer-image_quality.png
-share/help/de/gnumeric/figures/print-worksheet-printer-job.png
-share/help/de/gnumeric/figures/print-worksheet-printer.png
-share/help/de/gnumeric/figures/printing-preview.png
-share/help/de/gnumeric/figures/printing-setup-header-config.png
-share/help/de/gnumeric/figures/printing-setup-header.png
-share/help/de/gnumeric/figures/printing-setup-page-paper-type.png
-share/help/de/gnumeric/figures/printing-setup-page.png
-share/help/de/gnumeric/figures/printing-setup-printarea.png
-share/help/de/gnumeric/figures/printing-setup-scale.png
-share/help/de/gnumeric/figures/printing-setup-sheet.png
-share/help/de/gnumeric/figures/selection-1.png
-share/help/de/gnumeric/figures/selection-10.png
-share/help/de/gnumeric/figures/selection-2.png
-share/help/de/gnumeric/figures/selection-3.png
-share/help/de/gnumeric/figures/selection-4.png
-share/help/de/gnumeric/figures/selection-5.png
-share/help/de/gnumeric/figures/selection-8.png
-share/help/de/gnumeric/figures/selection-9.png
-share/help/de/gnumeric/figures/solver-01.png
-share/help/de/gnumeric/figures/solver-02.png
-share/help/de/gnumeric/figures/solver-03.png
-share/help/de/gnumeric/figures/solver-04.png
-share/help/de/gnumeric/figures/solver-05.png
-share/help/de/gnumeric/figures/textguru-export-panel1-withTags.png
-share/help/de/gnumeric/figures/textguru-export-panel2-withTags.png
-share/help/de/gnumeric/figures/textguru-import-panel1-withTags.png
-share/help/de/gnumeric/figures/textguru-import-panel2a-withTags.png
-share/help/de/gnumeric/figures/textguru-import-panel2b-withTags.png
-share/help/de/gnumeric/figures/textguru-import-panel3-withTags.png
-share/help/de/gnumeric/figures/toolbar-extension-menu.png
-share/help/de/gnumeric/figures/toolbar-format-long.png
-share/help/de/gnumeric/figures/toolbar-format.png
-share/help/de/gnumeric/figures/toolbar-object.png
-share/help/de/gnumeric/figures/toolbar-standard.png
-share/help/de/gnumeric/figures/toolbars.png
-share/help/de/gnumeric/figures/widget-checkbox.png
-share/help/de/gnumeric/figures/widget-combobox.png
-share/help/de/gnumeric/figures/widget-entryBox-outlined.png
-share/help/de/gnumeric/figures/widget-frame.png
-share/help/de/gnumeric/figures/widget-label.png
-share/help/de/gnumeric/figures/widget-list.png
-share/help/de/gnumeric/figures/widget-scrollbar.png
-share/help/de/gnumeric/figures/widget-slider.png
-share/help/de/gnumeric/figures/widget-spinbutton.png
-share/help/de/gnumeric/figures/worksheet-cols-1.png
-share/help/de/gnumeric/figures/worksheet-data-1.png
-share/help/de/gnumeric/figures/worksheet-data-2.png
-share/help/de/gnumeric/figures/worksheet-data-3.png
-share/help/de/gnumeric/figures/worksheet-data-4.png
-share/help/de/gnumeric/figures/worksheet-managing-dialog.png
-share/help/de/gnumeric/figures/worksheet-rows-1.png
-share/help/de/gnumeric/figures/worksheet-running-calc-1.png
-share/help/de/gnumeric/gnumeric.xml
-share/help/de/gnumeric/index.docbook
+@comment share/help/de/gnumeric/figures/advanced-filter-1.png
+@comment share/help/de/gnumeric/figures/advanced-filter-2.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-confidence-interval-equation.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-demand-ex1.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-demand-ex2.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-interations-equation1.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-interations-equation2.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-maximumtime-dialog.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-options-dialog.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-output-dialog.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-profit-ex1.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-profit-ex2.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-report-screen.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-simtable-screen.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-summary-dialog.png
+@comment share/help/de/gnumeric/figures/analysis-simulation-variables-dialog.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA1-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA1-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA2w-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA2w-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA2wo-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ANOVA2wo-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-correlation-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-correlation-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-correlation-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-correlation.png
+@comment share/help/de/gnumeric/figures/analysistools-covariance-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-covariance-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-covariance.png
+@comment share/help/de/gnumeric/figures/analysistools-descstats-ex1-options.png
+@comment share/help/de/gnumeric/figures/analysistools-descstats-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-descstats-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-descstats.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-a-holt-winters-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-a-holt-winters-stderr.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-holt-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-holt-stderr.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-hunter-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-hunter-stderr.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-m-holt-winters-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-m-holt-winters-stderr.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-roberts-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-exp-smoothing-roberts-stderr.png
+@comment share/help/de/gnumeric/figures/analysistools-fourier-formula.png
+@comment share/help/de/gnumeric/figures/analysistools-fourier.png
+@comment share/help/de/gnumeric/figures/analysistools-frequency-cats.png
+@comment share/help/de/gnumeric/figures/analysistools-frequency-graphs.png
+@comment share/help/de/gnumeric/figures/analysistools-frequency-results.png
+@comment share/help/de/gnumeric/figures/analysistools-frequency.png
+@comment share/help/de/gnumeric/figures/analysistools-ftest-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ftest-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ftest.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-bins.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-cutoffs.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-ex4.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-ex5.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram-graphs.png
+@comment share/help/de/gnumeric/figures/analysistools-histogram.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan-groups.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan-options.png
+@comment share/help/de/gnumeric/figures/analysistools-kaplan.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-formula-central.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-formula-spencer.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-formula-weighted.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average-options.png
+@comment share/help/de/gnumeric/figures/analysistools-moving-average.png
+@comment share/help/de/gnumeric/figures/analysistools-normality-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-normality-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-normality-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-normality-ex4.png
+@comment share/help/de/gnumeric/figures/analysistools-normality-testspec.png
+@comment share/help/de/gnumeric/figures/analysistools-normality.png
+@comment share/help/de/gnumeric/figures/analysistools-outputoptions.png
+@comment share/help/de/gnumeric/figures/analysistools-pcanalysis-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-pcanalysis-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-pcanalysis.png
+@comment share/help/de/gnumeric/figures/analysistools-random-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-random-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-random.png
+@comment share/help/de/gnumeric/figures/analysistools-ranges.png
+@comment share/help/de/gnumeric/figures/analysistools-rank-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-rank-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-rank.png
+@comment share/help/de/gnumeric/figures/analysistools-regression-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-regression-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-regression-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-regression.png
+@comment share/help/de/gnumeric/figures/analysistools-sampling-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-sampling-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-sampling.png
+@comment share/help/de/gnumeric/figures/analysistools-signtest-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-signtest-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-signtest-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-signtest.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex3.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex4.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex5.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex6.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex7.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing-ex8.png
+@comment share/help/de/gnumeric/figures/analysistools-smoothing.png
+@comment share/help/de/gnumeric/figures/analysistools-tools.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-equal-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-equal-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-equal.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-paired-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-paired-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-paired.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-unequal-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-unequal-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest-unequal.png
+@comment share/help/de/gnumeric/figures/analysistools-ttest.png
+@comment share/help/de/gnumeric/figures/analysistools-ztest-ex1.png
+@comment share/help/de/gnumeric/figures/analysistools-ztest-ex2.png
+@comment share/help/de/gnumeric/figures/analysistools-ztest.png
+@comment share/help/de/gnumeric/figures/arrowhead-dimensions.png
+@comment share/help/de/gnumeric/figures/button-align-center.png
+@comment share/help/de/gnumeric/figures/button-align-left.png
+@comment share/help/de/gnumeric/figures/button-align-right.png
+@comment share/help/de/gnumeric/figures/button-arrow.png
+@comment share/help/de/gnumeric/figures/button-bold.png
+@comment share/help/de/gnumeric/figures/button-borders.png
+@comment share/help/de/gnumeric/figures/button-button.png
+@comment share/help/de/gnumeric/figures/button-center-across-selection.png
+@comment share/help/de/gnumeric/figures/button-checkbox.png
+@comment share/help/de/gnumeric/figures/button-combo.png
+@comment share/help/de/gnumeric/figures/button-copy.png
+@comment share/help/de/gnumeric/figures/button-cut.png
+@comment share/help/de/gnumeric/figures/button-decrease-indent.png
+@comment share/help/de/gnumeric/figures/button-decrease-precision.png
+@comment share/help/de/gnumeric/figures/button-equals.png
+@comment share/help/de/gnumeric/figures/button-fill.png
+@comment share/help/de/gnumeric/figures/button-font-size.png
+@comment share/help/de/gnumeric/figures/button-font-type.png
+@comment share/help/de/gnumeric/figures/button-frame.png
+@comment share/help/de/gnumeric/figures/button-function.png
+@comment share/help/de/gnumeric/figures/button-graph.png
+@comment share/help/de/gnumeric/figures/button-graphEditor-add.png
+@comment share/help/de/gnumeric/figures/button-increase-indent.png
+@comment share/help/de/gnumeric/figures/button-increase-precision.png
+@comment share/help/de/gnumeric/figures/button-insert-component.png
+@comment share/help/de/gnumeric/figures/button-insert-hyperlink.png
+@comment share/help/de/gnumeric/figures/button-insert-object.png
+@comment share/help/de/gnumeric/figures/button-italic.png
+@comment share/help/de/gnumeric/figures/button-label.png
+@comment share/help/de/gnumeric/figures/button-line.png
+@comment share/help/de/gnumeric/figures/button-list.png
+@comment share/help/de/gnumeric/figures/button-merge.png
+@comment share/help/de/gnumeric/figures/button-money.png
+@comment share/help/de/gnumeric/figures/button-new.png
+@comment share/help/de/gnumeric/figures/button-open.png
+@comment share/help/de/gnumeric/figures/button-oval.png
+@comment share/help/de/gnumeric/figures/button-paste.png
+@comment share/help/de/gnumeric/figures/button-percent.png
+@comment share/help/de/gnumeric/figures/button-preview.png
+@comment share/help/de/gnumeric/figures/button-print.png
+@comment share/help/de/gnumeric/figures/button-radio.png
+@comment share/help/de/gnumeric/figures/button-rectangle.png
+@comment share/help/de/gnumeric/figures/button-redo-and-history.png
+@comment share/help/de/gnumeric/figures/button-save.png
+@comment share/help/de/gnumeric/figures/button-scrollbar.png
+@comment share/help/de/gnumeric/figures/button-slider.png
+@comment share/help/de/gnumeric/figures/button-sort-az.png
+@comment share/help/de/gnumeric/figures/button-sort-za.png
+@comment share/help/de/gnumeric/figures/button-spin.png
+@comment share/help/de/gnumeric/figures/button-split.png
+@comment share/help/de/gnumeric/figures/button-subscript.png
+@comment share/help/de/gnumeric/figures/button-sum.png
+@comment share/help/de/gnumeric/figures/button-superscript.png
+@comment share/help/de/gnumeric/figures/button-text-colour.png
+@comment share/help/de/gnumeric/figures/button-thousands.png
+@comment share/help/de/gnumeric/figures/button-underline.png
+@comment share/help/de/gnumeric/figures/button-undo-and-history.png
+@comment share/help/de/gnumeric/figures/button-zoom.png
+@comment share/help/de/gnumeric/figures/cell-grid.png
+@comment share/help/de/gnumeric/figures/cell-selected.png
+@comment share/help/de/gnumeric/figures/cell-with-text.png
+@comment share/help/de/gnumeric/figures/cells-1.png
+@comment share/help/de/gnumeric/figures/cells-2.png
+@comment share/help/de/gnumeric/figures/chart_area_1_1.png
+@comment share/help/de/gnumeric/figures/chart_area_1_2.png
+@comment share/help/de/gnumeric/figures/chart_area_1_3.png
+@comment share/help/de/gnumeric/figures/chart_bar_1_1.png
+@comment share/help/de/gnumeric/figures/chart_bar_1_2.png
+@comment share/help/de/gnumeric/figures/chart_bar_1_3.png
+@comment share/help/de/gnumeric/figures/chart_bubble_1_1.png
+@comment share/help/de/gnumeric/figures/chart_column_1_1.png
+@comment share/help/de/gnumeric/figures/chart_column_1_2.png
+@comment share/help/de/gnumeric/figures/chart_column_1_3.png
+@comment share/help/de/gnumeric/figures/chart_line_1_1.png
+@comment share/help/de/gnumeric/figures/chart_line_1_2.png
+@comment share/help/de/gnumeric/figures/chart_line_1_3.png
+@comment share/help/de/gnumeric/figures/chart_line_2_1.png
+@comment share/help/de/gnumeric/figures/chart_line_2_2.png
+@comment share/help/de/gnumeric/figures/chart_line_2_3.png
+@comment share/help/de/gnumeric/figures/chart_pie_1_1.png
+@comment share/help/de/gnumeric/figures/chart_pie_2_1.png
+@comment share/help/de/gnumeric/figures/chart_radar_1_1.png
+@comment share/help/de/gnumeric/figures/chart_radar_1_2.png
+@comment share/help/de/gnumeric/figures/chart_radar_1_3.png
+@comment share/help/de/gnumeric/figures/chart_ring_1_1.png
+@comment share/help/de/gnumeric/figures/chart_ring_1_2.png
+@comment share/help/de/gnumeric/figures/chart_scatter_1_1.png
+@comment share/help/de/gnumeric/figures/chart_scatter_3_1.png
+@comment share/help/de/gnumeric/figures/chart_scatter_3_2.png
+@comment share/help/de/gnumeric/figures/chart_surface_1.png
+@comment share/help/de/gnumeric/figures/chart_surface_2.png
+@comment share/help/de/gnumeric/figures/dialog-auto-correct.png
+@comment share/help/de/gnumeric/figures/dialog-autosave.png
+@comment share/help/de/gnumeric/figures/dialog-fileopen-withTags.png
+@comment share/help/de/gnumeric/figures/dialog-filesave-compact-withTags.png
+@comment share/help/de/gnumeric/figures/dialog-filesave-expanded-withTags.png
+@comment share/help/de/gnumeric/figures/dialog-filter.png
+@comment share/help/de/gnumeric/figures/dialog-insert-object.png
+@comment share/help/de/gnumeric/figures/dialog-properties-arrow.png
+@comment share/help/de/gnumeric/figures/dialog-properties-checkbox.png
+@comment share/help/de/gnumeric/figures/dialog-properties-frame.png
+@comment share/help/de/gnumeric/figures/dialog-properties-label.png
+@comment share/help/de/gnumeric/figures/dialog-properties-line.png
+@comment share/help/de/gnumeric/figures/dialog-properties-oval.png
+@comment share/help/de/gnumeric/figures/dialog-properties-rectangle.png
+@comment share/help/de/gnumeric/figures/dialog-properties-scrollbar.png
+@comment share/help/de/gnumeric/figures/drawing-arrow.png
+@comment share/help/de/gnumeric/figures/drawing-line.png
+@comment share/help/de/gnumeric/figures/drawing-oval.png
+@comment share/help/de/gnumeric/figures/drawing-rectangle.png
+@comment share/help/de/gnumeric/figures/example-colGraph-modified.png
+@comment share/help/de/gnumeric/figures/example-colGraph.png
+@comment share/help/de/gnumeric/figures/example-columnSelect.png
+@comment share/help/de/gnumeric/figures/example-data.png
+@comment share/help/de/gnumeric/figures/files-html-example.png
+@comment share/help/de/gnumeric/figures/files-html32-example.png
+@comment share/help/de/gnumeric/figures/files-html40-example.png
+@comment share/help/de/gnumeric/figures/formula-dmedian.png
+@comment share/help/de/gnumeric/figures/gnumeric-empty.png
+@comment share/help/de/gnumeric/figures/gnumeric-icon-24.png
+@comment share/help/de/gnumeric/figures/gnumeric-labelled.png
+@comment share/help/de/gnumeric/figures/gnumeric-power-example.png
+@comment share/help/de/gnumeric/figures/graph-axes-grid.png
+@comment share/help/de/gnumeric/figures/graph-components.png
+@comment share/help/de/gnumeric/figures/graph-example-area.png
+@comment share/help/de/gnumeric/figures/graph-example-bar.png
+@comment share/help/de/gnumeric/figures/graph-example-bubble.png
+@comment share/help/de/gnumeric/figures/graph-example-column.png
+@comment share/help/de/gnumeric/figures/graph-example-line.png
+@comment share/help/de/gnumeric/figures/graph-example-pie.png
+@comment share/help/de/gnumeric/figures/graph-example-radar.png
+@comment share/help/de/gnumeric/figures/graph-example-ring.png
+@comment share/help/de/gnumeric/figures/graph-example-surface-t1.png
+@comment share/help/de/gnumeric/figures/graph-example-surface-t2.png
+@comment share/help/de/gnumeric/figures/graph-example-xyplot.png
+@comment share/help/de/gnumeric/figures/graph-hierarchy.png
+@comment share/help/de/gnumeric/figures/graphguru-axes-category-bounds.png
+@comment share/help/de/gnumeric/figures/graphguru-axes-category-details.png
+@comment share/help/de/gnumeric/figures/graphguru-axes-category-style.png
+@comment share/help/de/gnumeric/figures/graphguru-axes-continuous-bounds.png
+@comment share/help/de/gnumeric/figures/graphguru-axes-continuous-format.png
+@comment share/help/de/gnumeric/figures/graphguru-backPanels-gradient.png
+@comment share/help/de/gnumeric/figures/graphguru-backPanels-image.png
+@comment share/help/de/gnumeric/figures/graphguru-backPanels-none.png
+@comment share/help/de/gnumeric/figures/graphguru-backPanels-pattern.png
+@comment share/help/de/gnumeric/figures/graphguru-components.png
+@comment share/help/de/gnumeric/figures/graphguru-plot-barCol.png
+@comment share/help/de/gnumeric/figures/graphguru-plot-bubble.png
+@comment share/help/de/gnumeric/figures/graphguru-plot-pie.png
+@comment share/help/de/gnumeric/figures/graphguru-plot-radar.png
+@comment share/help/de/gnumeric/figures/graphguru-plot-ring.png
+@comment share/help/de/gnumeric/figures/graphguru-series-data-bubble.png
+@comment share/help/de/gnumeric/figures/graphguru-series-data-single.png
+@comment share/help/de/gnumeric/figures/graphguru-series-data-xy.png
+@comment share/help/de/gnumeric/figures/graphguru-series-error.png
+@comment share/help/de/gnumeric/figures/graphguru-series-style-filled.png
+@comment share/help/de/gnumeric/figures/graphguru-series-style-line.png
+@comment share/help/de/gnumeric/figures/graphguru-title-font.png
+@comment share/help/de/gnumeric/figures/graphical-elements-selected.png
+@comment share/help/de/gnumeric/figures/graphical-elements-stacked.png
+@comment share/help/de/gnumeric/figures/graphical-elements.png
+@comment share/help/de/gnumeric/figures/graphs-types-area.png
+@comment share/help/de/gnumeric/figures/graphs-types-bar.png
+@comment share/help/de/gnumeric/figures/graphs-types-bubble.png
+@comment share/help/de/gnumeric/figures/graphs-types-column.png
+@comment share/help/de/gnumeric/figures/graphs-types-line.png
+@comment share/help/de/gnumeric/figures/graphs-types-pie.png
+@comment share/help/de/gnumeric/figures/graphs-types-radar.png
+@comment share/help/de/gnumeric/figures/graphs-types-ring.png
+@comment share/help/de/gnumeric/figures/graphs-types-stock.png
+@comment share/help/de/gnumeric/figures/graphs-types-surface.png
+@comment share/help/de/gnumeric/figures/graphs-types-xyplot.png
+@comment share/help/de/gnumeric/figures/icon-locked.png
+@comment share/help/de/gnumeric/figures/icon-unlocked.png
+@comment share/help/de/gnumeric/figures/icon-visible.png
+@comment share/help/de/gnumeric/figures/info-area.png
+@comment share/help/de/gnumeric/figures/menu-context-col-row-header.png
+@comment share/help/de/gnumeric/figures/menu-context-graph-order.png
+@comment share/help/de/gnumeric/figures/menu-context-graph.png
+@comment share/help/de/gnumeric/figures/menu-context-grid.png
+@comment share/help/de/gnumeric/figures/menu-context-object-order.png
+@comment share/help/de/gnumeric/figures/menu-context-object.png
+@comment share/help/de/gnumeric/figures/menu-context-sheet-tabs.png
+@comment share/help/de/gnumeric/figures/menu-context-tabs.png
+@comment share/help/de/gnumeric/figures/menu-context-toolbars.png
+@comment share/help/de/gnumeric/figures/menu-data-export.png
+@comment share/help/de/gnumeric/figures/menu-data-import.png
+@comment share/help/de/gnumeric/figures/menu-data-labelled.png
+@comment share/help/de/gnumeric/figures/menu-edit-delete-cells.png
+@comment share/help/de/gnumeric/figures/menu-edit-labelled.png
+@comment share/help/de/gnumeric/figures/menu-edit-modify-names.png
+@comment share/help/de/gnumeric/figures/menu-edit-paste-special.png
+@comment share/help/de/gnumeric/figures/menu-edit-select.png
+@comment share/help/de/gnumeric/figures/menu-file-labelled.png
+@comment share/help/de/gnumeric/figures/menu-file-printarea.png
+@comment share/help/de/gnumeric/figures/menu-format-column.png
+@comment share/help/de/gnumeric/figures/menu-format-labelled.png
+@comment share/help/de/gnumeric/figures/menu-format-sheet.png
+@comment share/help/de/gnumeric/figures/menu-help-labelled.png
+@comment share/help/de/gnumeric/figures/menu-insert-comment.png
+@comment share/help/de/gnumeric/figures/menu-insert-fw.png
+@comment share/help/de/gnumeric/figures/menu-insert-hyperlink.png
+@comment share/help/de/gnumeric/figures/menu-insert-labelled.png
+@comment share/help/de/gnumeric/figures/menu-insert-names.png
+@comment share/help/de/gnumeric/figures/menu-statistics-labelled.png
+@comment share/help/de/gnumeric/figures/menu-tools-labelled.png
+@comment share/help/de/gnumeric/figures/menu-torn-off.png
+@comment share/help/de/gnumeric/figures/menu-view-labelled.png
+@comment share/help/de/gnumeric/figures/menu-view-properties-dialog-cm.png
+@comment share/help/de/gnumeric/figures/menu-view-properties-dialog.png
+@comment share/help/de/gnumeric/figures/menubar.png
+@comment share/help/de/gnumeric/figures/number-format-border-dialog.png
+@comment share/help/de/gnumeric/figures/number-format-color-dialog.png
+@comment share/help/de/gnumeric/figures/number-format-dialog.png
+@comment share/help/de/gnumeric/figures/number-format-font-dialog.png
+@comment share/help/de/gnumeric/figures/number-format-justification-dialog-2.png
+@comment share/help/de/gnumeric/figures/number-format-protection.png
+@comment share/help/de/gnumeric/figures/number-format-validation-warning.png
+@comment share/help/de/gnumeric/figures/number-format-validation.png
+@comment share/help/de/gnumeric/figures/pointer_arrow_left_std.png
+@comment share/help/de/gnumeric/figures/pointer_cross_hair.png
+@comment share/help/de/gnumeric/figures/pointer_cross_wide.png
+@comment share/help/de/gnumeric/figures/pointer_diagonal_resize.png
+@comment share/help/de/gnumeric/figures/pointer_double_horizontal_arrow.png
+@comment share/help/de/gnumeric/figures/pointer_double_vertical_arrow.png
+@comment share/help/de/gnumeric/figures/pointer_four_way_arrow.png
+@comment share/help/de/gnumeric/figures/pointer_hand_left.png
+@comment share/help/de/gnumeric/figures/pointer_left.png
+@comment share/help/de/gnumeric/figures/pointer_resize_multiple.png
+@comment share/help/de/gnumeric/figures/pointer_right.png
+@comment share/help/de/gnumeric/figures/pointer_text_edit.png
+@comment share/help/de/gnumeric/figures/pointer_zoom_in.png
+@comment share/help/de/gnumeric/figures/pointer_zoom_out.png
+@comment share/help/de/gnumeric/figures/preferences-copypaste.png
+@comment share/help/de/gnumeric/figures/preferences-files.png
+@comment share/help/de/gnumeric/figures/preferences-font-header.png
+@comment share/help/de/gnumeric/figures/preferences-font.png
+@comment share/help/de/gnumeric/figures/preferences-screen.png
+@comment share/help/de/gnumeric/figures/preferences-sorting.png
+@comment share/help/de/gnumeric/figures/preferences-tools.png
+@comment share/help/de/gnumeric/figures/preferences-undo.png
+@comment share/help/de/gnumeric/figures/preferences-windows.png
+@comment share/help/de/gnumeric/figures/print-large.png
+@comment share/help/de/gnumeric/figures/print-preview-back.png
+@comment share/help/de/gnumeric/figures/print-preview-first.png
+@comment share/help/de/gnumeric/figures/print-preview-fit.png
+@comment share/help/de/gnumeric/figures/print-preview-fitonetoone.png
+@comment share/help/de/gnumeric/figures/print-preview-last.png
+@comment share/help/de/gnumeric/figures/print-preview-next.png
+@comment share/help/de/gnumeric/figures/print-preview-zoomin.png
+@comment share/help/de/gnumeric/figures/print-preview-zoomout.png
+@comment share/help/de/gnumeric/figures/print-worksheet-file-general.png
+@comment share/help/de/gnumeric/figures/print-worksheet-job.png
+@comment share/help/de/gnumeric/figures/print-worksheet-page_setup.png
+@comment share/help/de/gnumeric/figures/print-worksheet-paper.png
+@comment share/help/de/gnumeric/figures/print-worksheet-print_range.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer-advanced.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer-finishing.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer-general.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer-image_quality.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer-job.png
+@comment share/help/de/gnumeric/figures/print-worksheet-printer.png
+@comment share/help/de/gnumeric/figures/printing-preview.png
+@comment share/help/de/gnumeric/figures/printing-setup-header-config.png
+@comment share/help/de/gnumeric/figures/printing-setup-header.png
+@comment share/help/de/gnumeric/figures/printing-setup-page-paper-type.png
+@comment share/help/de/gnumeric/figures/printing-setup-page.png
+@comment share/help/de/gnumeric/figures/printing-setup-printarea.png
+@comment share/help/de/gnumeric/figures/printing-setup-scale.png
+@comment share/help/de/gnumeric/figures/printing-setup-sheet.png
+@comment share/help/de/gnumeric/figures/selection-1.png
+@comment share/help/de/gnumeric/figures/selection-10.png
+@comment share/help/de/gnumeric/figures/selection-2.png
+@comment share/help/de/gnumeric/figures/selection-3.png
+@comment share/help/de/gnumeric/figures/selection-4.png
+@comment share/help/de/gnumeric/figures/selection-5.png
+@comment share/help/de/gnumeric/figures/selection-8.png
+@comment share/help/de/gnumeric/figures/selection-9.png
+@comment share/help/de/gnumeric/figures/solver-01.png
+@comment share/help/de/gnumeric/figures/solver-02.png
+@comment share/help/de/gnumeric/figures/solver-03.png
+@comment share/help/de/gnumeric/figures/solver-04.png
+@comment share/help/de/gnumeric/figures/solver-05.png
+@comment share/help/de/gnumeric/figures/textguru-export-panel1-withTags.png
+@comment share/help/de/gnumeric/figures/textguru-export-panel2-withTags.png
+@comment share/help/de/gnumeric/figures/textguru-import-panel1-withTags.png
+@comment share/help/de/gnumeric/figures/textguru-import-panel2a-withTags.png
+@comment share/help/de/gnumeric/figures/textguru-import-panel2b-withTags.png
+@comment share/help/de/gnumeric/figures/textguru-import-panel3-withTags.png
+@comment share/help/de/gnumeric/figures/toolbar-extension-menu.png
+@comment share/help/de/gnumeric/figures/toolbar-format-long.png
+@comment share/help/de/gnumeric/figures/toolbar-format.png
+@comment share/help/de/gnumeric/figures/toolbar-object.png
+@comment share/help/de/gnumeric/figures/toolbar-standard.png
+@comment share/help/de/gnumeric/figures/toolbars.png
+@comment share/help/de/gnumeric/figures/widget-checkbox.png
+@comment share/help/de/gnumeric/figures/widget-combobox.png
+@comment share/help/de/gnumeric/figures/widget-entryBox-outlined.png
+@comment share/help/de/gnumeric/figures/widget-frame.png
+@comment share/help/de/gnumeric/figures/widget-label.png
+@comment share/help/de/gnumeric/figures/widget-list.png
+@comment share/help/de/gnumeric/figures/widget-scrollbar.png
+@comment share/help/de/gnumeric/figures/widget-slider.png
+@comment share/help/de/gnumeric/figures/widget-spinbutton.png
+@comment share/help/de/gnumeric/figures/worksheet-cols-1.png
+@comment share/help/de/gnumeric/figures/worksheet-data-1.png
+@comment share/help/de/gnumeric/figures/worksheet-data-2.png
+@comment share/help/de/gnumeric/figures/worksheet-data-3.png
+@comment share/help/de/gnumeric/figures/worksheet-data-4.png
+@comment share/help/de/gnumeric/figures/worksheet-managing-dialog.png
+@comment share/help/de/gnumeric/figures/worksheet-rows-1.png
+@comment share/help/de/gnumeric/figures/worksheet-running-calc-1.png
+@comment share/help/de/gnumeric/gnumeric.xml
+@comment share/help/de/gnumeric/index.docbook
 share/help/es/gnumeric/figures/advanced-filter-1.png
 share/help/es/gnumeric/figures/advanced-filter-2.png
 share/help/es/gnumeric/figures/analysis-simulation-confidence-interval-equation.png
@@ -2152,12 +2155,12 @@ share/help/sv/gnumeric/figures/worksheet-rows-1.png
 share/help/sv/gnumeric/figures/worksheet-running-calc-1.png
 share/help/sv/gnumeric/gnumeric.xml
 share/help/sv/gnumeric/index.docbook
-share/icons/hicolor/16x16/apps/gnumeric.png
-share/icons/hicolor/22x22/apps/gnumeric.png
-share/icons/hicolor/24x24/apps/gnumeric.png
-share/icons/hicolor/256x256/apps/gnumeric.png
-share/icons/hicolor/32x32/apps/gnumeric.png
-share/icons/hicolor/48x48/apps/gnumeric.png
+share/icons/hicolor/16x16/apps/org.gnumeric.gnumeric.png
+share/icons/hicolor/22x22/apps/org.gnumeric.gnumeric.png
+share/icons/hicolor/24x24/apps/org.gnumeric.gnumeric.png
+share/icons/hicolor/256x256/apps/org.gnumeric.gnumeric.png
+share/icons/hicolor/32x32/apps/org.gnumeric.gnumeric.png
+share/icons/hicolor/48x48/apps/org.gnumeric.gnumeric.png
 share/locale/am/LC_MESSAGES/gnumeric-functions.mo
 share/locale/am/LC_MESSAGES/gnumeric.mo
 share/locale/ar/LC_MESSAGES/gnumeric-functions.mo
@@ -2196,6 +2199,8 @@ share/locale/et/LC_MESSAGES/gnumeric-functions.mo
 share/locale/et/LC_MESSAGES/gnumeric.mo
 share/locale/eu/LC_MESSAGES/gnumeric-functions.mo
 share/locale/eu/LC_MESSAGES/gnumeric.mo
+share/locale/fa/LC_MESSAGES/gnumeric-functions.mo
+share/locale/fa/LC_MESSAGES/gnumeric.mo
 share/locale/fi/LC_MESSAGES/gnumeric-functions.mo
 share/locale/fi/LC_MESSAGES/gnumeric.mo
 share/locale/fr/LC_MESSAGES/gnumeric-functions.mo
@@ -2280,4 +2285,9 @@ share/locale/zh_HK/LC_MESSAGES/gnumeric-functions.mo
 share/locale/zh_HK/LC_MESSAGES/gnumeric.mo
 share/locale/zh_TW/LC_MESSAGES/gnumeric-functions.mo
 share/locale/zh_TW/LC_MESSAGES/gnumeric.mo
-share/metainfo/gnumeric.appdata.xml
+share/man/man1/gnumeric.1.gz
+share/man/man1/ssconvert.1.gz
+share/man/man1/ssdiff.1.gz
+share/man/man1/ssgrep.1.gz
+share/man/man1/ssindex.1.gz
+share/metainfo/org.gnumeric.gnumeric.appdata.xml


### PR DESCRIPTION
Updates Gnumeric to 1.12.61, removes PORTREVISION, refreshes dependencies, and regenerates the staged plist.

Validation: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the Gnumeric port to version 1.12.61 and refresh its packaging configuration.

Enhancements:
- Update Gnumeric to 1.12.61 with refreshed upstream metadata and dependencies.
- Align build configuration with the updated release by removing unsupported optional integrations and expanding required GNOME components.
- Regenerate the staged package plist for the updated file set.

Chores:
- Remove the obsolete PORTREVISION and refresh the distinfo checksum.