### PR TITLE
math/gnumeric: package generated German help file

### DIFF
--- a/math/gnumeric/pkg-plist
+++ b/math/gnumeric/pkg-plist
@@ -832,6 +832,7 @@ share/help/C/gnumeric/quick-start.xml
 share/help/C/gnumeric/welcome.xml
 share/help/C/gnumeric/workbooks.xml
 share/help/C/gnumeric/worksheets.xml
+share/help/de/gnumeric/gnumeric.xml
 share/help/es/gnumeric/figures/advanced-filter-1.png
 share/help/es/gnumeric/figures/advanced-filter-2.png
 share/help/es/gnumeric/figures/analysis-simulation-confidence-interval-equation.png


### PR DESCRIPTION
Follow-up to #1104. A clean `bmake fake` for Gnumeric 1.12.61 generates exactly one German help file: `share/help/de/gnumeric/gnumeric.xml`. Add that active plist entry; the 440 obsolete German-help comments removed by #1104 remain absent.

## Summary by Sourcery

Chores:
- Add the generated German Gnumeric help file to the package manifest.