### PR TITLE
x11/gnome-terminal: update to 3.58.1

### DIFF
--- a/x11/gnome-terminal/Makefile
+++ b/x11/gnome-terminal/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-terminal
-DISTVERSION=	3.56.3
-PORTREVISION=	2
+DISTVERSION=	3.58.1
+PORTREVISION=	0
 CATEGORIES=	x11 gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -26,6 +26,7 @@ USE_XORG=	x11
 CPE_VENDOR=	gnome
 
 MESON_ARGS=	-Ddocs=false
+INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.Terminal.gschema.xml
 

--- a/x11/gnome-terminal/distinfo
+++ b/x11/gnome-terminal/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1758615854
-SHA256 (gnome/gnome-terminal-3.56.3.tar.xz) = c3cc4906c7f34859ee873809a69d004f59204164d214b55331f44a1aa5d8b777
-SIZE (gnome/gnome-terminal-3.56.3.tar.xz) = 2019400
+TIMESTAMP = 1789163532
+SHA256 (gnome/gnome-terminal-3.58.1.tar.xz) = 1dfbaeb55a71cfc36a21aa1ee4a0d459c3fde8bb3d65b09fbca695c7fddfbeba
+SIZE (gnome/gnome-terminal-3.58.1.tar.xz) = 2020652


### PR DESCRIPTION
Updates GNOME Terminal to 3.58.1 and declares staged icon-cache support.

Validation: bmake makesum, patch, build, fake, package, test (1/1), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Enhancements:
- Update GNOME Terminal to version 3.58.1 and enable staged icon-cache support.