### PR TITLE
deskutils/gnome-font-viewer: update to 48.0

### DIFF
--- a/deskutils/gnome-font-viewer/Makefile
+++ b/deskutils/gnome-font-viewer/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-font-viewer
-PORTVERSION=	47.0
-PORTREVISION=	1
+PORTVERSION=	48.0
+PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -9,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	GNOME font viewer utility
 WWW=		https://github.com/GNOME/gnome-font-viewer
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 LIB_DEPENDS=	libfontconfig.so:x11-fonts/fontconfig \
@@ -23,7 +23,6 @@ USES=		compiler:c11 desktop-file-utils gettext gnome localbase meson \
 		pkgconfig tar:xz
 USES+=	cpe
 CPE_VENDOR=	gnome
-USE_LDCONFIG=	yes
 USE_GNOME=	gtk40 libadwaita
 INSTALLS_ICONS=	yes
 

--- a/deskutils/gnome-font-viewer/distinfo
+++ b/deskutils/gnome-font-viewer/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741152977
-SHA256 (gnome/gnome-font-viewer-47.0.tar.xz) = b8e5a042e0b241b0c7cae43f74da0d5f88e6423017a91feb86e7617edb4080ed
-SIZE (gnome/gnome-font-viewer-47.0.tar.xz) = 201744
+TIMESTAMP = 1789148289
+SHA256 (gnome/gnome-font-viewer-48.0.tar.xz) = 732624231b624ff5c7ac03a8ce71be12393daa53551d11550b20d7b0a3a872a7
+SIZE (gnome/gnome-font-viewer-48.0.tar.xz) = 202704


### PR DESCRIPTION
Updates GNOME Font Viewer to 48.0.\n\nThe project metadata and source headers confirm GPLv2-or-later, so this also corrects LICENSE to gpl2+. Removes obsolete USE_LDCONFIG because the port installs no shared library.\n\nValidation:\n- bmake makesum patch build fake package\n- bmake test (1/1 passed)\n- bmake check-license\n- portlint -C (0 fatals)\n- git diff --check

## Summary by Sourcery

Update the GNOME Font Viewer port to 48.0 and align its metadata with the current release.

Enhancements:
- Update GNOME Font Viewer to version 48.0.
- Correct the port’s GPL license classification and remove obsolete shared-library cache configuration.