### PR TITLE
deskutils/gnome-tweaks: update to 49.0

### DIFF
--- a/deskutils/gnome-tweaks/Makefile
+++ b/deskutils/gnome-tweaks/Makefile
@@ -23,6 +23,7 @@ USES=		desktop-file-utils gettext gnome localbase meson pkgconfig \
 		python shebangfix tar:xz
 USE_GNOME=	glib20 gnomedesktop4 gtk40 introspection libadwaita pygobject3
 GLIB_SCHEMAS=	org.gnome.tweaks.gschema.xml
+USE_GNOME+=	gtk-update-icon-cache
 INSTALLS_ICONS=	yes
 SHEBANG_FILES=	gnome-tweaks meson-postinstall.py
 BINARY_ALIAS=	python3=${PYTHON_VERSION}

--- a/deskutils/gnome-tweaks/Makefile
+++ b/deskutils/gnome-tweaks/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-tweaks
-PORTVERSION=	46.1
-PORTREVISION=	1
+PORTVERSION=	49.0
+PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -23,6 +23,7 @@ USES=		desktop-file-utils gettext gnome localbase meson pkgconfig \
 		python shebangfix tar:xz
 USE_GNOME=	glib20 gnomedesktop4 gtk40 introspection libadwaita pygobject3
 GLIB_SCHEMAS=	org.gnome.tweaks.gschema.xml
+INSTALLS_ICONS=	yes
 SHEBANG_FILES=	gnome-tweaks meson-postinstall.py
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 

--- a/deskutils/gnome-tweaks/distinfo
+++ b/deskutils/gnome-tweaks/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1745348042
-SHA256 (gnome/gnome-tweaks-46.1.tar.xz) = 2f192a7085fbd6843ecf825716d9da21ec9272029149ea35f3e159e0ac309b80
-SIZE (gnome/gnome-tweaks-46.1.tar.xz) = 691844
+TIMESTAMP = 1789148809
+SHA256 (gnome/gnome-tweaks-49.0.tar.xz) = b3909bdcb4905b68427d6ab581e01f436dff8e5c0a389b1e0b14500f18806ebb
+SIZE (gnome/gnome-tweaks-49.0.tar.xz) = 695716


### PR DESCRIPTION
Updates GNOME Tweaks to 49.0 and enables the staged icon-cache hooks for its installed icons.\n\nValidation:\n- bmake makesum patch build fake package\n- bmake test (3/3 passed)\n- bmake check-license\n- portlint -C (0 fatals)\n- git diff --check

## Summary by Sourcery

Enhancements:
- Update GNOME Tweaks to version 49.0 and enable staged icon-cache handling for its installed icons.