### PR TITLE
x11/cinnamon-screensaver: update to 6.4.1

### DIFF
--- a/x11/cinnamon-screensaver/Makefile
+++ b/x11/cinnamon-screensaver/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	cinnamon-screensaver
-PORTVERSION=	5.4.2
-PORTREVISION=	7
+PORTVERSION=	6.4.1
 CATEGORIES=	x11 gnome
 DIST_SUBDIR=	gnome
 
@@ -24,25 +23,34 @@ RUN_DEPENDS=	${LOCALBASE}/lib/pam_gnome_keyring.so:security/gnome-keyring \
 		${PYTHON_PKGNAMEPREFIX}python-xapp>0:x11/py-python-xapp@${PY_FLAVOR} \
 		${LOCALBASE}/libexec/unix-selfauth-helper:security/unix-selfauth-helper
 
-USES=		gettext-tools gnome meson pkgconfig python shebangfix xorg
+USES=		gnome localbase:ldflags meson pkgconfig python shebangfix xorg
 
 USE_GITHUB=	yes
 GH_ACCOUNT=	linuxmint
 
-USE_XORG=	x11 xext xinerama xrandr xscrnsaver
+USE_XORG=	x11 xext xrandr
 
-USE_GNOME=	cairo gdkpixbuf glib20 intltool introspection:build libgnomekbd pygobject3
+USE_GNOME=	cairo gdkpixbuf glib20 gtk-update-icon-cache gtk30 introspection:build pygobject3
 
 SHEBANG_GLOB=	*.py
 BINARY_ALIAS=	python3=${PYTHON_CMD}
 
-USE_LDCONFIG=	yes
+INSTALLS_ICONS=	yes
 
 SUB_FILES+=	cinnamon-screensaver.pam
 
+OPTIONS_DEFINE=		LOCKING SETRES XINERAMA
+OPTIONS_DEFAULT=	LOCKING XINERAMA
+
+LOCKING_DESC=	Compile in support for locking the display
+SETRES_DESC=	Use setresuid/setresgid in the setuid.c helper
+
+LOCKING_MESON_TRUE=	locking
+SETRES_MESON_TRUE=	setres
+XINERAMA_USE=		xorg=xinerama
+XINERAMA_MESON_TRUE=	xinerama
+
 post-patch:
-	@${REINPLACE_CMD} -e 's|/usr/lib|${PREFIX}/lib|g' \
-		${WRKSRC}/src/pamhelper/authClient.py
 	@${REINPLACE_CMD} -e 's|/usr/share|${PREFIX}/share|' \
 		${WRKSRC}/src/pamhelper/cinnamon-screensaver-pam-helper.c \
 		${WRKSRC}/libcscreensaver/test-passwd.c \

--- a/x11/cinnamon-screensaver/distinfo
+++ b/x11/cinnamon-screensaver/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1660022189
-SHA256 (gnome/linuxmint-cinnamon-screensaver-5.4.2_GH0.tar.gz) = 7ae54b1fc83fff3082b3b43bf5bf01f7cf49eb35cd6b5b42c0e454e2fd619748
-SIZE (gnome/linuxmint-cinnamon-screensaver-5.4.2_GH0.tar.gz) = 154799
+TIMESTAMP = 1788989092
+SHA256 (gnome/linuxmint-cinnamon-screensaver-6.4.1_GH0.tar.gz) = 413e5a178d5a0a81dfa876f829b5f29531033b38c4b2ea6b8b11863c32f07c11
+SIZE (gnome/linuxmint-cinnamon-screensaver-6.4.1_GH0.tar.gz) = 160605

--- a/x11/cinnamon-screensaver/pkg-plist
+++ b/x11/cinnamon-screensaver/pkg-plist
@@ -2,13 +2,10 @@ bin/cinnamon-screensaver
 bin/cinnamon-screensaver-command
 bin/cinnamon-unlock-desktop
 etc/pam.d/cinnamon-screensaver
-lib/girepository-1.0/CScreensaver-1.0.typelib
-lib/libcscreensaver.so
-lib/libcscreensaver.so.0
-lib/libcscreensaver.so.0.0.0
-libdata/pkgconfig/cscreensaver.pc
-@(,,4555) libexec/cinnamon-screensaver-pam-helper
-libexec/cs-backup-locker
+libexec/cinnamon-screensaver/girepository-1.0/CScreensaver-1.0.typelib
+libexec/cinnamon-screensaver/libcscreensaver.so
+@(,,4555) libexec/cinnamon-screensaver/cinnamon-screensaver-pam-helper
+libexec/cinnamon-screensaver/cs-backup-locker
 %%DATADIR%%/__init__.py
 %%DATADIR%%/albumArt.py
 %%DATADIR%%/audioPanel.py
@@ -27,6 +24,7 @@ libexec/cs-backup-locker
 %%DATADIR%%/dbusdepot/keybindingHandlerClient.py
 %%DATADIR%%/dbusdepot/loginInterface.py
 %%DATADIR%%/dbusdepot/logindClient.py
+%%DATADIR%%/dbusdepot/muffinClient.py
 %%DATADIR%%/dbusdepot/mediaPlayerWatcher.py
 %%DATADIR%%/dbusdepot/nameBlocker.py
 %%DATADIR%%/dbusdepot/sessionClient.py
@@ -66,5 +64,7 @@ share/gir-1.0/CScreensaver-1.0.gir
 share/icons/hicolor/scalable/actions/screensaver-switch-users-symbolic.svg
 share/icons/hicolor/scalable/actions/screensaver-unlock-symbolic.svg
 share/icons/hicolor/scalable/apps/csr-backup-locker-icon.svg
+share/icons/hicolor/scalable/status/cinnamon-screensaver-view-conceal.svg
+share/icons/hicolor/scalable/status/cinnamon-screensaver-view-reveal.svg
 share/icons/hicolor/scalable/status/screensaver-blank.svg
 share/icons/hicolor/scalable/status/screensaver-notification-symbolic.svg


### PR DESCRIPTION
Updates Cinnamon Screensaver to 6.4.1 and refreshes its Meson options, dependencies, and staged plist.

Validation: `bmake makesum patch build fake package test check-license`, `portlint -C` (0 fatals), and `git diff --check`. Upstream defines no tests.

## Summary by Sourcery

Update Cinnamon Screensaver to 6.4.1 with refreshed build options, dependencies, and packaging metadata.

Enhancements:
- Update Cinnamon Screensaver to version 6.4.1 and align its build configuration with the new upstream release.
- Refresh X11, GNOME, installation, and runtime dependency handling, including optional display-locking, setresuid/setresgid, and Xinerama support.

Chores:
- Refresh the staged file list and distribution checksums for the updated release.