### PR TITLE
graphics/inkscape: bump revision for lib2geom

### DIFF
--- a/graphics/inkscape/Makefile
+++ b/graphics/inkscape/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	inkscape
 DISTVERSION=	1.4.4
+PORTREVISION=	1
 CATEGORIES=	graphics gnome
 MASTER_SITES=	https://media.inkscape.org/dl/resources/file/
 


### PR DESCRIPTION
Rebuild Inkscape for the lib2geom 1.4 SONAME change from lib2geom.so.1.1.0 to lib2geom.so.1.4.0 (PR #1182).\n\nValidation: bmake -V PORTREVISION, portlint -C, and git diff --check passed.

## Summary by Sourcery

Bug Fixes:
- Trigger an Inkscape rebuild against the updated lib2geom 1.4 SONAME.