### PR TITLE
chinese/ibus-array: update to 0.3.2

### DIFF
--- a/chinese/ibus-array/Makefile
+++ b/chinese/ibus-array/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	ibus-array
-PORTVERSION=	0.2.2.${SNAPDATE}
-PORTREVISION=	1
+PORTVERSION=	0.3.2
 CATEGORIES=	chinese
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -9,27 +8,21 @@ WWW=		https://github.com/lexical/ibus-array/
 
 LICENSE=	gpl2
 
-BUILD_DEPENDS=	ibus-daemon:textproc/ibus zh-opencc>=1.0:chinese/opencc
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}sqlite3>=0:databases/py-sqlite3@${PY_FLAVOR} \
+		ibus-daemon:textproc/ibus \
+		zh-opencc>=1.0:chinese/opencc
 RUN_DEPENDS=	ibus-daemon:textproc/ibus zh-opencc>=1.0:chinese/opencc
 
-USES=		autoreconf gmake gnome libtool pkgconfig python sqlite
+USES=		gettext-tools gnome meson pkgconfig python sqlite
 USE_GNOME+=	glib20
 USE_GITHUB=	yes
 GH_ACCOUNT=	lexical
-GH_TAGNAME=	06146c5e6518ddf813d0ab1789ba84eadbe9d52b
-SNAPDATE=	20230502
+GH_TAGNAME=	release-${PORTVERSION}
 
-GNU_CONFIGURE=	yes
+BINARY_ALIAS=	python3=${PYTHON_CMD}
 
-OPTIONS_DEFINE=	NLS
-OPTIONS_SUB=	yes
-
-NLS_USES=		gettext
-NLS_CONFIGURE_ENABLE=	nls
-
-pre-configure:
-	${CP} ${MPORTSDIR}/Template/config.sub ${WRKSRC}/
-	${CP} ${MPORTSDIR}/Template/config.guess ${WRKSRC}/
-	cd ${WRKSRC} && ./autogen.sh
+post-patch:
+	@${REINPLACE_CMD} -e "s|cur.execute('INSERT INTO main.*|cur.execute('INSERT INTO main (keys, ch, cat, cnt) VALUES (?, ?, ?, ?);', (r[1], r[2], r[0], '0'))|" \
+		${WRKSRC}/data/cin2sqlite.py
 
 .include <bsd.port.mk>

--- a/chinese/ibus-array/distinfo
+++ b/chinese/ibus-array/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1694586372
-SHA256 (lexical-ibus-array-0.2.2.20230502-06146c5e6518ddf813d0ab1789ba84eadbe9d52b_GH0.tar.gz) = 7b8bd8b03fd86605a010530d7c56908691399e93b562be9568aa23776b98bfbe
-SIZE (lexical-ibus-array-0.2.2.20230502-06146c5e6518ddf813d0ab1789ba84eadbe9d52b_GH0.tar.gz) = 4272091
+TIMESTAMP = 1789055592
+SHA256 (lexical-ibus-array-0.3.2-release-0.3.2_GH0.tar.gz) = dcb543c21486a61cb54073288d1c875035628110df74c77ed3c7a32bf3788625
+SIZE (lexical-ibus-array-0.3.2-release-0.3.2_GH0.tar.gz) = 1040162

--- a/chinese/ibus-array/files/patch-data_updatePhrase.py
+++ b/chinese/ibus-array/files/patch-data_updatePhrase.py
@@ -1,0 +1,5 @@
+--- data/updatePhrase.py.orig
++++ data/updatePhrase.py
+@@ -21 +21 @@
+-		cur.execute('INSERT INTO ' + table + ' (keys, ph) VALUES ("' + i + '", "' + j + '");')
++		cur.execute(f'INSERT INTO {table} (keys, ph) VALUES (?, ?);', (i, j))

--- a/chinese/ibus-array/files/patch-data_updateShortcode.py
+++ b/chinese/ibus-array/files/patch-data_updateShortcode.py
@@ -1,0 +1,5 @@
+--- data/updateShortcode.py.orig
++++ data/updateShortcode.py
+@@ -21 +21 @@
+-		cur.execute('INSERT INTO ' + table + ' (keys, ch) VALUES ("' + i + '", "' + j + '");')
++		cur.execute(f'INSERT INTO {table} (keys, ch) VALUES (?, ?);', (i, j))

--- a/chinese/ibus-array/pkg-plist
+++ b/chinese/ibus-array/pkg-plist
@@ -1,12 +1,8 @@
 libexec/ibus-engine-array
 libexec/ibus-setup-array
 %%DATADIR%%/icons/ibus-array.png
-%%DATADIR%%/setup/__pycache__/config%%PYTHON_TAG%%.opt-1.pyc
-%%DATADIR%%/setup/__pycache__/config%%PYTHON_TAG%%.pyc
-%%DATADIR%%/setup/__pycache__/main%%PYTHON_TAG%%.opt-1.pyc
-%%DATADIR%%/setup/__pycache__/main%%PYTHON_TAG%%.pyc
 %%DATADIR%%/setup/config.py
 %%DATADIR%%/setup/main.py
 %%DATADIR%%/tables/array.db
 share/ibus/component/array.xml
-%%NLS%%share/locale/zh_TW/LC_MESSAGES/ibus-array.mo
+share/locale/zh_TW/LC_MESSAGES/ibus-array.mo


### PR DESCRIPTION
Updates IBus Array to 0.3.2 and migrates the port from Autotools to Meson.\n\n- Adds the source-required Python SQLite binding.\n- Removes stale Python bytecode entries: Meson deliberately installs sources without byte-compilation.\n- Includes the current upstream-compatible parameterized SQLite insertion fixes.\n\nValidated: bmake makesum, patch, build, fake, package, test (no upstream tests defined), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the IBus Array port to 0.3.2 with Meson-based builds and compatible SQLite data generation.

Bug Fixes:
- Use parameterized SQLite inserts in the bundled data update scripts to ensure current upstream-compatible database updates.

Enhancements:
- Update IBus Array to version 0.3.2 and migrate the port from Autotools to Meson.
- Add the required Python SQLite binding and align package contents with Meson's source-only installation behavior.