### PR TITLE
deskutils/gnome-characters: update to 48.0

### DIFF
--- a/deskutils/gnome-characters/Makefile
+++ b/deskutils/gnome-characters/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-characters
-PORTVERSION=	47.0
-PORTREVISION=	1
+PORTVERSION=	48.0
+PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -19,10 +19,9 @@ LIB_DEPENDS=	libadwaita-1.so:x11-toolkits/libadwaita \
 		libdbus-1.so:devel/dbus \
 		libgjs.so:lang/gjs \
 
-USES=		gettext gnome iconv:wchar_t localbase:ldflags meson pkgconfig \
+USES=		gettext gnome iconv:wchar_t meson pkgconfig \
 		python:build tar:xz
 USE_GNOME=	gtk40 introspection pango gnomedesktop3
-USE_LDCONFIG=	yes
 INSTALLS_ICONS=	yes
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 

--- a/deskutils/gnome-characters/distinfo
+++ b/deskutils/gnome-characters/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741109024
-SHA256 (gnome/gnome-characters-47.0.tar.xz) = 6bcf05a22f30f131d8a8035b0f63d86a9567007a5f6df5ce8556ba06777b7574
-SIZE (gnome/gnome-characters-47.0.tar.xz) = 601256
+TIMESTAMP = 1789144995
+SHA256 (gnome/gnome-characters-48.0.tar.xz) = a2c32ca54d911db2404420350d3442e691a2dce8b0f5d00899f66cff8c3c8d71
+SIZE (gnome/gnome-characters-48.0.tar.xz) = 602764


### PR DESCRIPTION
Updates GNOME Characters to 48.0.

Removes the localbase linker injection because its global `-L/usr/local/lib` made gobject-introspection resolve the private `libgc.so` against the unrelated Boehm GC library. The declared pkg-config dependencies provide the needed paths.

Validation: `bmake makesum`, `bmake patch`, `bmake`, `bmake fake`, `bmake package`, `bmake test` (inherited `NO_TEST=yes`), `bmake check-license`, `portlint -C`, and `git diff --check`.

## Summary by Sourcery

Update GNOME Characters to 48.0 and remove the unnecessary global linker path configuration.

Bug Fixes:
- Prevent gobject-introspection from resolving GNOME Characters' private libgc.so against an unrelated Boehm GC library by removing the global localbase linker path injection.

Enhancements:
- Update GNOME Characters to version 48.0.
- Reset the port revision for the new upstream release.