### PR TITLE
textproc/xfce4-dict-plugin: update to 0.8.10

### DIFF
--- a/textproc/xfce4-dict-plugin/Makefile
+++ b/textproc/xfce4-dict-plugin/Makefile
@@ -1,8 +1,7 @@
 # Created by: Oliver Lehmann (oliver@FreeBSD.org)
 
 PORTNAME=	xfce4-dict
-PORTVERSION=	0.8.4
-PORTREVISION=	1
+PORTVERSION=	0.8.10
 CATEGORIES=	textproc xfce
 MASTER_SITES=	XFCE/apps
 PKGNAMESUFFIX=	-plugin
@@ -10,25 +9,24 @@ DIST_SUBDIR=	xfce4
 
 MAINTAINER=	ports@MidnightbSD.org
 COMMENT=	Xfce4 plugin to query different dictionaries
+WWW=		https://goodies.xfce.org/projects/applications/xfce4-dict
 
 LICENSE=	gpl2
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-USES=		compiler:c11 gettext-tools gmake gnome libtool pkgconfig \
-		tar:bzip2 xfce xorg
-USE_GNOME=	cairo glib20 gtk30 intltool
-USE_XFCE=	panel
+USES=		compiler:c11 gettext-tools gnome meson pkgconfig tar:xz xfce xorg
+USE_GNOME=	gdkpixbuf glib20 gtk-update-icon-cache gtk30 intltool
+USE_XFCE=	libmenu panel
 USE_XORG=	x11
-USE_LDCONFIG=	yes
 
-GNU_CONFIGURE=	yes
 INSTALLS_ICONS=	yes
-INSTALL_TARGET=	install-strip
 
 OPTIONS_DEFINE=	NLS
 OPTIONS_SUB=	yes
 
-NLS_CONFIGURE_ENABLE=	nls
 NLS_USES=		gettext-runtime
+
+post-patch-NLS-off:
+	@${REINPLACE_CMD} -e "/^subdir('po')/d" ${WRKSRC}/meson.build
 
 .include <bsd.port.mk>

--- a/textproc/xfce4-dict-plugin/distinfo
+++ b/textproc/xfce4-dict-plugin/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1602749204
-SHA256 (xfce4/xfce4-dict-0.8.4.tar.bz2) = cb85fefbf742b306f2a8dca695252bae22842ab586abd31b52688312e3f631e3
-SIZE (xfce4/xfce4-dict-0.8.4.tar.bz2) = 526227
+TIMESTAMP = 1789049082
+SHA256 (xfce4/xfce4-dict-0.8.10.tar.xz) = 0a0be97fd056a528a1f37c8db05f5385ffc3dc9945b424cdafa05caf5f054b67
+SIZE (xfce4/xfce4-dict-0.8.10.tar.xz) = 197324

--- a/textproc/xfce4-dict-plugin/files/patch-lib_common.c
+++ b/textproc/xfce4-dict-plugin/files/patch-lib_common.c
@@ -1,0 +1,11 @@
+--- lib/common.c.orig	2026-08-18 20:52:36 UTC
++++ lib/common.c
+@@ -25,6 +25,8 @@
+ #include <stdlib.h>
+ #include <string.h>
+ #include <stdarg.h>
++#include <sys/socket.h>
++#include <netinet/in.h>
+ #include <netdb.h>
+ #include <netinet/tcp.h>
+ #include <gtk/gtk.h>

--- a/textproc/xfce4-dict-plugin/pkg-descr
+++ b/textproc/xfce4-dict-plugin/pkg-descr
@@ -1,5 +1,3 @@
 With xfce4-dict you can query a dictionary server (see RFC 2229) to search for
 the translation or explanation of a word. You can also choose a dictionary
 offered by the server to improve your search results.
-
-WWW: https://goodies.xfce.org/projects/applications/xfce4-dict

--- a/textproc/xfce4-dict-plugin/pkg-plist
+++ b/textproc/xfce4-dict-plugin/pkg-plist
@@ -7,6 +7,8 @@ share/icons/hicolor/16x16/apps/org.xfce.Dictionary.png
 share/icons/hicolor/24x24/apps/org.xfce.Dictionary.png
 share/icons/hicolor/32x32/apps/org.xfce.Dictionary.png
 share/icons/hicolor/48x48/apps/org.xfce.Dictionary.png
+share/icons/hicolor/64x64/apps/org.xfce.Dictionary.png
+share/icons/hicolor/96x96/apps/org.xfce.Dictionary.png
 share/icons/hicolor/scalable/apps/org.xfce.Dictionary.svg
 %%NLS%%share/locale/ar/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/ast/LC_MESSAGES/xfce4-dict.mo
@@ -22,6 +24,7 @@ share/icons/hicolor/scalable/apps/org.xfce.Dictionary.svg
 %%NLS%%share/locale/es/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/et/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/eu/LC_MESSAGES/xfce4-dict.mo
+%%NLS%%share/locale/fa_IR/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/fi/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/fr/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/gl/LC_MESSAGES/xfce4-dict.mo
@@ -34,8 +37,10 @@ share/icons/hicolor/scalable/apps/org.xfce.Dictionary.svg
 %%NLS%%share/locale/is/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/it/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/ja/LC_MESSAGES/xfce4-dict.mo
+%%NLS%%share/locale/ka/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/kk/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/ko/LC_MESSAGES/xfce4-dict.mo
+%%NLS%%share/locale/lo/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/lt/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/lv/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/ms/LC_MESSAGES/xfce4-dict.mo
@@ -45,6 +50,7 @@ share/icons/hicolor/scalable/apps/org.xfce.Dictionary.svg
 %%NLS%%share/locale/pl/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/pt/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/pt_BR/LC_MESSAGES/xfce4-dict.mo
+%%NLS%%share/locale/ro/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/ru/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/sk/LC_MESSAGES/xfce4-dict.mo
 %%NLS%%share/locale/sl/LC_MESSAGES/xfce4-dict.mo


### PR DESCRIPTION
Updates xfce4-dict-plugin to 0.8.10 and migrates the port to Meson.

- Adds the upstream MidnightBSD socket-header portability patch.
- Keeps NLS optional using Meson-level catalog gating.
- Adds newly staged icons and translations.
- Uses the icon-cache helper required by INSTALLS_ICONS.

Validation: `bmake makesum`, `bmake patch`, `bmake`, `bmake fake`, `bmake package`, `bmake test` (no upstream tests defined), `bmake check-license`, an `OPTIONS_UNSET=NLS` package/test check, `portlint -C`, and `git diff --check`.

## Summary by Sourcery

Update xfce4-dict-plugin to 0.8.10 and modernize its port configuration for Meson-based builds.

New Features:
- Update xfce4-dict-plugin to the 0.8.10 release with refreshed icons and translations.

Bug Fixes:
- Add portability support for systems requiring explicit socket and network headers.

Enhancements:
- Migrate the port from GNU configure to Meson while preserving optional NLS support.

Build:
- Update the port to the XZ-compressed release archive and add the required icon-cache integration.

Documentation:
- Add the upstream project homepage to the port metadata.