### PR TITLE
sysutils/gnome-system-monitor: update to 49.1

### DIFF
--- a/sysutils/gnome-system-monitor/Makefile
+++ b/sysutils/gnome-system-monitor/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gnome-system-monitor
-PORTVERSION=	47.1
+PORTVERSION=	49.1
+PORTREVISION=	0
 CATEGORIES=	sysutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -8,10 +9,11 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GNOME system monitor program
 WWW=		https://apps.gnome.org/GnomeSystemMonitor/
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	itstool:textproc/itstool
+BUILD_DEPENDS=	catch2>0:devel/catch2 \
+		itstool:textproc/itstool
 LIB_DEPENDS=	libgtop-2.0.so:devel/libgtop \
 		libgraphene-1.0.so:graphics/graphene
 RUN_DEPENDS=	polkit>0:sysutils/polkit

--- a/sysutils/gnome-system-monitor/distinfo
+++ b/sysutils/gnome-system-monitor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1745069388
-SHA256 (gnome/gnome-system-monitor-47.1.tar.xz) = d3c5714fd91fa7f05d6775e6797ccdab3149f131d1aa776a3352e2addb110f01
-SIZE (gnome/gnome-system-monitor-47.1.tar.xz) = 1093736
+TIMESTAMP = 1789138848
+SHA256 (gnome/gnome-system-monitor-49.1.tar.xz) = 915b6a321ada12eba7bf578c20c9fe5e41f55d532847cbd124bbddaaec11d70f
+SIZE (gnome/gnome-system-monitor-49.1.tar.xz) = 1105840

--- a/sysutils/gnome-system-monitor/pkg-plist
+++ b/sysutils/gnome-system-monitor/pkg-plist
@@ -4,7 +4,6 @@ libexec/gnome-system-monitor/gsm-renice
 libexec/gnome-system-monitor/gsm-taskset
 share/applications/gnome-system-monitor-kde.desktop
 share/applications/org.gnome.SystemMonitor.desktop
-%%DATADIR%%/gsm.gresource
 share/help/C/gnome-system-monitor/commandline.page
 share/help/C/gnome-system-monitor/cpu-check.page
 share/help/C/gnome-system-monitor/cpu-mem-normal.page
@@ -747,9 +746,10 @@ share/locale/th/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/tr/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/ug/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/uk/LC_MESSAGES/gnome-system-monitor.mo
+share/locale/uz/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/vi/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-system-monitor.mo
 share/locale/zh_TW/LC_MESSAGES/gnome-system-monitor.mo
-share/metainfo/org.gnome.SystemMonitor.appdata.xml
+share/metainfo/org.gnome.SystemMonitor.metainfo.xml
 share/polkit-1/actions/org.gnome.gnome-system-monitor.policy


### PR DESCRIPTION
Updates GNOME System Monitor to 49.1.

- Resets PORTREVISION to 0 for the upstream release
- Adds the required Catch2 build dependency
- Refreshes the staged plist for current metadata and locales
- Corrects the source-evidenced GPL-2.0-or-later declaration to gpl2+

Validation: bmake makesum, patch, build, fake, package, test (3/3), check-license, and git diff --check.

## Summary by Sourcery

Update GNOME System Monitor to 49.1 with current dependencies, licensing, and package metadata.

Enhancements:
- Update GNOME System Monitor to the 49.1 upstream release and refresh its packaging metadata.

Build:
- Add Catch2 as a build dependency.

Chores:
- Correct the package license declaration to GPL-2.0-or-later and reset PORTREVISION for the upstream release.