### PR TITLE
sysutils/xfce4-diskperf-plugin: update to 2.8.0

### DIFF
--- a/sysutils/xfce4-diskperf-plugin/Makefile
+++ b/sysutils/xfce4-diskperf-plugin/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	xfce4-diskperf-plugin
-PORTVERSION=	2.7.1
+PORTVERSION=	2.8.0
 CATEGORIES=	sysutils xfce
 MASTER_SITES=	XFCE/panel-plugins
 DIST_SUBDIR=	xfce4
@@ -11,26 +11,19 @@ WWW=		https://docs.xfce.org/panel-plugins/xfce4-diskperf-plugin/start
 LICENSE=	bsd2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-LIB_DEPENDS=	libharfbuzz.so:print/harfbuzz
-
-USES=		compiler:c11 gettext-tools gnome gmake libtool pkgconfig \
-		tar:bzip2 xfce
-USE_GNOME=	cairo gdkpixbuf gtk30
+USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce
+USE_GNOME=	gtk-update-icon-cache gtk30
 USE_XFCE=	libmenu panel
 
-GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-INSTALL_TARGET=	install-strip
 
-LIBS+=		-ldevstat
+LDFLAGS+=	-ldevstat
 
 OPTIONS_DEFINE=	NLS
 OPTIONS_SUB=	yes
-NLS_CONFIGURE_ENABLE=	nls
 NLS_USES=	gettext-runtime
 
 post-patch-NLS-off:
-	@${REINPLACE_CMD} -e 's|[[:blank:]]po||' \
-		-e 's|po$$||'  ${WRKSRC}/Makefile.in
+	@${REINPLACE_CMD} -e "/^subdir('po')/d" ${WRKSRC}/meson.build
 
 .include <bsd.port.mk>

--- a/sysutils/xfce4-diskperf-plugin/distinfo
+++ b/sysutils/xfce4-diskperf-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1735121308
-SHA256 (xfce4/xfce4-diskperf-plugin-2.7.1.tar.bz2) = dd5f521cc4ab40a42958dcf59b6bec5da8fafacf71f3266971942e25b43af8ae
-SIZE (xfce4/xfce4-diskperf-plugin-2.7.1.tar.bz2) = 457061
+TIMESTAMP = 1789048403
+SHA256 (xfce4/xfce4-diskperf-plugin-2.8.0.tar.xz) = 3833920a3a4a81b3c676c4fab6dd178f4a222d66f316a0783a9149a0153b7fb6
+SIZE (xfce4/xfce4-diskperf-plugin-2.8.0.tar.xz) = 59224

--- a/sysutils/xfce4-diskperf-plugin/pkg-plist
+++ b/sysutils/xfce4-diskperf-plugin/pkg-plist
@@ -51,6 +51,7 @@ lib/xfce4/panel/plugins/libdiskperf.so
 %%NLS%%share/locale/uk/LC_MESSAGES/xfce4-diskperf-plugin.mo
 %%NLS%%share/locale/ur/LC_MESSAGES/xfce4-diskperf-plugin.mo
 %%NLS%%share/locale/ur_PK/LC_MESSAGES/xfce4-diskperf-plugin.mo
+%%NLS%%share/locale/vi/LC_MESSAGES/xfce4-diskperf-plugin.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/xfce4-diskperf-plugin.mo
 %%NLS%%share/locale/zh_TW/LC_MESSAGES/xfce4-diskperf-plugin.mo
 share/xfce4/panel/plugins/diskperf.desktop


### PR DESCRIPTION
Updates xfce4-diskperf-plugin to 2.8.0 and migrates it to Meson.

- Retains the NLS option with Meson-level catalog gating.
- Adds the staged Vietnamese translation.
- Uses the GNOME icon-cache helper required by INSTALLS_ICONS.

Validation: `bmake makesum`, `bmake patch`, `bmake`, `bmake fake`, `bmake package`, `bmake test` (no upstream tests defined), `bmake check-license`, an `OPTIONS_UNSET=NLS` package/test check, `portlint -C`, and `git diff --check`.

## Summary by Sourcery

Update xfce4-diskperf-plugin to 2.8.0 and modernize its port configuration for the Meson build system.

New Features:
- Update xfce4-diskperf-plugin to version 2.8.0 with the new Vietnamese translation.

Enhancements:
- Migrate the port from Autotools to Meson while preserving optional NLS catalog support.
- Use the GNOME icon-cache integration required for icon installation.