### PR TITLE
graphics/inkscape: update to 1.4.4

### DIFF
--- a/graphics/inkscape/Makefile
+++ b/graphics/inkscape/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	inkscape
-DISTVERSION=	1.4.3
-PORTREVISION=	3
+DISTVERSION=	1.4.4
 CATEGORIES=	graphics gnome
 MASTER_SITES=	https://media.inkscape.org/dl/resources/file/
 
@@ -41,14 +40,14 @@ TEST_DEPENDS=	googletest>0:devel/googletest \
 		bash:shells/bash
 
 USES=		compiler:c++20-lang cmake:testing cpe desktop-file-utils ghostscript:run \
-		gnome jpeg pathfix pkgconfig python \
+		gnome iconv jpeg magick:test pathfix pkgconfig python \
 		readline shebangfix tar:xz xorg
 USE_GNOME=	cairo gdkpixbuf glibmm gtkmm30 gtksourceview4 libxml2 libxslt
 USE_PYTHON=	cython
 USE_XORG=	sm ice x11 xext
-USE_LDCONFIG=	yes
+INSTALLS_ICONS=	yes
 
-DATETAG=	2025-12-25_0d15f75042
+DATETAG=	2026-05-05_dcaf3e7d9e
 WRKSRC=		${WRKDIR}/${PORTNAME}-${DISTVERSION}_${DATETAG}
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}
@@ -106,6 +105,8 @@ NLS_USES=		gettext
 GSPELL_DESC=		Support for spell checking through gspell
 GSPELL_CMAKE_BOOL=	WITH_GSPELL
 GSPELL_LIB_DEPENDS=	libgspell-1.so:textproc/gspell
+
+PLIST_SUB=		DISTVERSION=${DISTVERSION}
 
 post-patch:
 	@${REINPLACE_CMD} -e 's|COMMAND python3|COMMAND ${PYTHON_VERSION}|g' \

--- a/graphics/inkscape/distinfo
+++ b/graphics/inkscape/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1769250053
-SHA256 (inkscape-1.4.3.tar.xz) = e83a2c3db570b6c5a1ff0fccfe7098837b3f6bd74b133567937c8a91710ed1d1
-SIZE (inkscape-1.4.3.tar.xz) = 53907460
+TIMESTAMP = 1789059041
+SHA256 (inkscape-1.4.4.tar.xz) = bbce5753a1e08b871a5cf16c665eb060700aaab9a6a379dc63f4c4d9b3b8856e
+SIZE (inkscape-1.4.4.tar.xz) = 53861940

--- a/graphics/inkscape/pkg-plist
+++ b/graphics/inkscape/pkg-plist
@@ -1,7 +1,7 @@
 bin/inkscape
 bin/inkview
 lib/inkscape/libinkscape_base.so
-lib/inkscape/libinkscape_base.so.1.4.3.0
+lib/inkscape/libinkscape_base.so.%%DISTVERSION%%.0
 share/applications/org.inkscape.Inkscape.desktop
 share/bash-completion/completions/inkscape
 share/icons/hicolor/16x16/apps/org.inkscape.Inkscape.png
@@ -4042,6 +4042,7 @@ share/icons/hicolor/symbolic/apps/org.inkscape.Inkscape-symbolic.svg
 %%DATADIR%%/palettes/Topographic.gpl
 %%DATADIR%%/palettes/Ubuntu.gpl
 %%DATADIR%%/palettes/echo-palette.gpl
+%%DATADIR%%/palettes/elementary.gpl
 %%DATADIR%%/palettes/inkscape.gpl
 %%DATADIR%%/palettes/svg.gpl
 %%DATADIR%%/palettes/webhex.gpl
@@ -4541,6 +4542,7 @@ share/icons/hicolor/symbolic/apps/org.inkscape.Inkscape-symbolic.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.sk.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.sr.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.svg
+%%DATADIR%%/tutorials/tutorial-tracing-pixelart.tr.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.uk.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.zh_CN.svg
 %%DATADIR%%/tutorials/tutorial-tracing-pixelart.zh_TW.svg
@@ -4565,6 +4567,7 @@ share/icons/hicolor/symbolic/apps/org.inkscape.Inkscape-symbolic.svg
 %%DATADIR%%/tutorials/tutorial-tracing.sl.svg
 %%DATADIR%%/tutorials/tutorial-tracing.sr.svg
 %%DATADIR%%/tutorials/tutorial-tracing.svg
+%%DATADIR%%/tutorials/tutorial-tracing.tr.svg
 %%DATADIR%%/tutorials/tutorial-tracing.uk.svg
 %%DATADIR%%/tutorials/tutorial-tracing.vi.svg
 %%DATADIR%%/tutorials/tutorial-tracing.zh_CN.svg
@@ -4760,6 +4763,7 @@ share/icons/hicolor/symbolic/apps/org.inkscape.Inkscape-symbolic.svg
 %%NLS%%share/locale/zh_TW/LC_MESSAGES/inkscape.mo
 share/man/de/man1/inkscape.1.gz
 share/man/de/man1/inkview.1.gz
+share/man/es/man1/inkscape.1.gz
 share/man/es/man1/inkview.1.gz
 share/man/fr/man1/inkscape.1.gz
 share/man/fr/man1/inkview.1.gz


### PR DESCRIPTION
Updates Inkscape to 1.4.4 and refreshes the staged plist.

- Removes the superseded PORTREVISION.
- Adds the required icon-cache integration and removes ineffective USE_LDCONFIG for a private lib/inkscape library.
- Keeps MidnightBSD packaging and existing test-safety policy intact.

Validation: bmake makesum, patch, build, fake, clean package, test, check-license, portlint -C, and git diff --check all pass. The port test target defines no executed suite; the existing TESTING_UNSAFE note is retained.

## Summary by Sourcery

Update the Inkscape graphics port to release 1.4.4 with refreshed packaging integration.

Enhancements:
- Update the Inkscape port to version 1.4.4 and refresh its staged source metadata.
- Integrate icon installation and align dependencies and packaging metadata with the updated release.
- Remove obsolete port revision and dynamic library registration for the private Inkscape library.