### PR TITLE
devel/py-dasbus: add port

### DIFF
--- a/devel/Makefile
+++ b/devel/Makefile
@@ -1437,6 +1437,7 @@
     SUBDIR += py-daemon
     SUBDIR += py-dataclasses-json
     SUBDIR += py-datadog
+    SUBDIR += py-dasbus
     SUBDIR += py-dbus
     SUBDIR += py-ddt
     SUBDIR += py-decorator

--- a/devel/py-dasbus/Makefile
+++ b/devel/py-dasbus/Makefile
@@ -11,8 +11,7 @@ WWW=		https://github.com/dasbus-project/dasbus
 LICENSE=	lgpl2.1+
 LICENSE_FILE=	${WRKSRC}/LICENSE
 
-BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}setuptools>0:devel/py-setuptools@${PY_FLAVOR} \
-		${PYTHON_PKGNAMEPREFIX}wheel>0:devel/py-wheel@${PY_FLAVOR}
+BUILD_DEPENDS=\t${PYTHON_PKGNAMEPREFIX}hatchling>=0:devel/py-hatchling@${PY_FLAVOR}
 
 USES=		gnome python
 USE_GNOME=	glib20 pygobject3

--- a/devel/py-dasbus/Makefile
+++ b/devel/py-dasbus/Makefile
@@ -1,0 +1,21 @@
+PORTNAME=	dasbus
+DISTVERSION=	1.7
+CATEGORIES=	devel python
+MASTER_SITES=	PYPI
+PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	D-Bus library written in Python and based on GLib
+WWW=		https://github.com/dasbus-project/dasbus
+
+LICENSE=	lgpl2.1+
+LICENSE_FILE=	${WRKSRC}/LICENSE
+
+BUILD_DEPENDS=	${PYTHON_PKGNAMEPREFIX}setuptools>0:devel/py-setuptools@${PY_FLAVOR} \
+		${PYTHON_PKGNAMEPREFIX}wheel>0:devel/py-wheel@${PY_FLAVOR}
+
+USES=		gnome python
+USE_GNOME=	glib20 pygobject3
+USE_PYTHON=	autoplist concurrent pep517
+
+.include <bsd.port.mk>

--- a/devel/py-dasbus/distinfo
+++ b/devel/py-dasbus/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1789150581
+SHA256 (dasbus-1.7.tar.gz) = a8850d841adfe8ee5f7bb9f82cf449ab9b4950dc0633897071718e0d0036b6f6
+SIZE (dasbus-1.7.tar.gz) = 78603

--- a/devel/py-dasbus/pkg-descr
+++ b/devel/py-dasbus/pkg-descr
@@ -1,0 +1,2 @@
+Dasbus is a D-Bus library written in Python 3, based on GLib and inspired by
+pydbus. It is designed to be easy to use and extend.


### PR DESCRIPTION
Adds Dasbus 1.7, the Python D-Bus library required by Orca 50.2. Imported from the local FreeBSD port and adapted for MidnightBSD (maintainer and LGPL-2.1-or-later metadata).

Validation: bmake makesum, patch, build, fake, package, test target, check-license, and git diff --check. The upstream unittest suite passes its earlier D-Bus cases but stalls in the system-bus fixture; the port exposes no test command, so no test policy was changed.

## Summary by Sourcery

Add the Dasbus 1.7 Python D-Bus library as a new MidnightBSD port.

New Features:
- Add the Dasbus 1.7 Python D-Bus library port for use by dependent applications such as Orca.

Build:
- Register the new py-dasbus package in the devel ports collection with Python, GLib, and PyGObject dependencies.

Chores:
- Include package metadata, licensing information, and distribution checksums for Dasbus.