### PR TITLE
graphics/rubygem-graphene1: enforce gem dependency version

### DIFF
--- a/graphics/rubygem-graphene1/Makefile
+++ b/graphics/rubygem-graphene1/Makefile
@@ -12,7 +12,7 @@ LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
 LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
-RUN_DEPENDS=	rubygem-gobject-introspection>=${PORTVERSION}<${PORTVERSION:R}.99:devel/rubygem-gobject-introspection
+RUN_DEPENDS=	rubygem-gobject-introspection>=${PORTVERSION}<${PORTVERSION}_99:devel/rubygem-gobject-introspection
 
 USES=		gem
 


### PR DESCRIPTION
The 4.3.7 gemspec requires gobject-introspection exactly at 4.3.7. Use a range that allows port revisions but not a different gem release.

## Summary by Sourcery

Bug Fixes:
- Correct the gobject-introspection dependency constraint to accept port revisions while preventing incompatible gem releases.