### PR TITLE
graphics/rubygem-clutter-gdk: update to 4.3.7

### DIFF
--- a/graphics/rubygem-clutter-gdk/Makefile
+++ b/graphics/rubygem-clutter-gdk/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	clutter-gdk
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	graphics rubygems
 MASTER_SITES=	RG
 
@@ -12,8 +13,8 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	${RUN_DEPENDS}
-RUN_DEPENDS=	rubygem-clutter>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-clutter \
-		rubygem-gdk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gdk3
+RUN_DEPENDS=	rubygem-clutter>=${PORTVERSION}<${PORTVERSION}_99:graphics/rubygem-clutter \
+		rubygem-gdk3>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gdk3
 
 USES=		gem
 

--- a/graphics/rubygem-clutter-gdk/distinfo
+++ b/graphics/rubygem-clutter-gdk/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920537
-SHA256 (rubygem/clutter-gdk-4.3.4.gem) = 863a75a5029958c5d79808ddeac3909d81d7c767554eb3d9c00e433b177db2df
-SIZE (rubygem/clutter-gdk-4.3.4.gem) = 14848
+TIMESTAMP = 1789082758
+SHA256 (rubygem/clutter-gdk-4.3.7.gem) = c2d2ca05f644b2637fcdc30d4a42b7ef6122c675f425e99a34411df96dfa7182
+SIZE (rubygem/clutter-gdk-4.3.7.gem) = 14848


### PR DESCRIPTION
Updates the Ruby GDK-specific Clutter binding to 4.3.7.

- Resets PORTREVISION to 0 for the version increment.
- Synchronizes dependency bounds with the gemspec exact 4.3.7 runtime requirements.

Validation:
- `bmake -DNO_DEPENDS patch build fake package test` with staged Ruby 3.3 dependencies (test target has no commands)
- staged `ruby33 -e 'require "clutter-gdk"'` smoke test
- `bmake check-license`
- `git diff --check`

`portlint -C` reports only the generated, untracked `.mport` artifact and `work/` directory (retained), plus existing style warnings.

## Summary by Sourcery

Update the Clutter GDK Ruby port to 4.3.7 with matching dependency metadata.

Enhancements:
- Update the Ruby Clutter GDK binding port to version 4.3.7 and align its Clutter and GDK runtime dependency bounds with the new release.

Chores:
- Reset PORTREVISION for the version update and refresh the gem checksum metadata.