### PR TITLE
graphics/rubygem-graphene1: add port

### DIFF
--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -394,10 +394,10 @@
     SUBDIR += rubygem-flamegraph
     SUBDIR += rubygem-gd2
     SUBDIR += rubygem-gdk_pixbuf2
-    SUBDIR += rubygem-graphene1
     SUBDIR += rubygem-gemojione
     SUBDIR += rubygem-gemojione32
     SUBDIR += rubygem-geokit
+    SUBDIR += rubygem-graphene1
     SUBDIR += rubygem-gitlab_emoji
     SUBDIR += rubygem-gruff
     SUBDIR += rubygem-histogram

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -394,6 +394,7 @@
     SUBDIR += rubygem-flamegraph
     SUBDIR += rubygem-gd2
     SUBDIR += rubygem-gdk_pixbuf2
+    SUBDIR += rubygem-graphene1
     SUBDIR += rubygem-gemojione
     SUBDIR += rubygem-gemojione32
     SUBDIR += rubygem-geokit

--- a/graphics/rubygem-graphene1/Makefile
+++ b/graphics/rubygem-graphene1/Makefile
@@ -1,0 +1,21 @@
+PORTNAME=	graphene1
+PORTVERSION=	4.3.7
+CATEGORIES=	graphics rubygems
+MASTER_SITES=	RG
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Ruby binding of Graphene
+WWW=		https://ruby-gnome.github.io/ \
+		https://github.com/ruby-gnome/ruby-gnome
+
+LICENSE=	lgpl2.1+
+LICENSE_FILE=	${WRKSRC}/COPYING.LIB
+
+LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
+RUN_DEPENDS=	rubygem-gobject-introspection>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-gobject-introspection
+
+USES=		gem
+
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/graphics/rubygem-graphene1/distinfo
+++ b/graphics/rubygem-graphene1/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1784005372
+SHA256 (rubygem/graphene1-4.3.7.gem) = b8a7f09522aadc9fcbf743b9dc8c0e58df5117b809e46870ab35027574bd97b4
+SIZE (rubygem/graphene1-4.3.7.gem) = 15872

--- a/graphics/rubygem-graphene1/pkg-descr
+++ b/graphics/rubygem-graphene1/pkg-descr
@@ -1,0 +1,1 @@
+Ruby/Graphene1 is a Ruby binding of Graphene.


### PR DESCRIPTION
Adds the pure-Ruby Graphene GI binding required by the Ruby GTK4 binding chain.

Imported from local FreeBSD ports and adapted for MidnightBSD: maintainer, `lgpl2.1+` license identifier, and exact GObject Introspection 4.3.7 runtime dependency. No FreeBSD 14+ gates or native extension code.

Validation: makesum, patch, build, fake, package, test target, check-license, source portlint (0 fatals), diff check, and staged Ruby 3.3 Graphene GI load.

## Summary by Sourcery

Add the Ruby Graphene binding port needed by the Ruby GTK4 binding stack.

New Features:
- Add a Ruby Graphene 1.0 binding port to the graphics package collection.

Enhancements:
- Declare the Graphene library and matching GObject Introspection runtime dependencies for the binding.

Chores:
- Add the port metadata, license information, distfile checksum, and package description.