### PR TITLE
x11/xfce4-docklike-plugin: update to 0.5.1

### DIFF
--- a/x11/xfce4-docklike-plugin/Makefile
+++ b/x11/xfce4-docklike-plugin/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xfce4-docklike-plugin
-PORTVERSION=	0.5.0
+DISTVERSION=	0.5.1
 CATEGORIES=	x11 xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4
@@ -10,10 +10,11 @@ WWW=		https://gitlab.xfce.org/panel-plugins/xfce4-docklike-plugin
 
 LICENSE=		gpl3
 
-USES=		gettext-tools gnome meson pkgconfig tar:xz xfce xorg
+USES=		compiler:c++11-lang gettext-tools gnome meson pkgconfig tar:xz \
+		xfce xorg
 USE_GNOME=	gdkpixbuf gtk30
 USE_XFCE=	libmenu panel windowing
-USE_XORG=	x11
+USE_XORG=	x11 xi
 
 MESON_ARGS=	-Dx11=enabled
 

--- a/x11/xfce4-docklike-plugin/distinfo
+++ b/x11/xfce4-docklike-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1747674178
-SHA256 (xfce4/xfce4-docklike-plugin-0.5.0.tar.xz) = 418aa01f51f6528d95ceeb3b19d52bdc0ac554447bdb7afa9975cca5234f244b
-SIZE (xfce4/xfce4-docklike-plugin-0.5.0.tar.xz) = 78724
+TIMESTAMP = 1789048137
+SHA256 (xfce4/xfce4-docklike-plugin-0.5.1.tar.xz) = 9d7b355c2be37fb0a73b77b4ed75f092d23c012a67b102c9f847c55ddc3095df
+SIZE (xfce4/xfce4-docklike-plugin-0.5.1.tar.xz) = 80056

--- a/x11/xfce4-docklike-plugin/pkg-plist
+++ b/x11/xfce4-docklike-plugin/pkg-plist
@@ -5,6 +5,7 @@ lib/xfce4/panel/plugins/libdocklike.so
 %%NLS%%share/locale/da/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/de/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/el/LC_MESSAGES/xfce4-docklike-plugin.mo
+%%NLS%%share/locale/en_CA/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/en_GB/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/es/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/et/LC_MESSAGES/xfce4-docklike-plugin.mo
@@ -18,10 +19,12 @@ lib/xfce4/panel/plugins/libdocklike.so
 %%NLS%%share/locale/ie/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/it/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/ja/LC_MESSAGES/xfce4-docklike-plugin.mo
+%%NLS%%share/locale/kk/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/ko/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/lt/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/nb/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/nl/LC_MESSAGES/xfce4-docklike-plugin.mo
+%%NLS%%share/locale/oc/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/pl/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/pt/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/pt_BR/LC_MESSAGES/xfce4-docklike-plugin.mo
@@ -32,7 +35,9 @@ lib/xfce4/panel/plugins/libdocklike.so
 %%NLS%%share/locale/sq/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/sr/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/sv/LC_MESSAGES/xfce4-docklike-plugin.mo
+%%NLS%%share/locale/th/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/tr/LC_MESSAGES/xfce4-docklike-plugin.mo
+%%NLS%%share/locale/ug/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/uk/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/vi/LC_MESSAGES/xfce4-docklike-plugin.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/xfce4-docklike-plugin.mo


### PR DESCRIPTION
Updates Xfce Docklike Plugin to 0.5.1, adds its C++11 and XInput build requirements, and refreshes the staged translation list.

Validation: `bmake makesum patch build fake package test check-license`, clean `portlint -C` (0 fatals), and `git diff --check`. Upstream defines no tests.

## Summary by Sourcery

Update the Xfce Docklike Panel plugin port to 0.5.1 with refreshed dependencies and translations.

Enhancements:
- Update the Xfce Docklike Panel plugin port to version 0.5.1 and include its required C++11 and XInput dependencies.
- Refresh the packaged translation files for the updated plugin.