### PR TITLE
lang/php84: stop running the upstream test suite

### DIFF
--- a/lang/php84/Makefile
+++ b/lang/php84/Makefile
@@ -20,6 +20,10 @@ CONFLICTS_INSTALL?=	php[0-9][0-9]${PKGNAMESUFFIX}
 .if !defined(PKGNAMESUFFIX)
 LIB_DEPENDS=	libpcre2-8.so:devel/pcre2
 
+# The upstream suite deadlocks in ext/standard/tests/streams (proc_open/pty)
+# and wedges the build cluster.  Matches lang/php82 and lang/php83.
+NO_TEST=	yes
+
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS+=	\
 		--disable-all \
@@ -164,9 +168,6 @@ post-build:
 	@${ECHO_CMD} -n "PHP_EXT_DIR=" >> ${WRKDIR}/php.conf
 	@${SH} ${WRKSRC}/scripts/php-config --extension-dir | ${SED} -ne 's,^${PREFIX}/lib/php/,,p' >> ${WRKDIR}/php.conf
 	@${ECHO_CMD} "PHP_EXT_INC=hash json openssl pcre random spl" >> ${WRKDIR}/php.conf
-
-test: build
-	@(cd ${WRKSRC} && ${MAKE} test)
 
 post-install:
 	${INSTALL_DATA} ${WRKSRC}/php.ini-development ${WRKSRC}/php.ini-production \


### PR DESCRIPTION
On magus run 646, `lang/php84` entered the test phase on 2026-09-04 and was still sitting there seven days later, wedging worker 1 on m4164 and stalling the rest of the run.

## Cause

The port defined its own test target:

```makefile
test: build
	@(cd ${WRKSRC} && ${MAKE} test)
```

This runs PHP's full upstream suite from the top of the source tree, which deadlocks in `ext/standard/tests/streams` (proc_open/pty).

Worse, because the rule defines `target(test)` itself, the guard in `Mk/bsd.mport.mk:4976` that emits the `NO_TEST`/`TESTING_UNSAFE` handling never fires — so the phase could not be disabled from the port at all. Magus decides whether to skip by reading `make -V NO_TEST`, which was empty here.

`lang/php82` and `lang/php83` have no such override and set `NO_TEST=yes`; both skipped in ~2s on the same machine in the same run.

## Fix

Drop the override and set `NO_TEST`. php82/php83 set it at the top of the file; this scopes it to the main port instead, so the php84 extension subports keep their `TEST_TARGET=test` — all 48 of them passed in run 646.

No packaged content changes, so no `PORTREVISION` bump.

## Verification

- `lang/php84`: `bmake -V NO_TEST` → `yes`; `bmake -n test` no longer emits `(cd work/php-8.4.24 && bmake test)`.
- `databases/php84-pdo_sqlite`: `NO_TEST` empty, `TEST_TARGET=test` — unchanged.
- `portlint -C`: 22 fatal / 8 warnings both before and after (all pre-existing; portlint cannot parse the multi-subport Makefile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JRCQA17KgZSRk2vV96wbT

## Summary by Sourcery

Bug Fixes:
- Prevent the PHP 8.4 port’s upstream test suite from deadlocking the build cluster by disabling its test phase.