### PR TITLE
x11-toolkits/rubygem-gdk3: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-gdk3/Makefile
+++ b/x11-toolkits/rubygem-gdk3/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gdk3
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -12,9 +13,10 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
-RUN_DEPENDS=	rubygem-cairo-gobject>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-cairo-gobject \
-		rubygem-gdk_pixbuf2>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-gdk_pixbuf2 \
-		rubygem-pango>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-pango
+RUN_DEPENDS=	rubygem-cairo-gobject>=${PORTVERSION}<${PORTVERSION}_99:devel/rubygem-cairo-gobject \
+		rubygem-gdk_pixbuf2>=${PORTVERSION}<${PORTVERSION}_99:graphics/rubygem-gdk_pixbuf2 \
+		rubygem-pango>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-pango \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem gnome
 USE_GNOME=	gtk30

--- a/x11-toolkits/rubygem-gdk3/distinfo
+++ b/x11-toolkits/rubygem-gdk3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920538
-SHA256 (rubygem/gdk3-4.3.4.gem) = 7a7a86a6741771a4dd8892848b652068c5d106fcf61c31150e6cfb94064e4768
-SIZE (rubygem/gdk3-4.3.4.gem) = 36352
+TIMESTAMP = 1789082072
+SHA256 (rubygem/gdk3-4.3.7.gem) = cf0641a39134ba9e32affbbb1ed86f76eaebb89674e1c6c5620c00ad0d80edd3
+SIZE (rubygem/gdk3-4.3.7.gem) = 36352


### PR DESCRIPTION
Updates the Ruby GDK 3 binding to 4.3.7.

The gemspec pins cairo-gobject, gdk_pixbuf2, and pango to 4.3.7 and declares Rake at runtime, so the dependency ranges now reflect those requirements. PORTREVISION is explicitly reset to 0 for the release update.

Validation:
- bmake makesum patch build
- bmake -DNO_DEPENDS with a staged Ruby 3.3 cairo/cairo-gobject/pango/GNOME dependency closure: fake package test
- bmake check-license
- git diff --check
- portlint -C (only expected PORTREVISION/pkg-descr warnings plus generated untracked artifact fatals; artifacts retained)

No host package installation was performed.

## Summary by Sourcery

Enhancements:
- Update the Ruby GDK 3 binding to version 4.3.7 and align its related gem dependencies with the new release.