### PR TITLE
x11-toolkits/gtk40: pass display environment to tests

### DIFF
--- a/x11-toolkits/gtk40/Makefile
+++ b/x11-toolkits/gtk40/Makefile
@@ -41,6 +41,7 @@ USE_PERL5=	build
 USE_GNOME=	atk cairo gdkpixbuf introspection:build pango \
 		librsvg2
 MESON_ARGS=	-Dbuild-testsuite=false
+TEST_ENV=	${MAKE_ENV}
 LDFLAGS+=	-lexecinfo
 
 BINARY_ALIAS=	python3=${PYTHON_CMD}


### PR DESCRIPTION
Pass `MAKE_ENV` through to Meson tests so the `display:test` extension's private Xvfb display reaches the suite.

This keeps the full test suite enabled. It fixes the prior no-display failures; Cairo renderer comparisons pass under Xvfb. GL/Vulkan renderer comparisons remain limited by Xvfb's unavailable EGL/Vulkan support (`Failed to create EGL display` / `VK_ERROR_INCOMPATIBLE_DRIVER`).

The GTK 4.22.5 package build, staging, package creation, and license check passed before this focused follow-up.

## Summary by Sourcery

Ensure GTK tests inherit the configured display environment so they run successfully under the package's private Xvfb display.

Bug Fixes:
- Pass the package build environment to GTK's Meson tests so the private Xvfb display is available and no-display test failures are avoided.

Tests:
- Keep the full GTK test suite enabled with the configured display environment.