### PR TITLE
cad/gtkwave: update to 3.3.128

### DIFF
--- a/cad/gtkwave/Makefile
+++ b/cad/gtkwave/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gtkwave
-DISTVERSION=	3.3.124
-PORTREVISION=	1
+DISTVERSION=	3.3.128
 CATEGORIES=	cad
 MASTER_SITES=	SF/${PORTNAME}/${DISTNAME}
 DISTNAME=	${PORTNAME}-gtk3-${DISTVERSION}
@@ -15,12 +14,14 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 FAKE_OPTS=	trueprefix
 
 LIB_DEPENDS=	libharfbuzz.so:print/harfbuzz
+RUN_DEPENDS=	gdk-pixbuf-extra>0:graphics/gdk-pixbuf-extra
 
 USES=		desktop-file-utils gettext-runtime gmake gnome gperf pkgconfig \
 		shared-mime-info
 USES+=	cpe
 CPE_VENDOR=		tonybybell
 USE_GNOME=	cairo gdkpixbuf gtk30
+INSTALLS_ICONS=	yes
 
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS=	--disable-mime-update \

--- a/cad/gtkwave/Makefile
+++ b/cad/gtkwave/Makefile
@@ -14,13 +14,12 @@ LICENSE_FILE=	${WRKSRC}/COPYING
 FAKE_OPTS=	trueprefix
 
 LIB_DEPENDS=	libharfbuzz.so:print/harfbuzz
-RUN_DEPENDS=	gdk-pixbuf-extra>0:graphics/gdk-pixbuf-extra
 
 USES=		desktop-file-utils gettext-runtime gmake gnome gperf pkgconfig \
 		shared-mime-info
 USES+=	cpe
 CPE_VENDOR=		tonybybell
-USE_GNOME=	cairo gdkpixbuf gtk30
+USE_GNOME=	cairo gdkpixbuf gdkpixbufextra gtk-update-icon-cache gtk30
 INSTALLS_ICONS=	yes
 
 GNU_CONFIGURE=	yes

--- a/cad/gtkwave/distinfo
+++ b/cad/gtkwave/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1747072768
-SHA256 (gtkwave-gtk3-3.3.124.tar.gz) = 4b1590e05e3e3ae26e34fa80aff369254397379b2f970cfa99150b8b97e535cf
-SIZE (gtkwave-gtk3-3.3.124.tar.gz) = 3353773
+TIMESTAMP = 1789062502
+SHA256 (gtkwave-gtk3-3.3.128.tar.gz) = 817e197fc1808f8aac3543c2c2f9683cb01368c91192b8eae5af58070ef1d1f8
+SIZE (gtkwave-gtk3-3.3.128.tar.gz) = 3517524


### PR DESCRIPTION
Updates GTKWave to 3.3.128, removes the release-specific PORTREVISION, and adds the upstream-required gdk-pixbuf-extra runtime dependency. INSTALLS_ICONS=yes now covers the staged icon payload.

Validation passed: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the GTKWave port to the 3.3.128 release with the dependencies and packaging metadata required by the new version.

Enhancements:
- Update GTKWave to version 3.3.128 and add the required GNOME runtime support for its icons and pixbuf loaders.

Chores:
- Remove the release-specific PORTREVISION and enable staged icon installation.