### PR TITLE
x11-toolkits/rubygem-gsk4: enforce gem dependency versions

### DIFF
--- a/x11-toolkits/rubygem-gsk4/Makefile
+++ b/x11-toolkits/rubygem-gsk4/Makefile
@@ -11,8 +11,8 @@ WWW=		https://ruby-gnome.github.io/ \
 LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING.LIB
 
-RUN_DEPENDS=	rubygem-gdk4>=${PORTVERSION}<${PORTVERSION:R}.99:x11-toolkits/rubygem-gdk4 \
-		rubygem-graphene1>=${PORTVERSION}<${PORTVERSION:R}.99:graphics/rubygem-graphene1
+RUN_DEPENDS=	rubygem-gdk4>=${PORTVERSION}<${PORTVERSION}_99:x11-toolkits/rubygem-gdk4 \
+		rubygem-graphene1>=${PORTVERSION}<${PORTVERSION}_99:graphics/rubygem-graphene1
 
 USES=		gem
 


### PR DESCRIPTION
The 4.3.7 gemspec requires GDK4 and Graphene1 exactly at 4.3.7. Use ranges that accept port revisions without admitting a different gem release.

## Summary by Sourcery

Bug Fixes:
- Constrain GDK4 and Graphene1 dependencies to the matching gem release while allowing compatible port revisions.