### PR TITLE
lang/typescript: add port

### DIFF
--- a/lang/Makefile
+++ b/lang/Makefile
@@ -136,6 +136,7 @@
     SUBDIR += tcl-wrapper
     SUBDIR += tcl86
     SUBDIR += tcl90
+    SUBDIR += typescript
     SUBDIR += tolua
     SUBDIR += tolua++
     SUBDIR += v

--- a/lang/typescript/Makefile
+++ b/lang/typescript/Makefile
@@ -1,0 +1,29 @@
+PORTNAME=	typescript
+DISTVERSION=	5.9.3
+CATEGORIES=	lang
+MASTER_SITES=	https://registry.npmjs.org/${PORTNAME}/-/
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Superset of JavaScript that compiles to JavaScript output
+WWW=		https://www.typescriptlang.org/
+
+LICENSE=	Apache-2.0
+
+USES=		nodejs:run tar:tgz
+
+NO_ARCH=	yes
+NO_BUILD=	yes
+
+WRKSRC=		${WRKDIR}/package
+
+post-patch:
+	${FIND} ${WRKSRC}/bin -type f | ${XARGS} \
+		${REINPLACE_CMD} -i "" -e 's|../lib|${LOCALBASE}/lib/node_modules/${PORTNAME}|'
+
+do-install:
+	${MKDIR} ${PREFIX}/lib/node_modules/${PORTNAME}
+	${INSTALL_SCRIPT} ${WRKSRC}/bin/tsc ${PREFIX}/bin
+	${INSTALL_SCRIPT} ${WRKSRC}/bin/tsserver ${PREFIX}/bin
+	cd ${WRKSRC}/lib && ${COPYTREE_SHARE} . ${PREFIX}/lib/node_modules/${PORTNAME}
+
+.include <bsd.port.mk>

--- a/lang/typescript/Makefile
+++ b/lang/typescript/Makefile
@@ -18,7 +18,7 @@ WRKSRC=		${WRKDIR}/package
 
 post-patch:
 	${FIND} ${WRKSRC}/bin -type f | ${XARGS} \
-		${REINPLACE_CMD} -i "" -e 's|../lib|${LOCALBASE}/lib/node_modules/${PORTNAME}|'
+		${REINPLACE_CMD} -i "" -e 's|../lib|${TRUE_PREFIX}/lib/node_modules/${PORTNAME}|'
 
 do-install:
 	${MKDIR} ${PREFIX}/lib/node_modules/${PORTNAME}

--- a/lang/typescript/distinfo
+++ b/lang/typescript/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1759274614
+SHA256 (typescript-5.9.3.tgz) = 10e108c9cf7d5f2879053dff18515fb405abf2ccef63eaaf017d9c571687a1d3
+SIZE (typescript-5.9.3.tgz) = 4377468

--- a/lang/typescript/pkg-descr
+++ b/lang/typescript/pkg-descr
@@ -1,0 +1,4 @@
+TypeScript is a language for application-scale JavaScript. TypeScript
+adds optional types to JavaScript that support tools for large-scale
+JavaScript applications for any browser, for any host, on any OS.
+TypeScript compiles to readable, standards-based JavaScript.

