### PR TITLE
graphics/rubygem-gdk_pixbuf2: update to 4.3.7

### DIFF
--- a/graphics/rubygem-gdk_pixbuf2/Makefile
+++ b/graphics/rubygem-gdk_pixbuf2/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gdk_pixbuf2
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
 CATEGORIES=	graphics rubygems
 MASTER_SITES=	RG
 

--- a/graphics/rubygem-gdk_pixbuf2/distinfo
+++ b/graphics/rubygem-gdk_pixbuf2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920538
-SHA256 (rubygem/gdk_pixbuf2-4.3.4.gem) = ad63068a69abf2f5820418ec7a24f63287996f62541bdf35784259fd5dd115a5
-SIZE (rubygem/gdk_pixbuf2-4.3.4.gem) = 34816
+TIMESTAMP = 1789081216
+SHA256 (rubygem/gdk_pixbuf2-4.3.7.gem) = 6eecabf3136ddc708ff438c9f6c19e11d0f5d883b8d83d9b577761070cc18807
+SIZE (rubygem/gdk_pixbuf2-4.3.7.gem) = 34816


### PR DESCRIPTION
Updates the Ruby GdkPixbuf binding to the synchronized 4.3.7 release.

Validation used a staged Ruby 3.3 dependency chain (GIO2, GObject Introspection, GLib2, Rake, and gem-only prerequisites) without host installs:
- bmake -DNO_DEPENDS makesum patch build fake package test
- bmake check-license
- git diff --check

portlint source checks have no port-content fatal; its two fatals are retained work/ and the generated local package artifact.

## Summary by Sourcery

Enhancements:
- Update the Ruby GdkPixbuf binding to the synchronized 4.3.7 release.