### PR TITLE
lang/php85: stop running the upstream test suite

### DIFF
--- a/lang/php85/Makefile
+++ b/lang/php85/Makefile
@@ -20,6 +20,10 @@ CONFLICTS_INSTALL?=	php[0-9][0-9]${PKGNAMESUFFIX}
 .if !defined(PKGNAMESUFFIX)
 LIB_DEPENDS=	libpcre2-8.so:devel/pcre2
 
+# The upstream suite deadlocks in ext/standard/tests/streams (proc_open/pty)
+# and wedges the build cluster.  Matches lang/php82, lang/php83 and lang/php84.
+NO_TEST=	yes
+
 GNU_CONFIGURE=	yes
 CONFIGURE_ARGS+=	\
 		--disable-all \
@@ -164,9 +168,6 @@ post-build:
 	@${ECHO_CMD} -n "PHP_EXT_DIR=" >> ${WRKDIR}/php.conf
 	@${SH} ${WRKSRC}/scripts/php-config --extension-dir | ${SED} -ne 's,^${PREFIX}/lib/php/,,p' >> ${WRKDIR}/php.conf
 	@${ECHO_CMD} "PHP_EXT_INC=hash json opcache openssl pcre random spl" >> ${WRKDIR}/php.conf
-
-test: build
-	@(cd ${WRKSRC} && ${MAKE} test)
 
 post-install:
 	${INSTALL_DATA} ${WRKSRC}/php.ini-development ${WRKSRC}/php.ini-production \


### PR DESCRIPTION
Same defect as #1213, in `lang/php85`.

## Cause

The port defined its own test target:

```makefile
test: build
	@(cd ${WRKSRC} && ${MAKE} test)
```

This runs PHP's full upstream suite, which deadlocks in `ext/standard/tests/streams` (proc_open/pty) — the hang that took a magus worker out for seven days on run 646 via `lang/php84`.

It also cannot be turned off: defining `target(test)` suppresses the guard in `Mk/bsd.mport.mk:4976` that emits the `NO_TEST`/`TESTING_UNSAFE` handling, which is also what magus reads to decide whether to skip the phase.

## Fix

Drop the override and set `NO_TEST` for the main port, leaving the php85 extension subports' `TEST_TARGET=test` alone.

`www/mod_php85` picks up `NO_TEST` too, since it uses `PKGNAMEPREFIX` rather than `PKGNAMESUFFIX`. Its test phase was already a no-op (no `TEST_TARGET`, no `do-test`), so this only makes the skip explicit — and matches `mod_php82`/`mod_php83`, which inherit `NO_TEST` from their masters. There is no `mod_php84`.

No packaged content changes, so no `PORTREVISION` bump.

## Verification

- `lang/php85`: `bmake -V NO_TEST` → `yes`; `bmake -n test` no longer emits `(cd work/php-8.5.9 && bmake test)`.
- `www/php85-tidy`: `NO_TEST` empty, `TEST_TARGET=test` — unchanged.
- `portlint -C`: 16 fatal / 6 warnings both before and after (all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JRCQA17KgZSRk2vV96wbT

## Summary by Sourcery

Disable the deadlocking upstream test suite for PHP 8.5 by removing its custom test target and marking the main port as not testable.

Bug Fixes:
- Prevent the PHP 8.5 upstream test suite from deadlocking build workers.

Enhancements:
- Use the ports framework's explicit test-skipping behavior for the PHP 8.5 main port and its mod_php85 package while leaving extension subport tests unchanged.