### PR TITLE
x11-toolkits/rubygem-gtksourceview4: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-gtksourceview4/Makefile
+++ b/x11-toolkits/rubygem-gtksourceview4/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gtksourceview4
-PORTVERSION=	4.3.4
-PORTREVISION=	1
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -13,7 +13,8 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
-RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk3
+RUN_DEPENDS=	rubygem-gtk3>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gtk3 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem gnome
 USE_GNOME=	gtksourceview4

--- a/x11-toolkits/rubygem-gtksourceview4/distinfo
+++ b/x11-toolkits/rubygem-gtksourceview4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920548
-SHA256 (rubygem/gtksourceview4-4.3.4.gem) = 777abe158f84d0a4ffccaf9145dd4fabf6eb3f379b913e84399bb6310c425e75
-SIZE (rubygem/gtksourceview4-4.3.4.gem) = 17408
+TIMESTAMP = 1789083574
+SHA256 (rubygem/gtksourceview4-4.3.7.gem) = 2c0e7f0259f3b20b663da46c194cb78078377686a46cfcb68a13a8089c0ab2f5
+SIZE (rubygem/gtksourceview4-4.3.7.gem) = 17408


### PR DESCRIPTION
Updates the Ruby GtkSourceView4 binding to 4.3.7.

- Sets PORTREVISION=0 for the release increment.
- Adds the gemspec-required runtime rake dependency and matches the exact GTK3 dependency bound.

Validation:
- bmake makesum patch
- bmake -DNO_DEPENDS GEM_ENV=<staged Ruby 3.3 GTK3 closure> package
- bmake -DNO_DEPENDS GEM_ENV=<staged closure> test (port target has no test commands)
- staged Ruby 3.3 require "gtksourceview4" smoke test
- bmake check-license
- git diff --check

portlint -C reports only the generated untracked .mport artifact and work directory, retained intentionally; remaining warnings are pre-existing style checks including explicit PORTREVISION=0.

## Summary by Sourcery

Enhancements:
- Update the Ruby GtkSourceView4 binding port to version 4.3.7 and align its GTK3 and Rake runtime dependencies with the gem requirements.