### PR TITLE
graphics/rubygem-clutter-gtk: update to 4.3.7

### DIFF
--- a/graphics/rubygem-clutter-gtk/Makefile
+++ b/graphics/rubygem-clutter-gtk/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	clutter-gtk
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	graphics rubygems
 MASTER_SITES=	RG
 
@@ -15,7 +16,8 @@ BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
 LIB_DEPENDS=	libclutter-gtk-1.0.so:graphics/clutter-gtk3
 RUN_DEPENDS=	rubygem-clutter>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-clutter \
 		rubygem-clutter-gdk>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-clutter-gdk \
-		rubygem-gtk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk3
+		rubygem-gtk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk3 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem
 

--- a/graphics/rubygem-clutter-gtk/distinfo
+++ b/graphics/rubygem-clutter-gtk/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920538
-SHA256 (rubygem/clutter-gtk-4.3.4.gem) = 647c13663d63e19ec7f5e0ba793037597cdf5e3984cba85e538fd9e10a10fbe1
-SIZE (rubygem/clutter-gtk-4.3.4.gem) = 31232
+TIMESTAMP = 1789083212
+SHA256 (rubygem/clutter-gtk-4.3.7.gem) = b7e20abcd834bc4b0d6d508ec12ca8545eec30be42478bdac6162cba5f487b16
+SIZE (rubygem/clutter-gtk-4.3.7.gem) = 31232


### PR DESCRIPTION
Updates the Ruby Clutter-GTK binding to 4.3.7.

- resets PORTREVISION to 0
- adds the upstream-required runtime Rake dependency
- retains existing build and native Clutter-GTK dependencies

Validation:
- bmake makesum, extract, and staged -DNO_DEPENDS package completed using Ruby 3.3 and the staged 4.3.7 dependency closure (no host installs)
- bmake test completed; this port has no test commands configured
- bmake check-license and git diff --check passed
- portlint -C reported only the generated untracked .mport artifact, work directory, and existing style warnings
- a direct staged require reached GTK initialization; it requires a display server and therefore cannot finish headlessly.

## Summary by Sourcery

Update the Clutter-GTK Ruby gem port to 4.3.7 with the dependency metadata required by the new release.

Enhancements:
- Update the Ruby Clutter-GTK binding to version 4.3.7 and include its required runtime Rake dependency.

Chores:
- Reset PORTREVISION for the updated port.