### PR TITLE
x11-toolkits/gtk30: update to 3.24.52

### DIFF
--- a/x11-toolkits/gtk30/Makefile
+++ b/x11-toolkits/gtk30/Makefile
@@ -1,6 +1,5 @@
 PORTNAME=	gtk
-DISTVERSION=	3.24.49 # sync with x11-themes: adwaita-icon-theme, gnome-themes-standard and mate-themes
-PORTREVISION=	1
+DISTVERSION=	3.24.52 # sync with x11-themes: adwaita-icon-theme, gnome-themes-standard and mate-themes
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME/sources/gtk/${DISTVERSION:R}
 PKGNAMESUFFIX=	3
@@ -34,11 +33,9 @@ USE_LDCONFIG=	yes
 USE_PERL5=	build
 SHEBANG_GLOB=	*.py
 
-MESON_ARGS=	-Dtests=false
-
 PORTSCOUT=	limit:1,even
 
-LIBVERSION=	0.2417.32
+LIBVERSION=	0.2420.32
 PLIST_SUB+=	LIBVERSION=${LIBVERSION}
 
 OPTIONS_DEFINE=		ATK_BRIDGE COLORD CUPS DEBUG DOCS
@@ -80,9 +77,6 @@ WAYLAND_MESON_TRUE=	wayland_backend
 X11_USES=	xorg
 X11_USE=	XORG=x11,xcomposite,xcursor,xdamage,xext,xfixes,xi,xinerama,xrandr,xrender
 X11_MESON_TRUE=	x11_backend
-
-TESTING_UNSAFE=	ld: error: unable to find library -lintl
-NO_TEST=	yes
 
 pre-build:
 	-${RM} -r ${WRKSRC}/docs/gtk.info*

--- a/x11-toolkits/gtk30/distinfo
+++ b/x11-toolkits/gtk30/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741533815
-SHA256 (gnome/gtk-3.24.49.tar.xz) = 5ea52c6a28f0e5ecf2e9a3c2facbb30d040b73871fcd5f33cd1317e9018a146e
-SIZE (gnome/gtk-3.24.49.tar.xz) = 13450556
+TIMESTAMP = 1788984684
+SHA256 (gnome/gtk-3.24.52.tar.xz) = 80931fa472a77b9a164f6740e3c0b444fac6770054632d35a7ff9d679e5e7b9f
+SIZE (gnome/gtk-3.24.52.tar.xz) = 13578032


### PR DESCRIPTION
Updates GTK 3 to 3.24.52, refreshes its ABI filename substitution, and restores upstream test execution.

Validation: makesum, patch, build, fake, package, check-license, portlint -C (0 fatals), and diff check. The package/listing preserves the existing gtk-query-immodules cache postexec and cache-removal entries unchanged.

Tests: 193/194 pass under an owned Xvfb/dbus session with valid XDG runtime and pixbuf loader cache. The remaining `tree-relationships` accessibility test expects an active-descendant signal without explicitly focusing the tree view; it reproduces under clean sessions and is left enabled rather than suppressed.

## Summary by Sourcery

Update the GTK 3 port to 3.24.52 and re-enable upstream test execution.

Enhancements:
- Update GTK 3 to version 3.24.52 and refresh its ABI version metadata.
- Restore the upstream GTK test suite to the port's validation workflow.

Tests:
- Enable GTK test execution, with 193 of 194 tests passing under the validated X11 session; retain the reproducible accessibility test failure without suppressing it.