### PR TITLE
deskutils/gnome-maps: update to 50.5

### DIFF
--- a/deskutils/gnome-maps/Makefile
+++ b/deskutils/gnome-maps/Makefile
@@ -1,5 +1,5 @@
 PORTNAME=	gnome-maps
-DISTVERSION=	50.0
+DISTVERSION=	50.5
 PORTREVISION=	0
 CATEGORIES=	deskutils gnome
 MASTER_SITES=	GNOME
@@ -11,8 +11,6 @@ WWW=		https://apps.gnome.org/Maps/
 
 LICENSE=	gpl2+
 LICENSE_FILE=	${WRKSRC}/COPYING
-
-PORTSCOUT=	limit:^47\.
 
 BUILD_DEPENDS=	blueprint-compiler:devel/blueprint-compiler \
 		geoclue>=0:net/geoclue
@@ -37,8 +35,6 @@ USE_GNOME+=	gtk-update-icon-cache
 INSTALLS_ICONS=	yes
 
 GLIB_SCHEMAS=	org.gnome.Maps.gschema.xml
-
-NO_TEST=	yes
 
 post-install:
 	@${RM} "${PREFIX}/share/gnome-maps/icons/hicolor/16x16/apps/explore-symbolic copy.svg"

--- a/deskutils/gnome-maps/distinfo
+++ b/deskutils/gnome-maps/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1789146182
-SHA256 (gnome/gnome-maps-50.0.tar.xz) = 0a66e01abd2cf048a793b0f83ab2a4156006075f27e1b2896fd8288694d1366e
-SIZE (gnome/gnome-maps-50.0.tar.xz) = 1259832
+TIMESTAMP = 1789164438
+SHA256 (gnome/gnome-maps-50.5.tar.xz) = cd4b702128ebed4128bab10489173b9afd0c9f54f0a4ea942406a0d0648e6b26
+SIZE (gnome/gnome-maps-50.5.tar.xz) = 1259012


### PR DESCRIPTION
Updates GNOME Maps to 50.5, removes stale portscout limiting, and restores the upstream test suite.

Validation: bmake makesum, patch, build, fake, package, test (15/15), check-license, portlint -C, and git diff --check. The build used a staged Blueprint Compiler only because the host package database has a stale record whose executable is absent; a normally installed package provides it.

## Summary by Sourcery

Update GNOME Maps to 50.5, remove stale version limiting, and restore test coverage.

Enhancements:
- Update GNOME Maps to version 50.5 and remove the obsolete port version restriction.
- Re-enable the upstream test suite for GNOME Maps.

Tests:
- Restore package testing and validate the upstream test suite successfully.