--- a/lang/typescript/pkg-plist
+++ b/lang/typescript/pkg-plist
@@ -1,0 +1,141 @@
+bin/tsc
+bin/tsserver
+lib/node_modules/typescript/_tsc.js
+lib/node_modules/typescript/_tsserver.js
+lib/node_modules/typescript/_typingsInstaller.js
+lib/node_modules/typescript/cs/diagnosticMessages.generated.json
+lib/node_modules/typescript/de/diagnosticMessages.generated.json
+lib/node_modules/typescript/es/diagnosticMessages.generated.json
+lib/node_modules/typescript/fr/diagnosticMessages.generated.json
+lib/node_modules/typescript/it/diagnosticMessages.generated.json
+lib/node_modules/typescript/ja/diagnosticMessages.generated.json
+lib/node_modules/typescript/ko/diagnosticMessages.generated.json
+lib/node_modules/typescript/lib.d.ts
+lib/node_modules/typescript/lib.decorators.d.ts
+lib/node_modules/typescript/lib.decorators.legacy.d.ts
+lib/node_modules/typescript/lib.dom.asynciterable.d.ts
+lib/node_modules/typescript/lib.dom.d.ts
+lib/node_modules/typescript/lib.dom.iterable.d.ts
+lib/node_modules/typescript/lib.es2015.collection.d.ts
+lib/node_modules/typescript/lib.es2015.core.d.ts
+lib/node_modules/typescript/lib.es2015.d.ts
+lib/node_modules/typescript/lib.es2015.generator.d.ts
+lib/node_modules/typescript/lib.es2015.iterable.d.ts
+lib/node_modules/typescript/lib.es2015.promise.d.ts
+lib/node_modules/typescript/lib.es2015.proxy.d.ts
+lib/node_modules/typescript/lib.es2015.reflect.d.ts
+lib/node_modules/typescript/lib.es2015.symbol.d.ts
+lib/node_modules/typescript/lib.es2015.symbol.wellknown.d.ts
+lib/node_modules/typescript/lib.es2016.array.include.d.ts
+lib/node_modules/typescript/lib.es2016.d.ts
+lib/node_modules/typescript/lib.es2016.full.d.ts
+lib/node_modules/typescript/lib.es2016.intl.d.ts
+lib/node_modules/typescript/lib.es2017.arraybuffer.d.ts
+lib/node_modules/typescript/lib.es2017.d.ts
+lib/node_modules/typescript/lib.es2017.date.d.ts
+lib/node_modules/typescript/lib.es2017.full.d.ts
+lib/node_modules/typescript/lib.es2017.intl.d.ts
+lib/node_modules/typescript/lib.es2017.object.d.ts
+lib/node_modules/typescript/lib.es2017.sharedmemory.d.ts
+lib/node_modules/typescript/lib.es2017.string.d.ts
+lib/node_modules/typescript/lib.es2017.typedarrays.d.ts
+lib/node_modules/typescript/lib.es2018.asyncgenerator.d.ts
+lib/node_modules/typescript/lib.es2018.asynciterable.d.ts
+lib/node_modules/typescript/lib.es2018.d.ts
+lib/node_modules/typescript/lib.es2018.full.d.ts
+lib/node_modules/typescript/lib.es2018.intl.d.ts
+lib/node_modules/typescript/lib.es2018.promise.d.ts
+lib/node_modules/typescript/lib.es2018.regexp.d.ts
+lib/node_modules/typescript/lib.es2019.array.d.ts
+lib/node_modules/typescript/lib.es2019.d.ts
+lib/node_modules/typescript/lib.es2019.full.d.ts
+lib/node_modules/typescript/lib.es2019.intl.d.ts
+lib/node_modules/typescript/lib.es2019.object.d.ts
+lib/node_modules/typescript/lib.es2019.string.d.ts
+lib/node_modules/typescript/lib.es2019.symbol.d.ts
+lib/node_modules/typescript/lib.es2020.bigint.d.ts
+lib/node_modules/typescript/lib.es2020.d.ts
+lib/node_modules/typescript/lib.es2020.date.d.ts
+lib/node_modules/typescript/lib.es2020.full.d.ts
+lib/node_modules/typescript/lib.es2020.intl.d.ts
+lib/node_modules/typescript/lib.es2020.number.d.ts
+lib/node_modules/typescript/lib.es2020.promise.d.ts
+lib/node_modules/typescript/lib.es2020.sharedmemory.d.ts
+lib/node_modules/typescript/lib.es2020.string.d.ts
+lib/node_modules/typescript/lib.es2020.symbol.wellknown.d.ts
+lib/node_modules/typescript/lib.es2021.d.ts
+lib/node_modules/typescript/lib.es2021.full.d.ts
+lib/node_modules/typescript/lib.es2021.intl.d.ts
+lib/node_modules/typescript/lib.es2021.promise.d.ts
+lib/node_modules/typescript/lib.es2021.string.d.ts
+lib/node_modules/typescript/lib.es2021.weakref.d.ts
+lib/node_modules/typescript/lib.es2022.array.d.ts
+lib/node_modules/typescript/lib.es2022.d.ts
+lib/node_modules/typescript/lib.es2022.error.d.ts
+lib/node_modules/typescript/lib.es2022.full.d.ts
+lib/node_modules/typescript/lib.es2022.intl.d.ts
+lib/node_modules/typescript/lib.es2022.object.d.ts
+lib/node_modules/typescript/lib.es2022.regexp.d.ts
+lib/node_modules/typescript/lib.es2022.string.d.ts
+lib/node_modules/typescript/lib.es2023.array.d.ts
+lib/node_modules/typescript/lib.es2023.collection.d.ts
+lib/node_modules/typescript/lib.es2023.d.ts
+lib/node_modules/typescript/lib.es2023.full.d.ts
+lib/node_modules/typescript/lib.es2023.intl.d.ts
+lib/node_modules/typescript/lib.es2024.arraybuffer.d.ts
+lib/node_modules/typescript/lib.es2024.collection.d.ts
+lib/node_modules/typescript/lib.es2024.d.ts
+lib/node_modules/typescript/lib.es2024.full.d.ts
+lib/node_modules/typescript/lib.es2024.object.d.ts
+lib/node_modules/typescript/lib.es2024.promise.d.ts
+lib/node_modules/typescript/lib.es2024.regexp.d.ts
+lib/node_modules/typescript/lib.es2024.sharedmemory.d.ts
+lib/node_modules/typescript/lib.es2024.string.d.ts
+lib/node_modules/typescript/lib.es5.d.ts
+lib/node_modules/typescript/lib.es6.d.ts
+lib/node_modules/typescript/lib.esnext.array.d.ts
+lib/node_modules/typescript/lib.esnext.collection.d.ts
+lib/node_modules/typescript/lib.esnext.d.ts
+lib/node_modules/typescript/lib.esnext.decorators.d.ts
+lib/node_modules/typescript/lib.esnext.disposable.d.ts
+lib/node_modules/typescript/lib.esnext.error.d.ts
+lib/node_modules/typescript/lib.esnext.float16.d.ts
+lib/node_modules/typescript/lib.esnext.full.d.ts
+lib/node_modules/typescript/lib.esnext.intl.d.ts
+lib/node_modules/typescript/lib.esnext.iterator.d.ts
+lib/node_modules/typescript/lib.esnext.promise.d.ts
+lib/node_modules/typescript/lib.esnext.sharedmemory.d.ts
+lib/node_modules/typescript/lib.scripthost.d.ts
+lib/node_modules/typescript/lib.webworker.asynciterable.d.ts
+lib/node_modules/typescript/lib.webworker.d.ts
+lib/node_modules/typescript/lib.webworker.importscripts.d.ts
+lib/node_modules/typescript/lib.webworker.iterable.d.ts
+lib/node_modules/typescript/pl/diagnosticMessages.generated.json
+lib/node_modules/typescript/pt-br/diagnosticMessages.generated.json
+lib/node_modules/typescript/ru/diagnosticMessages.generated.json
+lib/node_modules/typescript/tr/diagnosticMessages.generated.json
+lib/node_modules/typescript/tsc.js
+lib/node_modules/typescript/tsserver.js
+lib/node_modules/typescript/tsserverlibrary.d.ts
+lib/node_modules/typescript/tsserverlibrary.js
+lib/node_modules/typescript/typesMap.json
+lib/node_modules/typescript/typescript.d.ts
+lib/node_modules/typescript/typescript.js
+lib/node_modules/typescript/typingsInstaller.js
+lib/node_modules/typescript/watchGuard.js
+lib/node_modules/typescript/zh-cn/diagnosticMessages.generated.json
+lib/node_modules/typescript/zh-tw/diagnosticMessages.generated.json
+@dir lib/node_modules/typescript/cs
+@dir lib/node_modules/typescript/de
+@dir lib/node_modules/typescript/es
+@dir lib/node_modules/typescript/fr
+@dir lib/node_modules/typescript/it
+@dir lib/node_modules/typescript/ja
+@dir lib/node_modules/typescript/ko
+@dir lib/node_modules/typescript/pl
+@dir lib/node_modules/typescript/pt-br
+@dir lib/node_modules/typescript/ru
+@dir lib/node_modules/typescript/tr
+@dir lib/node_modules/typescript/zh-cn
+@dir lib/node_modules/typescript/zh-tw
+@dir lib/node_modules/typescript


### PR DESCRIPTION
Adds the TypeScript 5.9.3 compiler package.

This provides the TypeScript 5.x `tsc` required by GNOME Weather 50.0. The current TypeScript Go 7 compiler rejects Weather's upstream TypeScript 5 configuration.

Adapted from the local FreeBSD port history: Apache-2.0 mapped to MidnightBSD metadata; all installation work is confined to the fake staging tree.

Validation: makesum, patch, fake, package, test target, check-license, staged TypeScript compilation of GNOME Weather's tsconfig, portlint -C (only retained artifact/work-dir fatals), and git diff --check.

## Summary by Sourcery

Add the TypeScript 5.9.3 compiler package to support projects requiring the TypeScript 5.x toolchain.

New Features:
- Add a MidnightBSD port for the TypeScript 5.9.3 compiler, including the `tsc` and `tsserver` commands and packaged compiler libraries.

Build:
- Register the TypeScript port in the language ports collection.