### PR TITLE
editors/gnome-text-editor: update to 49.0

### DIFF
--- a/editors/gnome-text-editor/Makefile
+++ b/editors/gnome-text-editor/Makefile
@@ -22,7 +22,7 @@ LIB_DEPENDS=	libenchant-2.so:textproc/enchant2 \
 USES=		compiler:c11 desktop-file-utils gettext gnome localbase meson \
 		pkgconfig tar:xz
 USE_CSTD=	c11
-USE_GNOME=	cairo glib20 gtk40 gtksourceview5 libadwaita
+USE_GNOME=	cairo glib20 gtk40 gtk-update-icon-cache gtksourceview5 libadwaita
 INSTALLS_ICONS=	yes
 GLIB_SCHEMAS=	org.gnome.TextEditor.gschema.xml
 

--- a/editors/gnome-text-editor/Makefile
+++ b/editors/gnome-text-editor/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gnome-text-editor
-PORTVERSION=	47.4
+PORTVERSION=	49.0
+PORTREVISION=	0
 CATEGORIES=	editors gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -22,8 +23,9 @@ USES=		compiler:c11 desktop-file-utils gettext gnome localbase meson \
 		pkgconfig tar:xz
 USE_CSTD=	c11
 USE_GNOME=	cairo glib20 gtk40 gtksourceview5 libadwaita
+INSTALLS_ICONS=	yes
 GLIB_SCHEMAS=	org.gnome.TextEditor.gschema.xml
 
-PORTSCOUT=	limit:^47\.
+PORTSCOUT=	limit:^49\.
 
 .include <bsd.port.mk>

--- a/editors/gnome-text-editor/distinfo
+++ b/editors/gnome-text-editor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1788922656
-SHA256 (gnome/gnome-text-editor-47.4.tar.xz) = 3ac505a904aafce353813bb13a7b8f82a39d474c4a945ce89aef7e650ec9f8da
-SIZE (gnome/gnome-text-editor-47.4.tar.xz) = 639932
+TIMESTAMP = 1789139502
+SHA256 (gnome/gnome-text-editor-49.0.tar.xz) = 8e43b0cfa8152cd3c7630de565de2d6930e887cf2d8b84480fbf853a2bc2c8a6
+SIZE (gnome/gnome-text-editor-49.0.tar.xz) = 677176

--- a/editors/gnome-text-editor/pkg-plist
+++ b/editors/gnome-text-editor/pkg-plist
@@ -1,11 +1,6 @@
 bin/gnome-text-editor
 share/applications/org.gnome.TextEditor.desktop
 share/dbus-1/services/org.gnome.TextEditor.service
-%%DATADIR%%/styles/builder-dark.xml
-%%DATADIR%%/styles/builder.xml
-%%DATADIR%%/styles/peninsula-dark.xml
-%%DATADIR%%/styles/peninsula.xml
-%%DATADIR%%/styles/printing.xml
 share/help/C/gnome-text-editor/basics-create-new-file.page
 share/help/C/gnome-text-editor/basics-draft-folder.page
 share/help/C/gnome-text-editor/basics-open-file.page
@@ -207,6 +202,7 @@ share/help/zh_CN/gnome-text-editor/media/search-recent.png
 share/icons/hicolor/scalable/apps/org.gnome.TextEditor.svg
 share/icons/hicolor/symbolic/apps/org.gnome.TextEditor-symbolic.svg
 share/locale/ab/LC_MESSAGES/gnome-text-editor.mo
+share/locale/ar/LC_MESSAGES/gnome-text-editor.mo
 share/locale/be/LC_MESSAGES/gnome-text-editor.mo
 share/locale/bg/LC_MESSAGES/gnome-text-editor.mo
 share/locale/ca/LC_MESSAGES/gnome-text-editor.mo
@@ -255,7 +251,8 @@ share/locale/sv/LC_MESSAGES/gnome-text-editor.mo
 share/locale/th/LC_MESSAGES/gnome-text-editor.mo
 share/locale/tr/LC_MESSAGES/gnome-text-editor.mo
 share/locale/uk/LC_MESSAGES/gnome-text-editor.mo
+share/locale/uz/LC_MESSAGES/gnome-text-editor.mo
 share/locale/vi/LC_MESSAGES/gnome-text-editor.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-text-editor.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-text-editor.mo
-share/metainfo/org.gnome.TextEditor.appdata.xml
+share/metainfo/org.gnome.TextEditor.metainfo.xml


### PR DESCRIPTION
Updates GNOME Text Editor to 49.0 and resets PORTREVISION to 0. Adds icon-cache metadata and refreshes the plist for removed bundled styles, metainfo rename, and new translations.

Validation: bmake makesum, patch, build, fake, package, test (1/1), check-license, git diff --check. The test build used the packaged GtkSourceView 5.18.0 dependency, not Meson fallback. portlint reports only retained work artifacts and existing advisories.

## Summary by Sourcery

Update the GNOME Text Editor port to the 49.0 release with refreshed packaging metadata and icon-cache support.

Enhancements:
- Update GNOME Text Editor to version 49.0 and refresh its package metadata for the renamed metainfo, removed bundled styles, and new translations.
- Enable icon-cache integration for installed editor icons.

Chores:
- Reset PORTREVISION and update version tracking for the new upstream release.