### PR TITLE
devel/rubygem-gobject-introspection: update to 4.3.7

### DIFF
--- a/devel/rubygem-gobject-introspection/Makefile
+++ b/devel/rubygem-gobject-introspection/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gobject-introspection
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
 CATEGORIES=	devel rubygems
 MASTER_SITES=	RG
 

--- a/devel/rubygem-gobject-introspection/distinfo
+++ b/devel/rubygem-gobject-introspection/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920525
-SHA256 (rubygem/gobject-introspection-4.3.4.gem) = 78ba5f193280beccae9d1b406d521355abcec7d9e44b57c9dae3d23b7bd547a8
-SIZE (rubygem/gobject-introspection-4.3.4.gem) = 75264
+TIMESTAMP = 1789080971
+SHA256 (rubygem/gobject-introspection-4.3.7.gem) = 037cd58d338ec00f7cd877243527dcb52e9d8c54e461ee8ca090855ee62cce29
+SIZE (rubygem/gobject-introspection-4.3.7.gem) = 75776


### PR DESCRIPTION
Updates Ruby GObject Introspection to the version pinned by the synchronized Ruby GNOME 4.3.7 binding set.

Validation with staged Ruby 3.3 prerequisites and staged glib2 4.3.7 (no host installs):
- bmake -DNO_DEPENDS makesum patch build fake package test
- bmake check-license
- git diff --check

portlint source checks have no port-content fatal; its two fatals are retained work/ and the generated local package artifact.

## Summary by Sourcery

Enhancements:
- Update the Ruby GObject Introspection port to version 4.3.7 to align with the synchronized Ruby GNOME binding set.