### PR TITLE
net/gweather-locations: add port

### DIFF
--- a/net/Makefile
+++ b/net/Makefile
@@ -54,6 +54,7 @@
     SUBDIR += gnome-nettool
     SUBDIR += gnome-connections
     SUBDIR += gnome-online-accounts
+	SUBDIR += gweather-locations
     SUBDIR += google-cloud-sdk
     SUBDIR += gopher
     SUBDIR += grilo

--- a/net/gweather-locations/Makefile
+++ b/net/gweather-locations/Makefile
@@ -1,0 +1,21 @@
+PORTNAME=	gweather-locations
+DISTVERSION=	2026.2
+CATEGORIES=	net gnome
+MASTER_SITES=	GNOME
+DIST_SUBDIR=	gnome
+
+MAINTAINER=	ports@MidnightBSD.org
+COMMENT=	Locations database for libgweather
+WWW=		https://gitlab.gnome.org/GNOME/gweather-locations
+
+LICENSE=	gpl2+
+LICENSE_FILE=	${WRKSRC}/COPYING
+
+USES=		gettext gnome meson pkgconfig python:build shebangfix tar:xz
+USE_GNOME=	pygobject3
+
+SHEBANG_FILES=	build-aux/gen_locations_variant.py
+
+BINARY_ALIAS=	python3=${PYTHON_VERSION}
+
+.include <bsd.port.mk>

--- a/net/gweather-locations/distinfo
+++ b/net/gweather-locations/distinfo
@@ -1,0 +1,3 @@
+TIMESTAMP = 1789157511
+SHA256 (gnome/gweather-locations-2026.2.tar.xz) = e7570a3661e0a752a06387b2032585cf588fc56770b1f9f39f1a55d17b2835fe
+SIZE (gnome/gweather-locations-2026.2.tar.xz) = 2599712

--- a/net/gweather-locations/files/patch-data_meson.build
+++ b/net/gweather-locations/files/patch-data_meson.build
@@ -1,0 +1,13 @@
+--- data/meson.build.orig
++++ data/meson.build
+@@ -10,9 +10,10 @@
+   test('Valid Locations file',
+     xmllint,
+     args: [
+       xmllint_flags,
+       'Locations.xml',
+     ],
++    workdir: meson.current_source_dir(),
+     suite: ['lint'],
+   )
+ endif

--- a/net/gweather-locations/pkg-descr
+++ b/net/gweather-locations/pkg-descr
@@ -1,0 +1,1 @@
+Locations database used by libgweather and GNOME applications.

