### PR TITLE
security/gnome-keyring: update to 50.0

### DIFF
--- a/security/gnome-keyring/Makefile
+++ b/security/gnome-keyring/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gnome-keyring
-PORTVERSION=	48.0
+PORTVERSION=	50.0
+PORTREVISION=	0
 CATEGORIES=	security gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -8,8 +9,10 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Program that keeps passwords and other secrets
 WWW=		https://gitlab.gnome.org/GNOME/gnome-keyring
 
-LICENSE=	gpl2
-LICENSE_FILE=	${WRKSRC}/COPYING
+LICENSE=	gpl2+ lgpl2.1+
+LICENSE_COMB=	multi
+LICENSE_FILE_gpl2+ =	${WRKSRC}/COPYING
+LICENSE_FILE_lgpl2.1+ =	${WRKSRC}/COPYING.LIB
 
 BUILD_DEPENDS=	docbook-xsl>=0:textproc/docbook-xsl
 LIB_DEPENDS=	libdbus-1.so:devel/dbus \
@@ -28,9 +31,11 @@ USE_GNOME=	cairo glib20 gtk30 libxslt:build
 CPE_VENDOR=	gnome
 USE_LDCONFIG=	yes
 MESON_ARGS=	-Dssh-agent=true \
+		-Dlibcap-ng=disabled \
 		-Dselinux=disabled \
 		-Dsystemd=disabled
 GLIB_SCHEMAS=	org.gnome.crypto.cache.gschema.xml
+TEST_ENV=	DBUS_SESSION_BUS_ADDRESS=$$DBUS_SESSION_BUS_ADDRESS
 
 SUB_FILES=	pkg-message
 

--- a/security/gnome-keyring/distinfo
+++ b/security/gnome-keyring/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1788842862
-SHA256 (gnome/gnome-keyring-48.0.tar.xz) = f20518c920e9ea3f9c9b8b44be8c50d8d7feecd0dd5624960f77bd2ca4fbeb9d
-SIZE (gnome/gnome-keyring-48.0.tar.xz) = 767428
+TIMESTAMP = 1789100453
+SHA256 (gnome/gnome-keyring-50.0.tar.xz) = cbd72062c53c9702bc2c4733991ad5f051ca682882b30905a2829bcf1a8ecc7c
+SIZE (gnome/gnome-keyring-50.0.tar.xz) = 769896

--- a/security/gnome-keyring/files/patch-daemon_test-startup.c
+++ b/security/gnome-keyring/files/patch-daemon_test-startup.c
@@ -1,0 +1,10 @@
+--- daemon/test-startup.c.orig	2026-09-11 00:00:00 UTC
++++ daemon/test-startup.c
+@@ -33,0 +34 @@
++#include <unistd.h>
+@@ -128,0 +130,5 @@ test_control_noaccess (Test *test,
++	if (geteuid () == 0) {
++		g_test_skip ("root bypasses directory permissions");
++		return;
++	}
++

--- a/security/gnome-keyring/files/patch-pkcs11_secret-store_gkm-secret-fields.c
+++ b/security/gnome-keyring/files/patch-pkcs11_secret-store_gkm-secret-fields.c
@@ -1,0 +1,10 @@
+--- pkcs11/secret-store/gkm-secret-fields.c.orig	2025-09-13 11:58:24 UTC
++++ pkcs11/secret-store/gkm-secret-fields.c
+@@ -162,3 +162,4 @@ gkm_secret_fields_parse (CK_ATTRIBUTE_PTR attr,
+-	last = ptr + attr->ulValueLen;
+-	if (!ptr && last != ptr)
+-		return CKR_ATTRIBUTE_VALUE_INVALID;
++	if (!ptr && attr->ulValueLen != 0)
++		return CKR_ATTRIBUTE_VALUE_INVALID;
++
++	last = ptr + attr->ulValueLen;

--- a/security/gnome-keyring/pkg-plist
+++ b/security/gnome-keyring/pkg-plist
@@ -64,6 +64,7 @@ share/locale/kk/LC_MESSAGES/gnome-keyring.mo
 share/locale/km/LC_MESSAGES/gnome-keyring.mo
 share/locale/kn/LC_MESSAGES/gnome-keyring.mo
 share/locale/ko/LC_MESSAGES/gnome-keyring.mo
+share/locale/kw/LC_MESSAGES/gnome-keyring.mo
 share/locale/lt/LC_MESSAGES/gnome-keyring.mo
 share/locale/lv/LC_MESSAGES/gnome-keyring.mo
 share/locale/mai/LC_MESSAGES/gnome-keyring.mo
@@ -101,6 +102,7 @@ share/locale/th/LC_MESSAGES/gnome-keyring.mo
 share/locale/tr/LC_MESSAGES/gnome-keyring.mo
 share/locale/ug/LC_MESSAGES/gnome-keyring.mo
 share/locale/uk/LC_MESSAGES/gnome-keyring.mo
+share/locale/uz/LC_MESSAGES/gnome-keyring.mo
 share/locale/vi/LC_MESSAGES/gnome-keyring.mo
 share/locale/xh/LC_MESSAGES/gnome-keyring.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-keyring.mo


### PR DESCRIPTION
Updates GNOME Keyring to 50.0.

Corrects combined GPL-2.0-or-later and LGPL-2.1-or-later metadata, disables unavailable libcap-ng explicitly, and fixes null-pointer arithmetic in secret-field parsing.

All 62 tests pass under an isolated D-Bus session. The permission-denial case skips only as root, where root bypasses the condition it verifies.

Validated: bmake makesum, patch, build, fake, package, test, check-license; git diff --check.

## Summary by Sourcery

Update the GNOME Keyring port to 50.0 with corrected licensing, platform configuration, and safety fixes.

Bug Fixes:
- Fix null-pointer handling during secret-field parsing.
- Skip the permission-denial test when running as root, where permission checks are bypassed.

Enhancements:
- Update GNOME Keyring to version 50.0.
- Correct license metadata for the combined GPL and LGPL licensing.

Build:
- Explicitly disable unavailable libcap-ng support.

Tests:
- Run the test suite within the caller's isolated D-Bus session.

Chores:
- Update the package file list for the new release.