### PR TITLE
editors/gnome-text-editor: update to 50.0

### DIFF
--- a/editors/gnome-text-editor/Makefile
+++ b/editors/gnome-text-editor/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnome-text-editor
-PORTVERSION=	49.0
+PORTVERSION=	50.0
 PORTREVISION=	0
 CATEGORIES=	editors gnome
 MASTER_SITES=	GNOME
@@ -26,6 +26,6 @@ USE_GNOME=	cairo glib20 gtk40 gtk-update-icon-cache gtksourceview5 libadwaita
 INSTALLS_ICONS=	yes
 GLIB_SCHEMAS=	org.gnome.TextEditor.gschema.xml
 
-PORTSCOUT=	limit:^49\.
+PORTSCOUT=	limit:^50\.
 
 .include <bsd.port.mk>

--- a/editors/gnome-text-editor/distinfo
+++ b/editors/gnome-text-editor/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1789139502
-SHA256 (gnome/gnome-text-editor-49.0.tar.xz) = 8e43b0cfa8152cd3c7630de565de2d6930e887cf2d8b84480fbf853a2bc2c8a6
-SIZE (gnome/gnome-text-editor-49.0.tar.xz) = 677176
+TIMESTAMP = 1789149184
+SHA256 (gnome/gnome-text-editor-50.0.tar.xz) = 9dc299da4daa085423b5d48db59f0021ad55e74143a5cb8ab2e5ffe17967f45b
+SIZE (gnome/gnome-text-editor-50.0.tar.xz) = 697392


### PR DESCRIPTION
Updates GNOME Text Editor to 50.0.\n\nValidation:\n- bmake makesum patch build fake package\n- bmake test (1/1 passed)\n- bmake check-license\n- portlint -C (0 fatals)\n- git diff --check

## Summary by Sourcery

Enhancements:
- Update the GNOME Text Editor port to version 50.0 and track the corresponding release series.