### PR TITLE
x11-toolkits/libgdiplus: update to 6.1

### DIFF
--- a/x11-toolkits/libgdiplus/Makefile
+++ b/x11-toolkits/libgdiplus/Makefile
@@ -1,13 +1,13 @@
 # Created by: Tom McLaughlin <tmclaugh@sdf.lonestar.org>
 
 PORTNAME=	libgdiplus
-PORTVERSION=	6.0.4
-PORTREVISION=	1
+PORTVERSION=	6.1
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	http://download.mono-project.com/sources/${PORTNAME}/
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GDI+ API for System.Windows.Forms in Mono
+WWW=		https://www.mono-project.com/docs/gui/libgdiplus/
 
 LICENSE=	mit
 LICENSE_FILE=	${WRKSRC}/LICENSE
@@ -20,7 +20,7 @@ LIB_DEPENDS=	libtiff.so:graphics/tiff \
 		libfontconfig.so:x11-fonts/fontconfig
 
 GNU_CONFIGURE=	yes
-USES=		cpe gettext-runtime gmake gnome jpeg libtool:keepla pathfix \
+USES=		autoreconf cpe gettext-runtime gmake gnome jpeg libtool:keepla pathfix \
 		pkgconfig
 USE_GNOME=	cairo glib20 pango
 USE_LDCONFIG=	yes

--- a/x11-toolkits/libgdiplus/distinfo
+++ b/x11-toolkits/libgdiplus/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1584469047
-SHA256 (libgdiplus-6.0.4.tar.gz) = b75c38c9765d5b3e2fb3da4435f169c732983878c0f94b8bf9012137022abf29
-SIZE (libgdiplus-6.0.4.tar.gz) = 1390998
+TIMESTAMP = 1789054954
+SHA256 (libgdiplus-6.1.tar.gz) = 97d5a83d6d6d8f96c27fb7626f4ae11d3b38bc88a1726b4466aeb91451f3255b
+SIZE (libgdiplus-6.1.tar.gz) = 2336123

--- a/x11-toolkits/libgdiplus/files/patch-configure.ac
+++ b/x11-toolkits/libgdiplus/files/patch-configure.ac
@@ -1,0 +1,10 @@
+--- configure.ac.orig
++++ configure.ac
+@@ -30 +30 @@
+-AC_PATH_PROG(CMAKE, [cmake], [no], [$PATH:/Applications/CMake.app/Contents/bin:/usr/local/bin])
++AC_PATH_PROG(CMAKE, [DISABLEDcmake], [no], [$PATH:/Applications/CMake.app/Contents/bin:/usr/local/bin])
+@@ -78,2 +78,2 @@
+-	PANGO_LIBS="`$PKG_CONFIG --libs pangocairo `"
+-	PANGO_CFLAGS="`$PKG_CONFIG --cflags pangocairo `"
++	PANGO_LIBS="`$PKG_CONFIG --libs pangocairo pangoft2`"
++	PANGO_CFLAGS="`$PKG_CONFIG --cflags pangocairo pangoft2`"

--- a/x11-toolkits/libgdiplus/pkg-descr
+++ b/x11-toolkits/libgdiplus/pkg-descr
@@ -1,3 +1,1 @@
 libgdiplus is an Open Source implementation of the GDI+ API.
-
-WWW: https://www.mono-project.com/docs/gui/libgdiplus/


### PR DESCRIPTION
Updates libgdiplus to 6.1.\n\n- Regenerates Autotools metadata for the release.\n- Adds the upstream-compatible PangoFT2 configure dependency needed to resolve pango_fc_font_map_set_config during test-executable linking.\n- Avoids the optional bundled GoogleTest CMake build, which fails under the current compiler due to upstream warnings promoted to errors.\n\nValidated: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update libgdiplus to 6.1 with refreshed build configuration and compatibility fixes.

Enhancements:
- Update libgdiplus to the 6.1 release and refresh its package metadata and upstream documentation link.
- Regenerate the Autotools configuration and add the required PangoFT2 dependency for successful configuration and test linking.
- Disable the optional bundled GoogleTest build to support current compiler toolchains.