### PR TITLE
graphics/rubygem-clutter: update to 4.3.7

### DIFF
--- a/graphics/rubygem-clutter/Makefile
+++ b/graphics/rubygem-clutter/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	clutter
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	graphics rubygems
 MASTER_SITES=	RG
 
@@ -15,7 +16,8 @@ BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
 LIB_DEPENDS=	libclutter-1.0.so:graphics/clutter
 RUN_DEPENDS=	rubygem-cairo-gobject>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-cairo-gobject \
 		rubygem-gobject-introspection>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-gobject-introspection \
-		rubygem-pango>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-pango
+		rubygem-pango>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-pango \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem
 

--- a/graphics/rubygem-clutter/distinfo
+++ b/graphics/rubygem-clutter/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920537
-SHA256 (rubygem/clutter-4.3.4.gem) = 8e8ceca855ad07566d3754878eaebe5b08ca65b804d8329438b82982727ef04a
-SIZE (rubygem/clutter-4.3.4.gem) = 42496
+TIMESTAMP = 1789082126
+SHA256 (rubygem/clutter-4.3.7.gem) = 041a1dbd62448812d0a06a3643af146a58ada10e9600935940e45a94a3312fb1
+SIZE (rubygem/clutter-4.3.7.gem) = 42496


### PR DESCRIPTION
Updates the Ruby Clutter binding to 4.3.7 and explicitly resets PORTREVISION.

Adds rake to RUN_DEPENDS because the upstream gemspec declares it at runtime.

Validation:
- bmake makesum patch
- staged Ruby 3.3 bmake -DNO_DEPENDS build fake package test
- staged Ruby 3.3 require of clutter 4.3.7
- bmake check-license
- git diff --check

portlint -C has only artifact/work-tree fatals plus expected advisory warnings; generated artifacts were retained.

## Summary by Sourcery

Enhancements:
- Update the Ruby Clutter binding port to version 4.3.7 and align its runtime dependencies with the upstream gemspec.