### PR TITLE
magus: time out make targets that hang

### DIFF
--- a/Tools/lib/Magus/Config.pm
+++ b/Tools/lib/Magus/Config.pm
@@ -55,6 +55,8 @@ sub load_config {
         DBUser         => 'magus',
         Machine        => hostname(),
         DoneWaitPeriod => 200,
+        MakeTimeout    => 86400,
+        MakeTimeouts   => { test => 7200 },
         ChrootTarBall  => '/usr/magus/os.tar.xz',
         DistfilesRoot  => '/mnt/magus/distfiles',
         PkgfilesRoot   => '/mnt/magus/packages',

--- a/Tools/lib/Magus/PortTest.pm
+++ b/Tools/lib/Magus/PortTest.pm
@@ -161,8 +161,12 @@ sub run {
         
     if ($presults->{errors}) {
       # these will be the first errors we see.  If we parsed them, we just
-      # report the results of parsing.  
-      $results{errors} = $presults->{errors};
+      # report the results of parsing -- except for a timeout, which is why
+      # the log is truncated in the first place, so it stays at the front.
+      my @timeouts = grep { ($_->{name} || '') eq 'MakeTimeout' }
+                     @{$results{errors} || []};
+
+      $results{errors} = [@timeouts, @{$presults->{errors}}];
     }
     
     if ($presults->{warnings}) {
@@ -318,10 +322,20 @@ sub _run_make {
   die "Couldn't fork for make $target: $!\n" unless defined $pid;
 
   unless ($pid) {
-    # Lead our own process group so the watchdog can signal the whole build.
-    POSIX::setsid();
     open(STDOUT, '>', $logfile)  || exit 127;
     open(STDERR, '>&', \*STDOUT) || exit 127;
+
+    # Lead our own process group so the watchdog can signal the whole build.
+    # setsid() only fails when we already lead one, so check the invariant
+    # rather than the call: without it _reap_group cannot do its job, and
+    # silently running unsupervised is worse than not running at all.
+    POSIX::setsid();
+
+    unless (getpgrp() == $$) {
+      print STDERR "*** magus: no process group for make $target, refusing to run ***\n";
+      exit 127;
+    }
+
     exec(@cmd);
     exit 127;
   }
@@ -366,6 +380,12 @@ sub _run_make {
 Terminate the process group led by $pid, escalating to SIGKILL if it does not
 go away, and wait for the leader so we do not leave a zombie behind.
 
+Reaping the leader is not enough: make can exit on SIGTERM while a test runner
+or compiler it spawned ignores the signal and keeps running in the group, which
+is the very thing the watchdog exists to stop.  We are done only once the group
+itself is empty, so the caller can be delayed up to 2 * $KillGrace seconds past
+the configured limit -- bounded, unlike the hang it replaces.
+
 =cut
 
 sub _reap_group {
@@ -375,6 +395,7 @@ sub _reap_group {
     kill($signal, -$pid) || kill($signal, $pid);
 
     foreach (1 .. $KillGrace) {
+      # kill(0) counts the group's surviving members without signalling them.
       my $leader = waitpid($pid, WNOHANG);
       return if $leader != 0 && !kill(0, -$pid);
       sleep 1;

--- a/Tools/lib/Magus/PortTest.pm
+++ b/Tools/lib/Magus/PortTest.pm
@@ -375,7 +375,8 @@ sub _reap_group {
     kill($signal, -$pid) || kill($signal, $pid);
 
     foreach (1 .. $KillGrace) {
-      return if waitpid($pid, WNOHANG) > 0;
+      my $leader = waitpid($pid, WNOHANG);
+      return if $leader != 0 && !kill(0, -$pid);
       sleep 1;
     }
   }

--- a/Tools/lib/Magus/PortTest.pm
+++ b/Tools/lib/Magus/PortTest.pm
@@ -33,11 +33,15 @@ use strict;
 use warnings;
 
 use File::Path qw(mkpath);
+use POSIX qw(setsid :sys_wait_h);
 
 use Mport::Globals qw($MAKE);
 use Mport::Utils   qw(make_var);
 
 use Magus::OutcomeRules ();
+
+# Seconds to wait for a killed build to go away before escalating TERM to KILL.
+our $KillGrace = 10;
 
 =head1 NAME 
 
@@ -120,13 +124,21 @@ sub run {
 
   foreach my $target ($self->targets_for_phase($phase)) {
     if (!$self->_run_make($target)) {
-      my $error_code = $? >> 8;
-      push(@{$results{errors}}, {
-        phase => $target,
-        msg   => "make $target returned non-zero: $error_code",
-        name  => "MakeExitNonZero",
-      });
-      
+      if (my $limit = $self->{timed_out}) {
+        push(@{$results{errors}}, {
+          phase => $target,
+          msg   => "make $target timed out after $limit seconds and was killed",
+          name  => "MakeTimeout",
+        });
+      } else {
+        my $error_code = $? >> 8;
+        push(@{$results{errors}}, {
+          phase => $target,
+          msg   => "make $target returned non-zero: $error_code",
+          name  => "MakeExitNonZero",
+        });
+      }
+
       $results{summary} = 'fail';
     }
     
@@ -250,18 +262,125 @@ sub check_master_sites {
 }
 
 
+=head2 $test->_timeout_for($target)
+
+The wall clock limit, in seconds, for a single make target.  C<MakeTimeouts>
+gives per target overrides, C<MakeTimeout> the fallback.  Zero disables the
+watchdog.
+
+=cut
+
+sub _timeout_for {
+  my ($self, $target) = @_;
+
+  my $timeouts = $Magus::Config{MakeTimeouts};
+
+  if (ref $timeouts eq 'HASH' && defined $timeouts->{$target}) {
+    return $timeouts->{$target};
+  }
+
+  return $Magus::Config{MakeTimeout} || 0;
+}
+
+
+=head2 $test->_run_make($target)
+
+Runs a single make target, logging to F<$logdir/$target>.  The make runs in its
+own session so that a port which hangs -- a test suite deadlocked on a pipe, a
+configure script waiting on stdin -- can be killed off along with everything it
+spawned instead of wedging this worker forever.
+
+Returns true when make exited zero.  On a timeout C<$self->{timed_out}> is set
+to the limit that was exceeded.
+
+=cut
+
 sub _run_make {
   my ($self, $target) = @_;
 
-  my $flavor =  $self->{port}->flavor;
+  my $flavor  = $self->{port}->flavor;
+  my $logfile = "$self->{logdir}/$target";
+
+  delete $self->{timed_out};
 
   chdir($self->{port}->origin) || die "Couldn't chdir to " . $self->{port}->origin . ": $!\n";
 
-  if (length $flavor) {
-    return system("$MAKE LANG=C.UTF-8 LC_ALL=C.UTF-8 $target >$self->{logdir}/$target FLAVOR=$flavor 2>&1") == 0;
-  } else {
-    return system("$MAKE LANG=C.UTF-8 LC_ALL=C.UTF-8 $target >$self->{logdir}/$target 2>&1") == 0;
+  my @cmd = ($MAKE, 'LANG=C.UTF-8', 'LC_ALL=C.UTF-8', $target);
+  push(@cmd, "FLAVOR=$flavor") if length $flavor;
+
+  my $timeout = $self->_timeout_for($target);
+
+  # magus.pl installs a SIGCHLD handler that reaps indiscriminately; keep it
+  # away from our waitpid so we actually see make's exit status.
+  local $SIG{CHLD} = 'DEFAULT';
+
+  my $pid = fork;
+  die "Couldn't fork for make $target: $!\n" unless defined $pid;
+
+  unless ($pid) {
+    # Lead our own process group so the watchdog can signal the whole build.
+    POSIX::setsid();
+    open(STDOUT, '>', $logfile)  || exit 127;
+    open(STDERR, '>&', \*STDOUT) || exit 127;
+    exec(@cmd);
+    exit 127;
   }
+
+  my $status;
+  my $timed_out = 0;
+
+  eval {
+    local $SIG{ALRM} = sub { $timed_out = 1; die "make timeout\n" };
+    alarm($timeout) if $timeout;
+    waitpid($pid, 0);
+    $status = $?;
+    alarm(0);
+    1;
+  };
+
+  alarm(0);
+
+  if ($timed_out) {
+    $self->{timed_out} = $timeout;
+    $self->_reap_group($pid);
+
+    if (open(my $fh, '>>', $logfile)) {
+      print $fh "\n*** magus: make $target exceeded $timeout seconds, killed ***\n";
+      close($fh);
+    }
+
+    $? = -1;
+    return 0;
+  }
+
+  die $@ if $@;
+
+  $? = defined($status) ? $status : -1;
+
+  return defined($status) && $status == 0;
+}
+
+
+=head2 $test->_reap_group($pid)
+
+Terminate the process group led by $pid, escalating to SIGKILL if it does not
+go away, and wait for the leader so we do not leave a zombie behind.
+
+=cut
+
+sub _reap_group {
+  my ($self, $pid) = @_;
+
+  foreach my $signal (qw(TERM KILL)) {
+    kill($signal, -$pid) || kill($signal, $pid);
+
+    foreach (1 .. $KillGrace) {
+      return if waitpid($pid, WNOHANG) > 0;
+      sleep 1;
+    }
+  }
+
+  waitpid($pid, WNOHANG);
 }
 
 

--- a/Tools/magus/config.yaml.example
+++ b/Tools/magus/config.yaml.example
@@ -9,7 +9,9 @@ DoneWaitPeriod: 600
 # Wall clock limit, in seconds, for a single make target.  A port that hangs
 # (a deadlocked test suite, a configure script waiting on stdin) is killed off
 # along with everything it spawned instead of wedging the worker.  MakeTimeouts
-# overrides the limit per target; 0 disables the watchdog.
+# overrides the limit per target; 0 disables the watchdog.  Setting
+# MakeTimeouts here replaces the built-in hash outright rather than merging
+# with it, so list every target you care about, not just the one you change.
 MakeTimeout: 86400
 MakeTimeouts:
   test: 7200

--- a/Tools/magus/config.yaml.example
+++ b/Tools/magus/config.yaml.example
@@ -6,6 +6,13 @@ DBPass: changeme
 
 Machine: vm-current
 DoneWaitPeriod: 600
+# Wall clock limit, in seconds, for a single make target.  A port that hangs
+# (a deadlocked test suite, a configure script waiting on stdin) is killed off
+# along with everything it spawned instead of wedging the worker.  MakeTimeouts
+# overrides the limit per target; 0 disables the watchdog.
+MakeTimeout: 86400
+MakeTimeouts:
+  test: 7200
 ChrootTarBall: /usr/magus/0.2-CURRENT-20070901.tar
 # Set ZfsChrootEnabled to 1 to use per-worker ZFS datasets and snapshot
 # rollback instead of cpdup for cleanup.  ZfsChrootDataset must name an

--- a/Tools/t/magus-porttest-timeout.t
+++ b/Tools/t/magus-porttest-timeout.t
@@ -1,0 +1,163 @@
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use File::Temp qw(tempdir);
+use POSIX qw(:sys_wait_h);
+use Test::More;
+
+use Magus::PortTest;
+
+# _run_make shells out to $MAKE; point it at a script we control so the test
+# does not need a ports tree.
+my $dir = tempdir(CLEANUP => 1);
+mkdir("$dir/log") || die "Couldn't create log dir: $!";
+
+{
+  package Magus::PortTest::MockPort;
+  sub new    { bless {dir => $_[1]}, $_[0] }
+  sub flavor { '' }
+  sub origin { $_[0]->{dir} }
+}
+
+sub write_script {
+  my ($name, $body) = @_;
+  my $path = "$dir/$name";
+
+  open(my $fh, '>', $path) || die "Couldn't write $path: $!";
+  print $fh "#!/bin/sh\n$body";
+  close($fh) || die "Couldn't close $path: $!";
+  chmod(0755, $path) || die "Couldn't chmod $path: $!";
+
+  return $path;
+}
+
+sub tester {
+  bless {
+    port   => Magus::PortTest::MockPort->new($dir),
+    logdir => "$dir/log",
+  }, 'Magus::PortTest';
+}
+
+sub log_for { my $t = shift; local $/; open(my $fh, '<', "$dir/log/$t") || return ''; <$fh> }
+
+# Shorten the TERM->KILL grace so the timeout cases stay quick.
+local $Magus::PortTest::KillGrace = 2;
+
+# The worker inherits magus.pl's indiscriminate SIGCHLD reaper; _run_make has
+# to hold it off or it loses make's exit status.  Install it for every case.
+local $SIG{CHLD} = sub { 1 while waitpid(-1, WNOHANG) > 0 };
+
+subtest 'per-target limits' => sub {
+  local %Magus::Config = (MakeTimeout => 86400, MakeTimeouts => {test => 7200});
+  my $test = tester();
+
+  is($test->_timeout_for('test'), 7200, 'per-target override wins');
+  is($test->_timeout_for('build'), 86400, 'other targets fall back to MakeTimeout');
+
+  local %Magus::Config = (MakeTimeout => 0);
+  is($test->_timeout_for('build'), 0, 'watchdog can be disabled');
+};
+
+subtest 'exit status is preserved' => sub {
+  local %Magus::Config = (MakeTimeout => 60);
+  local $Magus::PortTest::MAKE = write_script('exiter.sh', <<'SH');
+for arg in "$@"; do target="$arg"; done
+echo "ran $target"
+case "$target" in
+  ok)  exit 0 ;;
+  bad) echo "it broke" >&2; exit 3 ;;
+esac
+SH
+
+  my $test = tester();
+  ok($test->_run_make('ok'), 'zero exit reports success');
+  is($? >> 8, 0, '$? reflects the exit status');
+  ok(!$test->{timed_out}, 'no timeout recorded');
+  like(log_for('ok'), qr/ran ok/, 'stdout captured to the target log');
+
+  $test = tester();
+  ok(!$test->_run_make('bad'), 'non-zero exit reports failure');
+  is($? >> 8, 3, '$? carries the exit code through the SIGCHLD reaper');
+  ok(!$test->{timed_out}, 'a plain failure is not a timeout');
+  like(log_for('bad'), qr/it broke/, 'stderr captured to the target log');
+};
+
+subtest 'a hung build is killed off with its children' => sub {
+  local %Magus::Config = (MakeTimeout => 3);
+  local $Magus::PortTest::MAKE = write_script('hang.sh', <<'SH');
+sh -c 'sleep 600' &
+echo "$!" > "$0.child"
+sleep 600
+SH
+
+  my $test = tester();
+  my $started = time;
+  ok(!$test->_run_make('hangs'), 'a hung target fails');
+  my $elapsed = time - $started;
+
+  is($test->{timed_out}, 3, 'the exceeded limit is recorded');
+  cmp_ok($elapsed, '<', 3 + 2 * $Magus::PortTest::KillGrace + 5,
+    'the watchdog returns within the grace window');
+  like(log_for('hangs'), qr/exceeded 3 seconds, killed/, 'the log says why it stopped');
+
+  open(my $fh, '<', "$dir/hang.sh.child") || die "Couldn't read child pid: $!";
+  chomp(my $child = <$fh>);
+  close($fh);
+
+  # The grandchild was never ours to wait on, so poll for it to disappear.
+  my $alive = 1;
+  foreach (1 .. 10) {
+    $alive = kill(0, $child) ? 1 : 0;
+    last unless $alive;
+    sleep 1;
+  }
+  ok(!$alive, "grandchild $child died with the process group");
+};
+
+subtest 'a child that ignores SIGTERM is still killed' => sub {
+  local %Magus::Config = (MakeTimeout => 3);
+
+  # make itself goes quietly on TERM, but the test runner it spawned does not.
+  # Reaping the leader is therefore not enough; the group has to be emptied.
+  local $Magus::PortTest::MAKE = write_script('stubborn.sh', <<'SH');
+sh -c 'trap "" TERM; sleep 600; :' &
+echo "$!" > "$0.child"
+trap 'exit 0' TERM
+sleep 600
+SH
+
+  my $test = tester();
+  ok(!$test->_run_make('stubborn'), 'a hung target fails');
+  is($test->{timed_out}, 3, 'the exceeded limit is recorded');
+
+  open(my $fh, '<', "$dir/stubborn.sh.child") || die "Couldn't read child pid: $!";
+  chomp(my $child = <$fh>);
+  close($fh);
+
+  my $alive = 1;
+  foreach (1 .. 10) {
+    $alive = kill(0, $child) ? 1 : 0;
+    last unless $alive;
+    sleep 1;
+  }
+  ok(!$alive, "SIGTERM-ignoring child $child was escalated to SIGKILL");
+};
+
+subtest 'a timeout survives parsed log diagnostics' => sub {
+  my %results = (summary => 'fail', errors => [
+    {phase => 'test', msg => 'make test timed out after 3 seconds and was killed',
+     name => 'MakeTimeout'},
+  ]);
+  my $presults = {errors => [{phase => 'test', msg => 'parsed', name => 'IncompleteInstall'}]};
+
+  # Mirrors the merge in run(): parsed errors win, but the timeout stays.
+  my @timeouts = grep { ($_->{name} || '') eq 'MakeTimeout' } @{$results{errors} || []};
+  $results{errors} = [@timeouts, @{$presults->{errors}}];
+
+  is(scalar @{$results{errors}}, 2, 'both errors are reported');
+  is($results{errors}[0]{name}, 'MakeTimeout', 'the timeout is reported first');
+};
+
+done_testing();


### PR DESCRIPTION
`Magus::PortTest::_run_make` used a bare blocking `system()`, so any port whose make target never returns takes a worker out of service indefinitely. On run 646, `lang/php84`'s deadlocked test suite held worker 1 on m4164 for seven days — nothing in the slave noticed or intervened. #1213 and #1214 fix that particular port; this fixes the class of failure.

## Change

Run make in its own session (`fork` + `setsid`) with a `SIGALRM` watchdog in the parent. On expiry the whole process group gets `TERM` then `KILL`, so children a hung build has spawned go away with it. The log is annotated and the phase is reported as `MakeTimeout` rather than a generic non-zero exit.

The limit is `MakeTimeout` **seconds**, default `86400` to leave room for llvm- and rust-sized builds, with per-target overrides in `MakeTimeouts` (`test: 7200`). `0` disables the watchdog.

Two details worth a reviewer's attention:

- **`local $SIG{CHLD} = 'DEFAULT'` is load-bearing.** `magus.pl:87` installs a `waitpid(-1, WNOHANG)` reaper that the worker inherits; without holding it off, it races our `waitpid` and we lose make's exit status.
- `exec(@cmd)` replaces `system($string)`, dropping the shell that used to sit between magus and make. `$MAKE` is a bare path (`Mport::Globals:15`), so no quoting behavior is lost.

## Verification

`perl -c` plus a harness driving the real `_run_make`/`_reap_group`/`_timeout_for` bodies:

| case | result |
|---|---|
| command hangs, spawns a background child | returns false at the limit, `timed_out` set, log annotated, no surviving processes |
| `exit 0` | returns true, `$? >> 8 == 0` |
| `exit 3` | returns false, `$? >> 8 == 3`, with the indiscriminate SIGCHLD reaper installed |
| `_timeout_for` | `test` → 7200, `build` → 86400 |

Not exercised against a live cluster — I have no slave here. Picking up the change needs a slave restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017JRCQA17KgZSRk2vV96wbT

## Summary by Sourcery

Add bounded execution and process cleanup for Magus make targets so hung builds fail clearly without taking workers out of service.

New Features:
- Add configurable watchdog timeouts for individual make targets, including per-target overrides and the ability to disable timeouts.
- Report timed-out builds distinctly and preserve timeout diagnostics alongside parsed port errors.

Bug Fixes:
- Prevent hung make targets and their descendant processes from indefinitely occupying Magus workers.
- Preserve make exit statuses despite the worker's inherited SIGCHLD reaper.

Enhancements:
- Run make targets in isolated process sessions and escalate termination from TERM to KILL when needed.
- Replace shell-based make invocation with direct argument execution while retaining build logging and environment settings.

Tests:
- Add coverage for timeout configuration, exit-status preservation, process-group cleanup, termination escalation, logging, and diagnostic merging.