### PR TITLE
devel/libdex: update to 1.1.0

### DIFF
--- a/devel/libdex/Makefile
+++ b/devel/libdex/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	libdex
-PORTVERSION=	1.0.0
+PORTVERSION=	1.1.0
+PORTREVISION=	0
 CATEGORIES=	devel
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -8,7 +9,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Library supporting Deferred Execution for GTK applications
 WWW=		https://gitlab.gnome.org/GNOME/libdex
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 
 USES=		gnome meson pkgconfig tar:xz vala:build
 USE_GNOME=	glib20 introspection:build

--- a/devel/libdex/distinfo
+++ b/devel/libdex/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1788927577
-SHA256 (gnome/libdex-1.0.0.tar.xz) = 7b8f5c5db3796e14e12e10422e2356766ba830b92815fee70bbc867b5b207f5d
-SIZE (gnome/libdex-1.0.0.tar.xz) = 107124
+TIMESTAMP = 1789161137
+SHA256 (gnome/libdex-1.1.0.tar.xz) = a9e04c8abee01c9a7cf1148c5b7aa66ba377efe6af6d83801d4fd1aa55219aaa
+SIZE (gnome/libdex-1.1.0.tar.xz) = 130544

--- a/devel/libdex/files/patch-src_meson.build
+++ b/devel/libdex/files/patch-src_meson.build
@@ -1,12 +1,9 @@
-src/meson.build:69:21: ERROR: C shared or static library 'atomic' not found
-
---- src/meson.build.orig	2025-03-15 19:01:29 UTC
+--- src/meson.build.orig
 +++ src/meson.build
-@@ -65,7 +65,7 @@ libdex_deps = [
-   glib_dep,
- ]
+@@ -106,7 +106,7 @@ if have_gdbus_codegen
+ endif
  
--if host_machine.system() != 'darwin'
+-if host_machine.system() != 'darwin' and cc.get_argument_syntax() != 'msvc'
 +if host_machine.system() == 'linux'
    libatomic_dep = cc.find_library('atomic')
    if not cc.links('int main(){}', dependencies: [libatomic_dep])

--- a/devel/libdex/pkg-plist
+++ b/devel/libdex/pkg-plist
@@ -7,9 +7,12 @@ include/libdex-1/dex-channel.h
 include/libdex-1/dex-delayed.h
 include/libdex-1/dex-enums.h
 include/libdex-1/dex-error.h
+include/libdex-1/dex-features.h
 include/libdex-1/dex-fiber.h
 include/libdex-1/dex-future-set.h
 include/libdex-1/dex-future.h
+include/libdex-1/dex-future-list-model.h
+include/libdex-1/dex-gdbus.h
 include/libdex-1/dex-gio.h
 include/libdex-1/dex-init.h
 include/libdex-1/dex-main-scheduler.h
@@ -30,6 +33,8 @@ lib/libdex-1.so
 lib/libdex-1.so.1
 lib/libdex-1.so.1.0.0
 libdata/pkgconfig/libdex-1.pc
+lib/python3.12/site-packages/gi/overrides/Dex.py
+libexec/libdex-1/dex-gdbus-codegen-extension.py
 share/gir-1.0/Dex-1.gir
 share/vala/vapi/libdex-1.deps
 share/vala/vapi/libdex-1.vapi


### PR DESCRIPTION
Updates libdex from 1.0.0 to 1.1.0.

- Reset PORTREVISION to 0.
- Refresh the MidnightBSD libatomic patch for the upstream Meson layout and restrict the probe to Linux.
- Track new public headers, GDBus codegen helper, and Python GI override.
- Correct the license metadata to LGPL-2.1-or-later, evidenced by source SPDX headers.

Validated: makesum, patch, build, fake, package, test target (upstream defines no tests), check-license, portlint -C, and git diff --check. SONAME remains libdex-1.so.1.