### PR TITLE
x11-toolkits/gtk30: reset PORTREVISION

### DIFF
--- a/x11-toolkits/gtk30/Makefile
+++ b/x11-toolkits/gtk30/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gtk
 DISTVERSION=	3.24.52 # sync with x11-themes: adwaita-icon-theme, gnome-themes-standard and mate-themes
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME/sources/gtk/${DISTVERSION:R}
 PKGNAMESUFFIX=	3


### PR DESCRIPTION
Restore the explicit PORTREVISION=0 required after the 3.24.52 upstream version update.

## Summary by Sourcery

Chores:
- Restore an explicit PORTREVISION of 0 for the GTK 3 port following the upstream version update.