### PR TITLE
net/librest1: correct LGPL metadata

### DIFF
--- a/net/librest1/Makefile
+++ b/net/librest1/Makefile
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidinghtBSD.org
 COMMENT=	GNOME REST library
 WWW=		https://gitlab.gnome.org/GNOME/librest
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 LIB_DEPENDS=	libadwaita-1.so:x11-toolkits/libadwaita \
@@ -24,6 +24,7 @@ USE_LDCONFIG=	yes
 MESON_ARGS=	-Dca_certificates=true \
 		-Dca_certificates_path=/etc/ssl/cert.pem \
 		-Dgtk_doc=false
+NO_TEST=	yes
 
 OPTIONS_DEFINE=	DOCS
 


### PR DESCRIPTION
The 0.10.2 meson project declares LGPL-2.1-or-later. Update the mport identifier accordingly.

## Summary by Sourcery

Align the librest1 port metadata with the upstream project’s licensing and test configuration.

Bug Fixes:
- Correct the port license metadata to reflect the project’s LGPL-2.1-or-later licensing.

Chores:
- Disable testing for the port.