### PR TITLE
net-im/meanwhile: reset PORTREVISION

### DIFF
--- a/net-im/meanwhile/Makefile
+++ b/net-im/meanwhile/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	meanwhile
 PORTVERSION=	1.1.1
+PORTREVISION=	0
 CATEGORIES=	net-im
 
 MAINTAINER=	ports@MidnightBSD.org


### PR DESCRIPTION
The 1.1.1 GitHub/autoreconf update is already on master (da75fb804d). Add the explicit PORTREVISION=0 required for a PORTVERSION increment.

Validation:
- bmake makesum
- bmake patch
- bmake
- bmake fake
- bmake package
- bmake test (no test commands defined; exits 0)
- bmake check-license
- git diff --check

Source audit: upstream COPYING and LICENSE both identify GNU Library General Public License version 2. Existing LICENSE=lgpl is unchanged as requested.

portlint -C reports only the expected PORTREVISION=0 warning plus fatal entries for generated untracked `work/` and `meanwhile-1.1.1.mport` artifacts; these were retained and are not part of the commit.

## Summary by Sourcery

Enhancements:
- Reset the port revision for the 1.1.1 version of net-im/meanwhile.