### PR TITLE
devel/rubygem-pkg-config: update to 1.6.5

### DIFF
--- a/devel/rubygem-pkg-config/Makefile
+++ b/devel/rubygem-pkg-config/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	pkg-config
-PORTVERSION=	1.6.2
+PORTVERSION=	1.6.5
 CATEGORIES=	devel rubygems
 MASTER_SITES=	RG
 

--- a/devel/rubygem-pkg-config/distinfo
+++ b/devel/rubygem-pkg-config/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1745936364
-SHA256 (rubygem/pkg-config-1.6.2.gem) = e01b004465c0e43a2e6aaa241fcaee42166cf658eb849bf4d31b645358c5be35
-SIZE (rubygem/pkg-config-1.6.2.gem) = 23552
+TIMESTAMP = 1789080745
+SHA256 (rubygem/pkg-config-1.6.5.gem) = 33f9f81c5322983d22b439b8b672f27777b406fea23bfec74ff14bbeb42ec733
+SIZE (rubygem/pkg-config-1.6.5.gem) = 24576


### PR DESCRIPTION
Updates the Ruby pkg-config binding required by the Ruby GNOME 4.3.7 binding set.

Validation:
- bmake makesum patch build fake package test
- bmake check-license
- git diff --check

portlint source checks have no port-content fatal; the two fatals are retained generated work/ and the local package artifact.

## Summary by Sourcery

Enhancements:
- Update the Ruby pkg-config binding to version 1.6.5 for compatibility with the Ruby GNOME 4.3.7 binding set.