### PR TITLE
graphics/sane-backends: update to 1.4.0

### DIFF
--- a/graphics/sane-backends/Makefile
+++ b/graphics/sane-backends/Makefile
@@ -1,8 +1,7 @@
 PORTNAME=	sane-backends
-DISTVERSION=	1.3.1
-PORTREVISION=	1
+DISTVERSION=	1.4.0
 CATEGORIES=	graphics
-MASTER_SITES=	https://gitlab.com/sane-project/backends/uploads/83bdbb6c9a115184c2d48f1fdc6847db/
+MASTER_SITES=	https://gitlab.com/-/project/429008/uploads/843c156420e211859e974f78f64c3ea3/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	API for accessing scanners, digital cameras, frame grabbers, etc

--- a/graphics/sane-backends/distinfo
+++ b/graphics/sane-backends/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1716563691
-SHA256 (sane-backends-1.3.1.tar.gz) = aa82f76f409b88f8ea9793d4771fce01254d9b6549ec84d6295b8f59a3879a0c
-SIZE (sane-backends-1.3.1.tar.gz) = 7432184
+TIMESTAMP = 1789054734
+SHA256 (sane-backends-1.4.0.tar.gz) = f99205c903dfe2fb8990f0c531232c9a00ec9c2c66ac7cb0ce50b4af9f407a72
+SIZE (sane-backends-1.4.0.tar.gz) = 7505056

--- a/graphics/sane-backends/pkg-plist
+++ b/graphics/sane-backends/pkg-plist
@@ -597,6 +597,7 @@ sbin/saned
 %%NLS%%share/locale/pt/LC_MESSAGES/sane-backends.mo
 %%NLS%%share/locale/ru/LC_MESSAGES/sane-backends.mo
 %%NLS%%share/locale/sv/LC_MESSAGES/sane-backends.mo
+%%NLS%%share/locale/tr/LC_MESSAGES/sane-backends.mo
 %%NLS%%share/locale/uk/LC_MESSAGES/sane-backends.mo
 %%NLS%%share/locale/zh_CN/LC_MESSAGES/sane-backends.mo
 @dir etc/sane.d/dll.d


### PR DESCRIPTION
Updates SANE Backends to 1.4.0, refreshes the upstream source location/checksum, adds the staged Turkish locale, and removes PORTREVISION for the new release.

Validation:
- bmake makesum, patch, build, fake, package
- bmake test
- bmake check-license
- portlint -C (0 fatals)
- git diff --check

## Summary by Sourcery

Update the SANE Backends port to the 1.4.0 release and include its staged Turkish locale.

New Features:
- Add the staged Turkish locale to the package contents.

Enhancements:
- Update SANE Backends to version 1.4.0 and refresh its upstream source metadata.

Chores:
- Remove the obsolete PORTREVISION for the new upstream release.