### PR TITLE
deskutils/baobab: update to 48.0

### DIFF
--- a/deskutils/baobab/Makefile
+++ b/deskutils/baobab/Makefile
@@ -20,6 +20,7 @@ LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
 USES=		desktop-file-utils gettext gnome meson pkgconfig \
 		python:build tar:xz vala:build
 USE_GNOME=	cairo glib20 gtk40 libadwaita
+USE_GNOME+=	gtk-update-icon-cache
 INSTALLS_ICONS=	yes
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}

--- a/deskutils/baobab/Makefile
+++ b/deskutils/baobab/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	baobab
-PORTVERSION=	47.0
+PORTVERSION=	48.0
+PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -19,6 +20,7 @@ LIB_DEPENDS=	libgraphene-1.0.so:graphics/graphene
 USES=		desktop-file-utils gettext gnome meson pkgconfig \
 		python:build tar:xz vala:build
 USE_GNOME=	cairo glib20 gtk40 libadwaita
+INSTALLS_ICONS=	yes
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}
 

--- a/deskutils/baobab/distinfo
+++ b/deskutils/baobab/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1745054044
-SHA256 (gnome/baobab-47.0.tar.xz) = b88f74f9c052d3c2388f7062d228cf5e927545acf7408c56841df80ccd1f9c37
-SIZE (gnome/baobab-47.0.tar.xz) = 606432
+TIMESTAMP = 1789148557
+SHA256 (gnome/baobab-48.0.tar.xz) = 54592504d49d807f23591be7e7eef10c6c9dfcb7ac527b81c3acd58787b26fda
+SIZE (gnome/baobab-48.0.tar.xz) = 606832

--- a/deskutils/baobab/pkg-plist
+++ b/deskutils/baobab/pkg-plist
@@ -446,4 +446,4 @@ share/locale/xh/LC_MESSAGES/baobab.mo
 share/locale/zh_CN/LC_MESSAGES/baobab.mo
 share/locale/zh_HK/LC_MESSAGES/baobab.mo
 share/locale/zh_TW/LC_MESSAGES/baobab.mo
-share/metainfo/org.gnome.baobab.appdata.xml
+share/metainfo/org.gnome.baobab.metainfo.xml


### PR DESCRIPTION
Updates Baobab to 48.0.\n\nRefreshes the AppStream plist path and enables icon-cache handling for staged icons.\n\nValidation:\n- bmake makesum patch build fake package\n- bmake test (1/1 passed)\n- bmake check-license\n- portlint -C (0 fatals)\n- git diff --check

## Summary by Sourcery

Update Baobab to 48.0 with refreshed packaging metadata and icon-cache handling.

Enhancements:
- Update Baobab to version 48.0 and refresh its packaged application metadata path.
- Enable icon-cache integration for staged Baobab icons.