### PR TITLE
x11-toolkits/rubygem-vte3: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-vte3/Makefile
+++ b/x11-toolkits/rubygem-vte3/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	vte3
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -12,7 +13,8 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
-RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk3
+RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gtk3 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem gnome
 USE_GNOME=	vte3

--- a/x11-toolkits/rubygem-vte3/distinfo
+++ b/x11-toolkits/rubygem-vte3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920548
-SHA256 (rubygem/vte3-4.3.4.gem) = cf045ff370bdf50c4e3a6cdcc8f46cd57b51d0b000c4e60b7c8da3c6d2bea0ae
-SIZE (rubygem/vte3-4.3.4.gem) = 19456
+TIMESTAMP = 1789083606
+SHA256 (rubygem/vte3-4.3.7.gem) = eda412b95f2823afa65a0bce99603b373b7a91ce3dc666c8e169cf8eac631e37
+SIZE (rubygem/vte3-4.3.7.gem) = 19456


### PR DESCRIPTION
Updates the Ruby VTE3 binding to 4.3.7.

The upstream gemspec now requires exactly gtk3 4.3.7 and runtime rake; both are reflected in RUN_DEPENDS. PORTREVISION is explicitly reset to 0.

Validation:
- bmake makesum patch
- bmake -DNO_DEPENDS build fake package test using the staged Ruby 3.3 GTK3 closure (no host package installs)
- staged ruby33 require vte3 smoke test
- bmake check-license
- git diff --check

portlint -C warnings include the explicit PORTREVISION=0 and existing pkg-descr/maintainer-mode warnings. Its only fatals are generated local work/ and .mport artifacts, retained for validation.

## Summary by Sourcery

Update the Ruby VTE3 port to 4.3.7 with its revised dependency requirements.

Enhancements:
- Update the Ruby VTE3 binding port to version 4.3.7 and align its GTK3 and Rake runtime dependencies with the upstream gemspec.

Chores:
- Reset PORTREVISION for the upstream version update and refresh the gem checksum data.