### PR TITLE
x11-toolkits/rubygem-gtksourceview3: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-gtksourceview3/Makefile
+++ b/x11-toolkits/rubygem-gtksourceview3/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gtksourceview3
-PORTVERSION=	4.3.4
-PORTREVISION=	1
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -13,7 +13,8 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
-RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk3
+RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gtk3 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem gnome
 USE_GNOME=	gtksourceview3

--- a/x11-toolkits/rubygem-gtksourceview3/distinfo
+++ b/x11-toolkits/rubygem-gtksourceview3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920548
-SHA256 (rubygem/gtksourceview3-4.3.4.gem) = dcd1229daf371adcf0e5dca3d6b368a784e6e124acb01c7f5bc89f981e48bf12
-SIZE (rubygem/gtksourceview3-4.3.4.gem) = 17408
+TIMESTAMP = 1789083230
+SHA256 (rubygem/gtksourceview3-4.3.7.gem) = 240755de6d7d695e9f1daca638c5dd3a2024743df5ace138f8b411950fac816e
+SIZE (rubygem/gtksourceview3-4.3.7.gem) = 17408


### PR DESCRIPTION
Updates Ruby GtkSourceView 3 bindings to 4.3.7.

- Resets PORTREVISION to 0 for the version increment.
- Adds the gemspec-required runtime Rake dependency and exact GTK3 4.3.7 bound.

Validated with staged Ruby 3.3 dependencies, without host package installation:
- bmake makesum patch build fake package test -DNO_DEPENDS
- Xvfb Ruby smoke test: require gtksourceview3, initialize GtkSource, create/read a source buffer, and enumerate language IDs
- bmake check-license
- git diff --check

portlint -C reports only generated untracked work/ and .mport artifacts plus existing style warnings; artifacts are intentionally retained.

## Summary by Sourcery

Update the Ruby GtkSourceView3 port to 4.3.7 with its required dependency metadata.

Enhancements:
- Update the Ruby GtkSourceView3 binding port to version 4.3.7 and align its GTK3 dependency with the new release.
- Declare Rake as a runtime dependency required by the gemspec.