### PR TITLE
multimedia/gstreamer1-rtsp-server: update to 1.26.1

### DIFF
--- a/multimedia/gstreamer1-rtsp-server/Makefile
+++ b/multimedia/gstreamer1-rtsp-server/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gstreamer1-rtsp-server
-PORTVERSION=	1.22.4
-PORTREVISION=	1
+PORTVERSION=	${_GST_VERSION}
+PORTREVISION=	0
 CATEGORIES=	multimedia
 MASTER_SITES=	https://gstreamer.freedesktop.org/src/gst-rtsp-server/
 DISTNAME=	gst-rtsp-server-${PORTVERSION}
@@ -12,16 +12,15 @@ WWW=		https://gstreamer.freedesktop.org/
 LICENSE=	lgpl+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-USES=		bison gnome gstreamer libtool meson ninja pathfix pkgconfig python:build tar:xz
+USES=		bison gnome gstreamer meson ninja pathfix pkgconfig python:build tar:xz
 USE_LDCONFIG=	yes
 USE_GNOME=	glib20 introspection:build
 USE_GSTREAMER=	good bad
 MESON_ARGS=	-Ddoc=disabled
 
-NO_TEST=	yes
-
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 
-PLIST_SUB=	VERSION=1.0 SOVERSION=0.2204.0
+PLIST_SUB=	SOVERSION=${_GST_SOVERSION} \
+		VERSION=${_GST_LIB_VER}
 
 .include <bsd.port.mk>

--- a/multimedia/gstreamer1-rtsp-server/distinfo
+++ b/multimedia/gstreamer1-rtsp-server/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1687416226
-SHA256 (gst-rtsp-server-1.22.4.tar.xz) = 4666612d7a99c60dcd6f0bdba1b7a74d2562a0501b2a3e0576f0916bf1d8811b
-SIZE (gst-rtsp-server-1.22.4.tar.xz) = 272712
+TIMESTAMP = 1789058374
+SHA256 (gst-rtsp-server-1.26.1.tar.xz) = 253fdfec78320c2f67486cd3797a0253c06982c3a8d5160f795b4257fadab301
+SIZE (gst-rtsp-server-1.26.1.tar.xz) = 276216

--- a/multimedia/gstreamer1-rtsp-server/files/patch-tests_check_gst_rtspserver.c
+++ b/multimedia/gstreamer1-rtsp-server/files/patch-tests_check_gst_rtspserver.c
@@ -1,0 +1,30 @@
+--- tests/check/gst/rtspserver.c.orig
++++ tests/check/gst/rtspserver.c
+@@ -2078,5 +2078,5 @@ test_shared (gpointer (thread_func) (gpo
+   g_mutex_lock (&lock2);
+   thread2 = g_thread_new ("thread2", thread_func, &lock2);
+   g_mutex_unlock (&lock2);
+-  g_mutex_clear (&lock2);
+   g_thread_join (thread2);
++  g_mutex_clear (&lock2);
+@@ -2084,6 +2084,6 @@ test_shared (gpointer (thread_func) (gpo
+   /* Do it again. */
+   g_mutex_lock (&lock3);
+   thread3 = g_thread_new ("thread3", thread_func, &lock3);
+   g_mutex_unlock (&lock3);
+-  g_mutex_clear (&lock3);
+   g_thread_join (thread3);
++  g_mutex_clear (&lock3);
+@@ -2091,4 +2091,4 @@ test_shared (gpointer (thread_func) (gpo
+   /* Disconnect the last client. This will clean up the media. */
+   g_mutex_unlock (&lock1);
+-  g_mutex_clear (&lock1);
+   g_thread_join (thread1);
++  g_mutex_clear (&lock1);
+@@ -2098,5 +2098,5 @@ test_shared (gpointer (thread_func) (gpo
+   g_mutex_lock (&lock4);
+   thread4 = g_thread_new ("thread4", thread_func, &lock4);
+   g_mutex_unlock (&lock4);
+-  g_mutex_clear (&lock4);
+   g_thread_join (thread4);
++  g_mutex_clear (&lock4);


### PR DESCRIPTION
Updates gst-rtsp-server to the GStreamer 1.26.1 release.

The upstream UDP shared-media test cleared its mutexes before joining worker threads that still polled them. On MidnightBSD that correctly aborts with EINVAL from pthread_mutex_trylock. The included test-only patch joins each worker before clearing its mutex.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (16/16)
- bmake check-license
- git diff --check

portlint -C reports no source fatal; it retains the expected PORTREVISION=0 advisory and local generated-artifact fatals.

## Summary by Sourcery

Update the GStreamer RTSP server port to 1.26.1 with portable test support.

Bug Fixes:
- Update gst-rtsp-server to the GStreamer 1.26.1 release and fix its shared-media test for reliable mutex cleanup on MidnightBSD.

Enhancements:
- Enable the port's test suite and align version and plist metadata with the shared GStreamer port settings.

Tests:
- Add a test-only portability fix that prevents worker mutexes from being cleared before their threads finish.