--- a/net/gweather-locations/pkg-plist
+++ b/net/gweather-locations/pkg-plist
@@ -1,0 +1,157 @@
+lib/gweather-locations/Locations.bin
+share/gweather-locations/Locations.xml
+share/gweather-locations/locations.dtd
+share/locale/ab/LC_MESSAGES/gweather-locations.mo
+share/locale/ang/LC_MESSAGES/gweather-locations.mo
+share/locale/ar/LC_MESSAGES/gweather-locations.mo
+share/locale/as/LC_MESSAGES/gweather-locations.mo
+share/locale/ast/LC_MESSAGES/gweather-locations.mo
+share/locale/az/LC_MESSAGES/gweather-locations.mo
+share/locale/be/LC_MESSAGES/gweather-locations.mo
+share/locale/be@latin/LC_MESSAGES/gweather-locations.mo
+share/locale/bg/LC_MESSAGES/gweather-locations.mo
+share/locale/bn/LC_MESSAGES/gweather-locations.mo
+share/locale/bn_IN/LC_MESSAGES/gweather-locations.mo
+share/locale/br/LC_MESSAGES/gweather-locations.mo
+share/locale/bs/LC_MESSAGES/gweather-locations.mo
+share/locale/ca/LC_MESSAGES/gweather-locations.mo
+share/locale/ca@valencia/LC_MESSAGES/gweather-locations.mo
+share/locale/crh/LC_MESSAGES/gweather-locations.mo
+share/locale/cs/LC_MESSAGES/gweather-locations.mo
+share/locale/cy/LC_MESSAGES/gweather-locations.mo
+share/locale/da/LC_MESSAGES/gweather-locations.mo
+share/locale/de/LC_MESSAGES/gweather-locations.mo
+share/locale/dz/LC_MESSAGES/gweather-locations.mo
+share/locale/el/LC_MESSAGES/gweather-locations.mo
+share/locale/en@shaw/LC_MESSAGES/gweather-locations.mo
+share/locale/en_CA/LC_MESSAGES/gweather-locations.mo
+share/locale/en_GB/LC_MESSAGES/gweather-locations.mo
+share/locale/eo/LC_MESSAGES/gweather-locations.mo
+share/locale/es/LC_MESSAGES/gweather-locations.mo
+share/locale/et/LC_MESSAGES/gweather-locations.mo
+share/locale/eu/LC_MESSAGES/gweather-locations.mo
+share/locale/fa/LC_MESSAGES/gweather-locations.mo
+share/locale/fi/LC_MESSAGES/gweather-locations.mo
+share/locale/fr/LC_MESSAGES/gweather-locations.mo
+share/locale/fur/LC_MESSAGES/gweather-locations.mo
+share/locale/ga/LC_MESSAGES/gweather-locations.mo
+share/locale/gd/LC_MESSAGES/gweather-locations.mo
+share/locale/gl/LC_MESSAGES/gweather-locations.mo
+share/locale/gu/LC_MESSAGES/gweather-locations.mo
+share/locale/he/LC_MESSAGES/gweather-locations.mo
+share/locale/hi/LC_MESSAGES/gweather-locations.mo
+share/locale/hr/LC_MESSAGES/gweather-locations.mo
+share/locale/hu/LC_MESSAGES/gweather-locations.mo
+share/locale/id/LC_MESSAGES/gweather-locations.mo
+share/locale/is/LC_MESSAGES/gweather-locations.mo
+share/locale/it/LC_MESSAGES/gweather-locations.mo
+share/locale/ja/LC_MESSAGES/gweather-locations.mo
+share/locale/ka/LC_MESSAGES/gweather-locations.mo
+share/locale/kab/LC_MESSAGES/gweather-locations.mo
+share/locale/kk/LC_MESSAGES/gweather-locations.mo
+share/locale/kn/LC_MESSAGES/gweather-locations.mo
+share/locale/ko/LC_MESSAGES/gweather-locations.mo
+share/locale/ku/LC_MESSAGES/gweather-locations.mo
+share/locale/kw/LC_MESSAGES/gweather-locations.mo
+share/locale/ky/LC_MESSAGES/gweather-locations.mo
+share/locale/lt/LC_MESSAGES/gweather-locations.mo
+share/locale/lv/LC_MESSAGES/gweather-locations.mo
+share/locale/mai/LC_MESSAGES/gweather-locations.mo
+share/locale/mg/LC_MESSAGES/gweather-locations.mo
+share/locale/mk/LC_MESSAGES/gweather-locations.mo
+share/locale/ml/LC_MESSAGES/gweather-locations.mo
+share/locale/mn/LC_MESSAGES/gweather-locations.mo
+share/locale/mr/LC_MESSAGES/gweather-locations.mo
+share/locale/ms/LC_MESSAGES/gweather-locations.mo
+share/locale/nb/LC_MESSAGES/gweather-locations.mo
+share/locale/nds/LC_MESSAGES/gweather-locations.mo
+share/locale/ne/LC_MESSAGES/gweather-locations.mo
+share/locale/nl/LC_MESSAGES/gweather-locations.mo
+share/locale/nn/LC_MESSAGES/gweather-locations.mo
+share/locale/oc/LC_MESSAGES/gweather-locations.mo
+share/locale/or/LC_MESSAGES/gweather-locations.mo
+share/locale/pa/LC_MESSAGES/gweather-locations.mo
+share/locale/pl/LC_MESSAGES/gweather-locations.mo
+share/locale/pt/LC_MESSAGES/gweather-locations.mo
+share/locale/pt_BR/LC_MESSAGES/gweather-locations.mo
+share/locale/ro/LC_MESSAGES/gweather-locations.mo
+share/locale/ru/LC_MESSAGES/gweather-locations.mo
+share/locale/rw/LC_MESSAGES/gweather-locations.mo
+share/locale/si/LC_MESSAGES/gweather-locations.mo
+share/locale/sk/LC_MESSAGES/gweather-locations.mo
+share/locale/sl/LC_MESSAGES/gweather-locations.mo
+share/locale/sq/LC_MESSAGES/gweather-locations.mo
+share/locale/sr/LC_MESSAGES/gweather-locations.mo
+share/locale/sr@latin/LC_MESSAGES/gweather-locations.mo
+share/locale/sv/LC_MESSAGES/gweather-locations.mo
+share/locale/ta/LC_MESSAGES/gweather-locations.mo
+share/locale/te/LC_MESSAGES/gweather-locations.mo
+share/locale/th/LC_MESSAGES/gweather-locations.mo
+share/locale/tr/LC_MESSAGES/gweather-locations.mo
+share/locale/ug/LC_MESSAGES/gweather-locations.mo
+share/locale/uk/LC_MESSAGES/gweather-locations.mo
+share/locale/uz/LC_MESSAGES/gweather-locations.mo
+share/locale/vi/LC_MESSAGES/gweather-locations.mo
+share/locale/zh_CN/LC_MESSAGES/gweather-locations.mo
+share/locale/zh_HK/LC_MESSAGES/gweather-locations.mo
+share/locale/zh_TW/LC_MESSAGES/gweather-locations.mo
+share/pkgconfig/gweather-locations.pc
+@dir lib/gweather-locations
+@dir share/gweather-locations
+@dir share/locale/ab/LC_MESSAGES
+@dir share/locale/ab
+@dir share/locale/ang/LC_MESSAGES
+@dir share/locale/ang
+@dir share/locale/as/LC_MESSAGES
+@dir share/locale/as
+@dir share/locale/ast/LC_MESSAGES
+@dir share/locale/ast
+@dir share/locale/be@latin/LC_MESSAGES
+@dir share/locale/be@latin
+@dir share/locale/bn_IN/LC_MESSAGES
+@dir share/locale/bn_IN
+@dir share/locale/ca@valencia/LC_MESSAGES
+@dir share/locale/ca@valencia
+@dir share/locale/crh/LC_MESSAGES
+@dir share/locale/crh
+@dir share/locale/dz/LC_MESSAGES
+@dir share/locale/dz
+@dir share/locale/en@shaw/LC_MESSAGES
+@dir share/locale/en@shaw
+@dir share/locale/fur/LC_MESSAGES
+@dir share/locale/fur
+@dir share/locale/gd/LC_MESSAGES
+@dir share/locale/gd
+@dir share/locale/kab/LC_MESSAGES
+@dir share/locale/kab
+@dir share/locale/kk/LC_MESSAGES
+@dir share/locale/kk
+@dir share/locale/ku/LC_MESSAGES
+@dir share/locale/ku
+@dir share/locale/kw/LC_MESSAGES
+@dir share/locale/kw
+@dir share/locale/ky/LC_MESSAGES
+@dir share/locale/ky
+@dir share/locale/mai/LC_MESSAGES
+@dir share/locale/mai
+@dir share/locale/mg/LC_MESSAGES
+@dir share/locale/mg
+@dir share/locale/mr/LC_MESSAGES
+@dir share/locale/mr
+@dir share/locale/nds/LC_MESSAGES
+@dir share/locale/nds
+@dir share/locale/oc/LC_MESSAGES
+@dir share/locale/oc
+@dir share/locale/rw/LC_MESSAGES
+@dir share/locale/rw
+@dir share/locale/si/LC_MESSAGES
+@dir share/locale/si
+@dir share/locale/sr@latin/LC_MESSAGES
+@dir share/locale/sr@latin
+@dir share/locale/te/LC_MESSAGES
+@dir share/locale/te
+@dir share/locale/ug/LC_MESSAGES
+@dir share/locale/ug
+@dir share/locale/zh_HK/LC_MESSAGES
+@dir share/locale/zh_HK
+@dir share/pkgconfig


### PR DESCRIPTION
Adds GNOME gweather-locations 2026.2, the locations database provider required by libgweather 4.5.

The included Meson patch fixes the upstream XML validation test workdir; the test passes after the correction.

Validated: bmake makesum, patch, build, fake, package, test (1/1), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Add the GNOME gweather-locations database provider for libgweather 4.5.

New Features:
- Add the GNOME gweather-locations 2026.2 locations database port required by libgweather.

Bug Fixes:
- Correct the Meson XML validation test working directory so the upstream test passes.

Build:
- Add the new gweather-locations port to the net category and define its package metadata, dependencies, generated files, and installation manifest.

Tests:
- Enable the upstream XML validation test for the new port.