### PR TITLE
devel/gsettings-desktop-schemas: update to 50.1

### DIFF
--- a/devel/gsettings-desktop-schemas/Makefile
+++ b/devel/gsettings-desktop-schemas/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gsettings-desktop-schemas
-DISTVERSION=	47.1
-PORTREVISION=	2
+DISTVERSION=	50.1
+PORTREVISION=	0
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -38,6 +38,7 @@ GLIB_SCHEMAS=	org.gnome.desktop.a11y.applications.gschema.xml \
 		org.gnome.desktop.notifications.gschema.xml \
 		org.gnome.desktop.peripherals.gschema.xml \
 		org.gnome.desktop.privacy.gschema.xml \
+		org.gnome.desktop.screen-time-limits.gschema.xml \
 		org.gnome.desktop.screensaver.gschema.xml \
 		org.gnome.desktop.search-providers.gschema.xml \
 		org.gnome.desktop.session.gschema.xml \

--- a/devel/gsettings-desktop-schemas/distinfo
+++ b/devel/gsettings-desktop-schemas/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1741188169
-SHA256 (gnome/gsettings-desktop-schemas-47.1.tar.xz) = a60204d9c9c0a1b264d6d0d134a38340ba5fc6076a34b84da945d8bfcc7a2815
-SIZE (gnome/gsettings-desktop-schemas-47.1.tar.xz) = 806272
+TIMESTAMP = 1789166209
+SHA256 (gnome/gsettings-desktop-schemas-50.1.tar.xz) = 0a2aa25082672585d16fcdab61c7b0e33f035fb87476505c794f29565afa485b
+SIZE (gnome/gsettings-desktop-schemas-50.1.tar.xz) = 896852

--- a/devel/gsettings-desktop-schemas/pkg-plist
+++ b/devel/gsettings-desktop-schemas/pkg-plist
@@ -61,6 +61,7 @@ share/locale/tg/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/tr/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/ug/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/uk/LC_MESSAGES/gsettings-desktop-schemas.mo
+share/locale/uz/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/vi/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/zh_CN/LC_MESSAGES/gsettings-desktop-schemas.mo
 share/locale/zh_HK/LC_MESSAGES/gsettings-desktop-schemas.mo


### PR DESCRIPTION
Updates GSettings Desktop Schemas to 50.1. Adds the upstream screen-time-limits schema and Uzbek translation.

Validation: bmake makesum, patch, package, test (no tests defined), check-license, portlint -C, and git diff --check.

## Summary by Sourcery

Update the GSettings Desktop Schemas port to version 50.1 and package its additional schema and translation data.

New Features:
- Add the upstream GNOME screen-time-limits GSettings schema to the package.
- Include the new Uzbek translation provided by the updated schemas release.

Enhancements:
- Update GSettings Desktop Schemas from version 47.1 to 50.1.