### PR TITLE
sysutils/xfce4-settings: update to 4.20.5

### DIFF
--- a/sysutils/xfce4-settings/Makefile
+++ b/sysutils/xfce4-settings/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xfce4-settings
-PORTVERSION=	4.20.1
+PORTVERSION=	4.20.5
 CATEGORIES=	sysutils xfce
 MASTER_SITES=	XFCE
 DIST_SUBDIR=	xfce4
@@ -19,7 +19,8 @@ RUN_DEPENDS=	hwdata>0:misc/hwdata
 
 USES=		compiler:c11 desktop-file-utils gettext-tools gmake gnome \
 		libtool pkgconfig python shebangfix tar:bzip2 xfce xorg
-USE_GNOME=	cairo gdkpixbuf glib20 gtk30 libxml2:build
+USE_GNOME=	cairo gdkpixbuf glib20 gtk-update-icon-cache gtk30 libxml2:build
+INSTALLS_ICONS=	yes
 USE_XFCE=	garcon libexo xfconf
 USE_XORG=	x11 xcursor xext xi xorgproto xrandr
 

--- a/sysutils/xfce4-settings/distinfo
+++ b/sysutils/xfce4-settings/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1739131964
-SHA256 (xfce4/xfce4-settings-4.20.1.tar.bz2) = fd0d602853ea75d94024e5baae2d2bf5ca8f8aa4dad7bfd5d08f9ff8afee77b2
-SIZE (xfce4/xfce4-settings-4.20.1.tar.bz2) = 2507814
+TIMESTAMP = 1789047664
+SHA256 (xfce4/xfce4-settings-4.20.5.tar.bz2) = a5fbe0e511cce29d603320ade575ad4001bd570e60f37760233237ba478affe8
+SIZE (xfce4/xfce4-settings-4.20.5.tar.bz2) = 2606817

--- a/sysutils/xfce4-settings/pkg-plist
+++ b/sysutils/xfce4-settings/pkg-plist
@@ -160,6 +160,7 @@ share/icons/hicolor/scalable/devices/xfce-display-right.svg
 %%NLS%%share/locale/kab/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/kk/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/ko/LC_MESSAGES/xfce4-settings.mo
+%%NLS%%share/locale/lo/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/lt/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/lv/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/ms/LC_MESSAGES/xfce4-settings.mo
@@ -187,6 +188,7 @@ share/icons/hicolor/scalable/devices/xfce-display-right.svg
 %%NLS%%share/locale/uk/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/ur/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/ur_PK/LC_MESSAGES/xfce4-settings.mo
+%%NLS%%share/locale/vi/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/zh_HK/LC_MESSAGES/xfce4-settings.mo
 %%NLS%%share/locale/zh_TW/LC_MESSAGES/xfce4-settings.mo


### PR DESCRIPTION
Updates Xfce Settings to 4.20.5, includes its staged Lao and Vietnamese translations, and enables mports icon-cache hooks for its Freedesktop icons.

Validation: `bmake makesum patch build fake package test check-license`, clean `portlint -C` (0 fatals), and `git diff --check`.

## Summary by Sourcery

Update the Xfce Settings port to 4.20.5 with additional translations and icon-cache support.

Enhancements:
- Update Xfce Settings to version 4.20.5 and include the newly staged Lao and Vietnamese translations.
- Enable icon-cache integration for the installed Freedesktop icons.