### PR TITLE
x11-toolkits/pango: update to 1.57.1

### DIFF
--- a/x11-toolkits/pango/Makefile
+++ b/x11-toolkits/pango/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	pango
-PORTVERSION=	1.56.4
+DISTVERSION=	1.57.1
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -8,13 +9,14 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Open-source framework for the layout and rendering of i18n text
 WWW=		https://www.gtk.org/docs/architecture/pango
 
-LICENSE=	lgpl
+LICENSE=	lgpl+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 LIB_DEPENDS=	libfreetype.so:print/freetype2 \
 		libharfbuzz.so:print/harfbuzz \
 		libfontconfig.so:x11-fonts/fontconfig \
 		libfribidi.so:converters/fribidi
+TEST_DEPENDS=	cantarell-fonts>=0:x11-fonts/cantarell-fonts
 
 USES=		compiler:c11 cpe gnome meson pkgconfig tar:xz
 CPE_VENDOR=	gnome
@@ -23,26 +25,34 @@ USE_LDCONFIG=	yes
 
 PORTSCOUT=	limit:^1\.[^9]
 
-PLIST_SUB=	LIBVERSION=0.${PORTVERSION:R:E}00.${PORTVERSION:E}
+PLIST_SUB=	LIBVERSION=0.${PORTVERSION:R:E}0${PORTVERSION:E}.0
+
+TESTING_UNSAFE=	test-fonts and test-layout depend on host Cantarell variable-font metrics
 
 OPTIONS_DEFINE=		DOCS LANG_TH MANPAGES X11
 OPTIONS_DEFAULT=	LANG_TH MANPAGES X11
 OPTIONS_SUB=		yes
 
 DOCS_BUILD_DEPENDS=	gi-docgen:textproc/py-gi-docgen \
-			rst2man:textproc/py-docutils
+			rst2html5:textproc/py-docutils
 DOCS_MESON_TRUE=	documentation
 
 LANG_TH_LIB_DEPENDS=	libthai.so:devel/libthai
 LANG_TH_MESON_ENABLED=	libthai
 
+MANPAGES_BUILD_DEPENDS=	rst2man:textproc/py-docutils
 MANPAGES_MESON_TRUE=	man-pages
-MANPAGES_IMPLIES=	DOCS
 
 X11_USES=		xorg
 X11_USE=		XORG=x11,xft,xrender
 X11_MESON_ENABLED=	xft
 
-NO_TEST=	yes
+post-patch:
+	${REINPLACE_CMD} -e 's|/etc/fonts/fonts.conf|${LOCALBASE}&|' \
+		${WRKSRC}/tests/meson.build
+
+pre-test:
+# Don't test backup files. Silly Meson.
+	@${FIND} ${WRKSRC}/tests/fontsets/ -name "*.orig" -delete
 
 .include <bsd.port.mk>

--- a/x11-toolkits/pango/distinfo
+++ b/x11-toolkits/pango/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1756562922
-SHA256 (gnome/pango-1.56.4.tar.xz) = 17065e2fcc5f5a5bdbffc884c956bfc7c451a96e8c4fb2f8ad837c6413cb5a01
-SIZE (gnome/pango-1.56.4.tar.xz) = 1883988
+TIMESTAMP = 1788984141
+SHA256 (gnome/pango-1.57.1.tar.xz) = e65d6d117080dc3aeeb7d8b4b3b518f7383aa2e6cfce23117c623cd624764c2f
+SIZE (gnome/pango-1.57.1.tar.xz) = 2588416

--- a/x11-toolkits/pango/pkg-plist
+++ b/x11-toolkits/pango/pkg-plist
@@ -161,6 +161,7 @@ libdata/pkgconfig/pangoot.pc
 %%DOCS%%share/doc/Pango/enum.CoverageLevel.html
 %%DOCS%%share/doc/Pango/enum.Direction.html
 %%DOCS%%share/doc/Pango/enum.EllipsizeMode.html
+%%DOCS%%share/doc/Pango/enum.FontColor.html
 %%DOCS%%share/doc/Pango/enum.FontScale.html
 %%DOCS%%share/doc/Pango/enum.Gravity.html
 %%DOCS%%share/doc/Pango/enum.GravityHint.html
@@ -365,6 +366,7 @@ libdata/pkgconfig/pangoot.pc
 %%DOCS%%share/doc/Pango/method.FontDescription.copy_static.html
 %%DOCS%%share/doc/Pango/method.FontDescription.equal.html
 %%DOCS%%share/doc/Pango/method.FontDescription.free.html
+%%DOCS%%share/doc/Pango/method.FontDescription.get_color.html
 %%DOCS%%share/doc/Pango/method.FontDescription.get_family.html
 %%DOCS%%share/doc/Pango/method.FontDescription.get_features.html
 %%DOCS%%share/doc/Pango/method.FontDescription.get_gravity.html
@@ -380,6 +382,7 @@ libdata/pkgconfig/pangoot.pc
 %%DOCS%%share/doc/Pango/method.FontDescription.merge.html
 %%DOCS%%share/doc/Pango/method.FontDescription.merge_static.html
 %%DOCS%%share/doc/Pango/method.FontDescription.set_absolute_size.html
+%%DOCS%%share/doc/Pango/method.FontDescription.set_color.html
 %%DOCS%%share/doc/Pango/method.FontDescription.set_family.html
 %%DOCS%%share/doc/Pango/method.FontDescription.set_family_static.html
 %%DOCS%%share/doc/Pango/method.FontDescription.set_features.html


### PR DESCRIPTION
Updates Pango to 1.57.1, resets PORTREVISION to 0, and corrects LICENSE to lgpl+.\n\nValidation: makesum, patch, build, fake, package, check-license, portlint (0 fatals before generated artifacts), and git diff --check passed. Tests remain enabled: 25 passed, 2 skipped, and 2 font-environment failures remain (Cantarell variable-font naming and rotated glyph offsets); no assertions or baselines were weakened.

## Summary by Sourcery

Update the Pango port to 1.57.1, refresh licensing and packaging metadata, and re-enable its test suite.

Bug Fixes:
- Correct the package license declaration to LGPL+.

Enhancements:
- Update Pango to version 1.57.1 and refresh its packaging metadata.
- Enable the test suite with Cantarell font test dependencies while documenting known host-font-related failures.
- Refine documentation and man-page build dependencies and keep the DOCS and MANPAGES options independent.

Tests:
- Add port test setup for locating font configuration and excluding generated backup files.