### PR TITLE
databases/pgmodeler: update to 1.2.3

### DIFF
--- a/databases/pgmodeler/Makefile
+++ b/databases/pgmodeler/Makefile
@@ -1,7 +1,6 @@
 PORTNAME=	pgmodeler
-PORTVERSION=	1.2.2
+PORTVERSION=	1.2.3
 DISTVERSIONPREFIX=	v
-PORTREVISION=	1
 CATEGORIES=	databases
 
 MAINTAINER=	ports@MidnightBSD.org
@@ -18,8 +17,6 @@ USE_GNOME=	libxml2
 USE_GL=		gl
 USE_QT=		base svg tools
 USE_XORG=	x11 xext
-
-USE_LDCONFIG=	yes
 
 LDFLAGS+=	-lexecinfo
 

--- a/databases/pgmodeler/distinfo
+++ b/databases/pgmodeler/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1762541813
-SHA256 (pgmodeler-pgmodeler-v1.2.2_GH0.tar.gz) = 25c731eeb62bc372dfbd7b76638152c4f544e604182caa5bf6a0f9c74d659610
-SIZE (pgmodeler-pgmodeler-v1.2.2_GH0.tar.gz) = 4270108
+TIMESTAMP = 1789064153
+SHA256 (pgmodeler-pgmodeler-v1.2.3_GH0.tar.gz) = 862a8caf8d3822b62bc584ed17ba53d1a61733b92d3d5ba29e1be47eadf8f061
+SIZE (pgmodeler-pgmodeler-v1.2.3_GH0.tar.gz) = 4343622


### PR DESCRIPTION
Updates pgModeler to 1.2.3.

Keeps the MidnightBSD execinfo linkage: the release source still calls backtrace APIs. Removes stale PORTREVISION and USE_LDCONFIG; private libraries install under lib/pgmodeler and the executables use a relative rpath.

Validation passed: bmake makesum, patch, build, fake, package, test, check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the pgModeler port to release 1.2.3 and align its packaging metadata with the current release.

Enhancements:
- Update pgModeler to version 1.2.3 while retaining the required execinfo linkage for MidnightBSD.
- Remove obsolete port revision and dynamic library configuration settings.