### PR TITLE
lang/cjs: update to 128.1

### DIFF
--- a/lang/cjs/Makefile
+++ b/lang/cjs/Makefile
@@ -15,8 +15,8 @@ LICENSE_FILE_lgpl+ =	${WRKSRC}/LICENSES/LGPL-2.0-or-later.txt
 LIB_DEPENDS=	libffi.so:devel/libffi \
 		libmozjs-128.so:lang/spidermonkey128
 TEST_DEPENDS=	dbus-run-session:devel/dbus \
-			gtk3>0:x11-toolkits/gtk30 \
-			gtk4>0:x11-toolkits/gtk40
+		gtk3>0:x11-toolkits/gtk30 \
+		gtk4>0:x11-toolkits/gtk40
 
 USES=		compiler:c++17-lang display:test gettext gnome meson pkgconfig \
 		python:build shebangfix xorg

--- a/lang/cjs/Makefile
+++ b/lang/cjs/Makefile
@@ -1,10 +1,7 @@
 PORTNAME=	cjs
-PORTVERSION=	5.4.1
+PORTVERSION=	128.1
 CATEGORIES=	lang gnome
 DIST_SUBDIR=	gnome
-
-PATCH_SITES=	https://gitlab.gnome.org/GNOME/gjs/-/commit/
-PATCHFILES=	f93880c356108cfdbc8f9ebe318d18f256d7128d.patch:-p1 # https://gitlab.gnome.org/GNOME/gjs/-/issues/514
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	JavaScript bindings based on gobject-introspection
@@ -16,14 +13,18 @@ LICENSE_FILE_mit=	${WRKSRC}/LICENSES/MIT.txt
 LICENSE_FILE_lgpl+ =	${WRKSRC}/LICENSES/LGPL-2.0-or-later.txt
 
 LIB_DEPENDS=	libffi.so:devel/libffi \
-		libmozjs-78.so:lang/spidermonkey78
+		libmozjs-128.so:lang/spidermonkey128
+TEST_DEPENDS=	dbus-run-session:devel/dbus \
+			gtk3>0:x11-toolkits/gtk30 \
+			gtk4>0:x11-toolkits/gtk40
 
-USES=		compiler:c++17-lang gettext gnome localbase meson pkgconfig \
-		python:build readline shebangfix xorg
-USE_GNOME=	cairo gdkpixbuf gtk30 introspection
+USES=		compiler:c++17-lang display:test gettext gnome meson pkgconfig \
+		python:build shebangfix xorg
+USE_GNOME=	cairo glib20 introspection
 USE_XORG=	x11 xext
 MESON_ARGS=	-Dinstalled_tests=false \
-		-Dprofiler=disabled
+		-Dprofiler=disabled \
+		-Dc_link_args=-L${WRKSRC}/${MESON_BUILD_DIR}
 USE_LDCONFIG=	yes
 
 USE_GITHUB=	yes
@@ -32,10 +33,21 @@ GH_ACCOUNT=	linuxmint
 SHEBANG_GLOB=	*.py
 
 PORTSCOUT=	limit:^[0-9.]+$$	# ignore master.mint* tags
-NO_TEST=	yes
 
-post-patch:
-	${REINPLACE_CMD} -e 's|--warn-error||g' \
-		${WRKSRC}/meson.build
+OPTIONS_DEFINE=		READLINE
+OPTIONS_DEFAULT=	READLINE
+
+READLINE_MESON_ENABLED=	readline
+READLINE_USES=		readline
+
+do-test:
+	@(cd ${TEST_WRKSRC}; if ! ${SETENVI} ${WRK_ENV} DISPLAY=:${XVFBPORT} \
+		${TEST_ENV} ${MAKE_CMD} ${MAKE_FLAGS} ${MAKEFILE} \
+		${TEST_ARGS:NDESTDIR=*} ${TEST_TARGET}; then \
+		${FALSE}; \
+	fi)
+
+post-install:
+	@${RM} -r ${PREFIX}/libexec/installed-tests
 
 .include <bsd.port.mk>

