### PR TITLE
net/libcmis: correct 0.6.3 library filenames

### DIFF
--- a/net/libcmis/pkg-plist
+++ b/net/libcmis/pkg-plist
@@ -36,10 +36,10 @@ include/libcmis-c-%%MAJVER%%/libcmis-c/vectors.h
 lib/libcmis-%%MAJVER%%.a
 lib/libcmis-%%MAJVER%%.so
 lib/libcmis-%%MAJVER%%.so.%%SHLIBVER%%
-lib/libcmis-%%MAJVER%%.so.%%SHLIBVER%%.2.1
+lib/libcmis-%%MAJVER%%.so.%%SHLIBVER%%.1.2
 lib/libcmis-c-%%MAJVER%%.a
 lib/libcmis-c-%%MAJVER%%.so
 lib/libcmis-c-%%MAJVER%%.so.%%SHLIBVER%%
-lib/libcmis-c-%%MAJVER%%.so.%%SHLIBVER%%.0.0
+lib/libcmis-c-%%MAJVER%%.so.%%SHLIBVER%%.0.1
 libdata/pkgconfig/libcmis-%%MAJVER%%.pc
 libdata/pkgconfig/libcmis-c-%%MAJVER%%.pc


### PR DESCRIPTION
Correct the two pkg-plist micro-versioned shared-library entries to match the staged 0.6.3 install.\n\nValidation: fresh fake/package; check-license; git diff --check; upstream C++ suite 6/6 (162 cases) and C API suite 1/1 passed using an isolated CppUnit stage.

## Summary by Sourcery

Bug Fixes:
- Correct the pkg-plist entries for libcmis 0.6.3 shared libraries so packaging matches the staged installation.