### PR TITLE
devel/dconf-editor: update to 49.0

### DIFF
--- a/devel/dconf-editor/Makefile
+++ b/devel/dconf-editor/Makefile
@@ -1,13 +1,9 @@
 PORTNAME=	dconf-editor
-PORTVERSION=	45.0.1
+PORTVERSION=	49.0
+PORTREVISION=	0
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
-
-# https://gitlab.gnome.org/GNOME/dconf-editor/-/merge_requests/34
-PATCH_SITES=	https://gitlab.gnome.org/GNOME/${PORTNAME}/-/commit/
-PATCHFILES=	baf18373.patch:-p1 \
-		dd8ddbbf.patch:-p1
 
 MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Viewer and editor of applications internal settings

--- a/devel/dconf-editor/distinfo
+++ b/devel/dconf-editor/distinfo
@@ -1,7 +1,3 @@
-TIMESTAMP = 1740336026
-SHA256 (gnome/dconf-editor-45.0.1.tar.xz) = 1180297678eedae6217cc514a2638c187d2f1d1ef2720cb9079b740c429941dd
-SIZE (gnome/dconf-editor-45.0.1.tar.xz) = 608576
-SHA256 (gnome/baf18373.patch) = f1313f8a907deda0aff0ab5362f39a211f3f2ae87bfe3213c4038dc68822a5ef
-SIZE (gnome/baf18373.patch) = 1143
-SHA256 (gnome/dd8ddbbf.patch) = 8b7a72b23ce41b164008749e113f311201daebf7e44dd3d09e74003b1132a4dc
-SIZE (gnome/dd8ddbbf.patch) = 1071
+TIMESTAMP = 1789139844
+SHA256 (gnome/dconf-editor-49.0.tar.xz) = 90a8ccfadf51dff31e0028324fb9a358b2d26c5ae861a71c7dbf9f4dd9bdd399
+SIZE (gnome/dconf-editor-49.0.tar.xz) = 652952

--- a/devel/dconf-editor/pkg-plist
+++ b/devel/dconf-editor/pkg-plist
@@ -71,9 +71,10 @@ share/locale/th/LC_MESSAGES/dconf-editor.mo
 share/locale/tr/LC_MESSAGES/dconf-editor.mo
 share/locale/ug/LC_MESSAGES/dconf-editor.mo
 share/locale/uk/LC_MESSAGES/dconf-editor.mo
+share/locale/uz/LC_MESSAGES/dconf-editor.mo
 share/locale/vi/LC_MESSAGES/dconf-editor.mo
 share/locale/zh_CN/LC_MESSAGES/dconf-editor.mo
 share/locale/zh_HK/LC_MESSAGES/dconf-editor.mo
 share/locale/zh_TW/LC_MESSAGES/dconf-editor.mo
 share/man/man1/dconf-editor.1.gz
-share/metainfo/ca.desrt.dconf-editor.appdata.xml
+share/metainfo/ca.desrt.dconf-editor.metainfo.xml


### PR DESCRIPTION
Updates Dconf Editor to 49.0 and resets PORTREVISION to 0. Drops two upstreamed external patches and refreshes the plist for the AppStream metainfo rename and Uzbek translation.

Validation: bmake makesum, patch, build, fake, package, test (2/2), check-license, git diff --check. portlint reports only retained work artifacts and existing advisories.

## Summary by Sourcery

Update the Dconf Editor port to version 49.0 and align its packaging files with the upstream release.

Enhancements:
- Update Dconf Editor to the 49.0 release and refresh its packaging metadata.

Chores:
- Remove external patches incorporated upstream and reset PORTREVISION for the new release.
- Update the package plist for renamed AppStream metadata and the added Uzbek translation.