### PR TITLE
x11-toolkits/rubygem-vte4: update to 4.3.7

### DIFF
--- a/x11-toolkits/rubygem-vte4/Makefile
+++ b/x11-toolkits/rubygem-vte4/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	vte4
-PORTVERSION=	4.3.4
+PORTVERSION=	4.3.7
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits rubygems
 MASTER_SITES=	RG
 
@@ -12,7 +13,8 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	rubygem-rake>=0:devel/rubygem-rake
-RUN_DEPENDS=	rubygem-gtk4>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gtk4
+RUN_DEPENDS=	rubygem-gtk4>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gtk4 \
+		rubygem-rake>=0:devel/rubygem-rake
 
 USES=		gem gnome
 USE_GNOME=	vte3

--- a/x11-toolkits/rubygem-vte4/distinfo
+++ b/x11-toolkits/rubygem-vte4/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1782920548
-SHA256 (rubygem/vte4-4.3.4.gem) = b74f1a938532614b6c2211069f225749713a47aca2a955851a685bfb2e0af704
-SIZE (rubygem/vte4-4.3.4.gem) = 18944
+TIMESTAMP = 1784005400
+SHA256 (rubygem/vte4-4.3.7.gem) = 3faf93f3bd39d989d9cba6b0ffa9409a9a94299e79f47e0c4d1babd44896cab4
+SIZE (rubygem/vte4-4.3.7.gem) = 18944


### PR DESCRIPTION
Updates Ruby VTE4 to 4.3.7, sets PORTREVISION explicitly to 0, aligns the GTK4 bound with the exact gem version, and adds the gemspec-required runtime Rake dependency.

Validation: makesum, patch, staged Ruby 3.3 build/fake/package/test (no upstream test commands), check-license, source portlint (0 fatals), and diff check. The native dependency-check passed against the staged GTK4 closure; no host packages were installed.

This follows the Ruby GTK4 update chain in [#1174](https://github.com/MidnightBSD/mports/pull/1174).

## Summary by Sourcery

Update the Ruby VTE4 port to release 4.3.7 with corrected dependency metadata.

Enhancements:
- Update the Ruby VTE4 port to version 4.3.7 and align its GTK4 and runtime Rake dependencies with the updated gem requirements.

Build:
- Set the port revision explicitly to 0 and refresh the gem distfile checksum.