### PR TITLE
deskutils/gnome-calendar: update to 50.0

### DIFF
--- a/deskutils/gnome-calendar/Makefile
+++ b/deskutils/gnome-calendar/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-calendar
-PORTVERSION=	47.0
-PORTREVISION=	1
+PORTVERSION=	50.0
+PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -9,10 +9,11 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Simple and beautiful calendar application for GNOME
 WWW=		https://wiki.gnome.org/Apps/Calendar/
 
-LICENSE=	gpl3
+LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
+BUILD_DEPENDS=	blueprint-compiler:devel/blueprint-compiler \
+		gsettings-desktop-schemas>=0:devel/gsettings-desktop-schemas
 LIB_DEPENDS=	libical.so:devel/libical \
 		libsoup-3.0.so:devel/libsoup3 \
 		libgweather-4.so:net/libgweather4 \
@@ -23,14 +24,11 @@ PORTSCOUT=	limitw:1,even
 
 USES=		compiler:c11 desktop-file-utils gettext gnome \
 		localbase:ldflags meson pkgconfig python:build tar:xz
-USE_LDCONFIG=	yes
 USE_GNOME=	cairo evolutiondataserver3 libadwaita
 BINARY_ALIAS=	python3=${PYTHON_VERSION}
 INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.calendar.enums.xml \
 		org.gnome.calendar.gschema.xml
-
-NO_TEST=	yes
 
 .include <bsd.port.mk>

--- a/deskutils/gnome-calendar/distinfo
+++ b/deskutils/gnome-calendar/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741108014
-SHA256 (gnome/gnome-calendar-47.0.tar.xz) = 3b03313f1c4d12dc821e07e209d1596d53eafa255d492d2ce5abf92ed1b51e76
-SIZE (gnome/gnome-calendar-47.0.tar.xz) = 513128
+TIMESTAMP = 1789100938
+SHA256 (gnome/gnome-calendar-50.0.tar.xz) = 4b75df071a52d98fb35e647d018030129d24d9007790d02457746c98617aeab0
+SIZE (gnome/gnome-calendar-50.0.tar.xz) = 590268

--- a/deskutils/gnome-calendar/pkg-plist
+++ b/deskutils/gnome-calendar/pkg-plist
@@ -10,6 +10,7 @@ share/locale/af/LC_MESSAGES/gnome-calendar.mo
 share/locale/an/LC_MESSAGES/gnome-calendar.mo
 share/locale/ar/LC_MESSAGES/gnome-calendar.mo
 share/locale/be/LC_MESSAGES/gnome-calendar.mo
+share/locale/be@latin/LC_MESSAGES/gnome-calendar.mo
 share/locale/bg/LC_MESSAGES/gnome-calendar.mo
 share/locale/bs/LC_MESSAGES/gnome-calendar.mo
 share/locale/ca/LC_MESSAGES/gnome-calendar.mo
@@ -42,6 +43,7 @@ share/locale/ja/LC_MESSAGES/gnome-calendar.mo
 share/locale/kab/LC_MESSAGES/gnome-calendar.mo
 share/locale/kk/LC_MESSAGES/gnome-calendar.mo
 share/locale/ko/LC_MESSAGES/gnome-calendar.mo
+share/locale/kw/LC_MESSAGES/gnome-calendar.mo
 share/locale/lt/LC_MESSAGES/gnome-calendar.mo
 share/locale/lv/LC_MESSAGES/gnome-calendar.mo
 share/locale/mjw/LC_MESSAGES/gnome-calendar.mo
@@ -66,7 +68,9 @@ share/locale/ta/LC_MESSAGES/gnome-calendar.mo
 share/locale/tg/LC_MESSAGES/gnome-calendar.mo
 share/locale/th/LC_MESSAGES/gnome-calendar.mo
 share/locale/tr/LC_MESSAGES/gnome-calendar.mo
+share/locale/ug/LC_MESSAGES/gnome-calendar.mo
 share/locale/uk/LC_MESSAGES/gnome-calendar.mo
+share/locale/uz/LC_MESSAGES/gnome-calendar.mo
 share/locale/vi/LC_MESSAGES/gnome-calendar.mo
 share/locale/zh_CN/LC_MESSAGES/gnome-calendar.mo
 share/locale/zh_HK/LC_MESSAGES/gnome-calendar.mo


### PR DESCRIPTION
Updates GNOME Calendar to 50.0, resets PORTREVISION, adds the required blueprint compiler, and corrects the verified GPL-3.0-or-later metadata.

Validation: makesum, patch, build, fake, package, check-license, and git diff --check passed. The test target was retained and executed, but all 10 tests abort because the release build injects G_DISABLE_ASSERT and upstream refuses to run tests compiled that way. No tests were suppressed.

## Summary by Sourcery

Update GNOME Calendar to 50.0 with refreshed dependencies, metadata, packaging, and test handling.

Enhancements:
- Update GNOME Calendar to version 50.0 and refresh its packaging metadata and installed file list.
- Enable the package's standard test target and add the build dependency required by the updated release.

Build:
- Reset PORTREVISION for the version update and add Blueprint Compiler as a build dependency.

Tests:
- Retain and run the upstream test target; the release configuration causes all tests to abort because assertions are disabled.

Chores:
- Correct the license metadata to GPL-3.0-or-later and remove obsolete port settings.