### PR TITLE
audio/strawberry: update to 1.2.27

### DIFF
--- a/audio/strawberry/Makefile
+++ b/audio/strawberry/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	strawberry
-DISTVERSION=	1.2.17
-PORTREVISION=	1
+DISTVERSION=	1.2.27
 CATEGORIES=	audio
 MASTER_SITES=	https://github.com/strawberrymusicplayer/${PORTNAME}/releases/download/${DISTVERSION}/
 
@@ -27,6 +26,7 @@ USE_GNOME=	glib20
 USE_GSTREAMER=	faac faad flac lame libav mpg123 opus soup taglib vorbis
 USE_QT=		base imageformats:run sqldriver-sqlite:run
 USE_XORG=	ice sm x11 xcb xext
+INSTALLS_ICONS=	yes
 
 CMAKE_OFF=		ENABLE_UDISKS2
 CMAKE_TESTING_SETENV=	yes

--- a/audio/strawberry/distinfo
+++ b/audio/strawberry/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1769120611
-SHA256 (strawberry-1.2.17.tar.xz) = 98c988d4c9574681bf0b32b804c4d6b120807034a60ecb2fa8bd7f20ba2e1ca7
-SIZE (strawberry-1.2.17.tar.xz) = 11531604
+TIMESTAMP = 1789061623
+SHA256 (strawberry-1.2.27.tar.xz) = 85e9990b9bd4641e620ebd55d2c9383d3c19359b0a4c647baab65c7cb7c5772c
+SIZE (strawberry-1.2.27.tar.xz) = 11690940


### PR DESCRIPTION
Updates Strawberry to 1.2.27 and removes the release-specific PORTREVISION. Adds INSTALLS_ICONS=yes for the staged application icons.

Validation: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check all pass.

The build framework installed missing dependencies (sparsehash, faac, gstreamer1-plugins-faac, taglib, and kdsingleapplication) on the validation host.

## Summary by Sourcery

Update the Strawberry port to the 1.2.27 release and package its staged application icons.

Enhancements:
- Update the Strawberry audio port to version 1.2.27 and enable installation of its application icons.

Chores:
- Remove the release-specific PORTREVISION now that the port version has been updated.