### PR TITLE
devel/goffice: restore plist library version token

### DIFF
--- a/devel/goffice/pkg-plist
+++ b/devel/goffice/pkg-plist
@@ -196,7 +196,7 @@ lib/goffice/%%VERSION%%/plugins/smoothing/smoothing.so
 lib/goffice/%%VERSION%%/plugins/smoothing/types.xml
 lib/libgoffice-%%SHORT_VER%%.so
 lib/libgoffice-%%SHORT_VER%%.so.10
-lib/libgoffice-%%SHORT_VER%%.so.10.0.61
+lib/libgoffice-%%SHORT_VER%%.so.10.0.%%LIB_VER%%
 libdata/pkgconfig/libgoffice-%%SHORT_VER%%.pc
 share/gir-1.0/GOffice-%%SHORT_VER%%.gir
 %%DATADIR%%/%%VERSION%%/mmlitex/README


### PR DESCRIPTION
Follow-up to #1097. Restore the existing %%LIB_VER%% substitution for the libgoffice micro-version in pkg-plist, so future PORTVERSION updates do not require a manual plist edit.\n\nValidation: bmake -V PLIST_SUB; bmake check-license; bmake package; git diff --check.

## Summary by Sourcery

Bug Fixes:
- Restore the libgoffice micro-version substitution in the package plist so future version updates remain synchronized automatically.