### PR TITLE
x11-toolkits/rubygem-poppler: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-poppler/Makefile
+++ b/x11-toolkits/rubygem-poppler/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	poppler
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -14,7 +15,8 @@ LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
 LIB_DEPENDS=	libpoppler-glib.so:graphics/poppler-glib
 RUN_DEPENDS=	rubygem-cairo-gobject>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-cairo-gobject \
-		rubygem-gio2>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-gio2
+		rubygem-gio2>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-gio2 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem
 

--- a/x11-toolkits/rubygem-poppler/distinfo
+++ b/x11-toolkits/rubygem-poppler/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920548
-SHA256 (rubygem/poppler-4.3.4.gem) = ae22aa868b36e72068a30ddc26f852917a89bc17f1f1b69feba7b931c3953ea7
-SIZE (rubygem/poppler-4.3.4.gem) = 95232
+TIMESTAMP = 1789081659
+SHA256 (rubygem/poppler-4.3.7.gem) = 4ad066021a1d0e32a50707930529733b437dcfb95da2821cfe1ad88b5dfd257e
+SIZE (rubygem/poppler-4.3.7.gem) = 95232


### PR DESCRIPTION
Updates the Ruby Poppler binding to 4.3.7 and resets PORTREVISION for the release update.

The gemspec pins cairo-gobject and gio2 to 4.3.7 and requires rake at runtime, so the RUN_DEPENDS reflect that.

Validation:
- bmake makesum patch
- Ruby 3.3 staged-dependency bmake build fake package
- bmake test (no test command is defined by this port)
- bmake check-license
- git diff --check

portlint -C reports only the retained generated package/work artifacts plus existing advisory warnings.

## Summary by Sourcery

Update the rubygem-poppler port to release 4.3.7 with matching dependency metadata.

Enhancements:
- Update the Ruby Poppler binding port to version 4.3.7 and align its gem dependencies with the new release.

Chores:
- Reset PORTREVISION for the version update and refresh the distfile checksum.