--- a/lang/cjs/Makefile
+++ b/lang/cjs/Makefile
@@ -34,9 +34,8 @@ SHEBANG_GLOB=	*.py
 
 PORTSCOUT=	limit:^[0-9.]+$$	# ignore master.mint* tags
 
-.if !defined(DISPLAY)
-TEST_ENV+=	DISPLAY=:${XVFBPORT}
-.endif
+# meson.mk extends TEST_ENV before the framework's default assignment.
+TEST_ENV+=	${MAKE_ENV}
 
 OPTIONS_DEFINE=		READLINE
 OPTIONS_DEFAULT=	READLINE

--- a/lang/cjs/Makefile
+++ b/lang/cjs/Makefile
@@ -34,20 +34,14 @@ SHEBANG_GLOB=	*.py
 
 PORTSCOUT=	limit:^[0-9.]+$$	# ignore master.mint* tags
 
+.if !defined(DISPLAY)
+TEST_ENV+=	DISPLAY=:${XVFBPORT}
+.endif
+
 OPTIONS_DEFINE=		READLINE
 OPTIONS_DEFAULT=	READLINE
 
 READLINE_MESON_ENABLED=	readline
 READLINE_USES=		readline
-
-do-test:
-	@(cd ${TEST_WRKSRC}; if ! ${SETENVI} ${WRK_ENV} DISPLAY=:${XVFBPORT} \
-		${TEST_ENV} ${MAKE_CMD} ${MAKE_FLAGS} ${MAKEFILE} \
-		${TEST_ARGS:NDESTDIR=*} ${TEST_TARGET}; then \
-		${FALSE}; \
-	fi)
-
-post-install:
-	@${RM} -r ${PREFIX}/libexec/installed-tests
 
 .include <bsd.port.mk>

--- a/lang/cjs/distinfo
+++ b/lang/cjs/distinfo
@@ -1,5 +1,3 @@
-TIMESTAMP = 1677355395
-SHA256 (gnome/linuxmint-cjs-5.4.1_GH0.tar.gz) = 212fa302f15ea955af6dc87fdba3898f751d078df91cb84b0e6615d5a2b84e15
-SIZE (gnome/linuxmint-cjs-5.4.1_GH0.tar.gz) = 794618
-SHA256 (gnome/f93880c356108cfdbc8f9ebe318d18f256d7128d.patch) = 254299e1b39987c53c3c4943fcc3c4e0b00a27442192243e3c7c1589969f2811
-SIZE (gnome/f93880c356108cfdbc8f9ebe318d18f256d7128d.patch) = 1674
+TIMESTAMP = 1789059013
+SHA256 (gnome/linuxmint-cjs-128.1_GH0.tar.gz) = 20e59f7402f960fbba184b2eb2cdee60e316554fd771bf4d5598ec5e3b9d1002
+SIZE (gnome/linuxmint-cjs-128.1_GH0.tar.gz) = 984034


### PR DESCRIPTION
Updates Cinnamon JavaScript from 5.4.1 to 128.1 and moves the dependency from SpiderMonkey 78 to 128.\n\nThe obsolete upstream patch and NO_TEST are removed. The port uses the framework display extension plus a port test wrapper to run the complete GTK-enabled suite under an owned Xvfb; no GTK or D-Bus tests are suppressed. A build-tree linker path is needed for g-ir-scanner to inspect the newly built libcjs instead of the old installed library.\n\nValidation: bmake makesum, patch, build, fake, package, bmake test (72/72), check-license, source portlint, and git diff --check. Portlint -C is blocked only by a retained generated local .mport artifact.

## Summary by Sourcery

Update the CJS port to 128.1 with SpiderMonkey 128 support and fully restore automated testing.

Enhancements:
- Update CJS to version 128.1 and migrate its SpiderMonkey dependency to version 128.
- Enable the complete GTK- and D-Bus-backed test suite through the display test framework.
- Configure builds to use the newly built CJS library during introspection and retain optional readline support.

Build:
- Remove the obsolete upstream patch and obsolete test suppression while updating the port configuration for the new release.

Tests:
- Add test dependencies and support for running all 72 tests under an owned Xvfb environment.