### PR TITLE
x11-toolkits/rubygem-gsk4: add port

### DIFF
--- a/x11-toolkits/Makefile
+++ b/x11-toolkits/Makefile
@@ -125,6 +125,7 @@
     SUBDIR += qwt6
     SUBDIR += rubygem-gdk3
     SUBDIR += rubygem-gdk4
+    SUBDIR += rubygem-gsk4
     SUBDIR += rubygem-gtk2
     SUBDIR += rubygem-gtk3
     SUBDIR += rubygem-gtk4

--- a/x11-toolkits/rubygem-gsk4/Makefile
+++ b/x11-toolkits/rubygem-gsk4/Makefile
@@ -1,0 +1,21 @@
+PORTNAME=	gsk4
+PORTVERSION=	4.3.7
+CATEGORIES=	x11-toolkits rubygems
+MASTER_SITES=	RG
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Ruby binding of GSK 4
+WWW=		https://ruby-gnome.github.io/ \
+		https://github.com/ruby-gnome/ruby-gnome
+
+LICENSE=	lgpl2.1+
+LICENSE_FILE=	${WRKSRC}/COPYING.LIB
+
+RUN_DEPENDS=	rubygem-gdk4>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gdk4 \
+		rubygem-graphene1>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-graphene1
+
+USES=		gem
+
+NO_ARCH=	yes
+
+.include <bsd.port.mk>

--- a/x11-toolkits/rubygem-gsk4/distinfo
+++ b/x11-toolkits/rubygem-gsk4/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1784005384
+SHA256 (rubygem/gsk4-4.3.7.gem) = d3381db908e5d863384a18536d6185fba9b41a1578ed6dbbafa0cb69a0fc9cb0
+SIZE (rubygem/gsk4-4.3.7.gem) = 15872

--- a/x11-toolkits/rubygem-gsk4/pkg-descr
+++ b/x11-toolkits/rubygem-gsk4/pkg-descr
@@ -1,0 +1,1 @@
+Ruby/GSK4 is a Ruby binding of GSK 4.


### PR DESCRIPTION
Adds the pure-Ruby GSK 4 GI binding required by Ruby GTK4.

Imported from local FreeBSD ports and adapted for MidnightBSD identifiers/maintainer. It has no FreeBSD 14+ gate or native extension. Runtime dependencies are exact GDK4 and Graphene1 4.3.7 bindings; this PR should merge after [#1172](https://github.com/MidnightBSD/mports/pull/1172).

Validation: makesum, patch, build, fake, package, test target, check-license, source portlint (0 fatals), diff check, and staged Ruby 3.3 GSK GI load.

## Summary by Sourcery

Add the Ruby GSK 4 binding port and integrate it with the existing x11-toolkits ports collection.

New Features:
- Add the Ruby GSK 4 GObject Introspection binding port for use with Ruby GTK4.

Enhancements:
- Register the new port in the x11-toolkits category and declare its GDK4 and Graphene1 runtime dependencies.