### PR TITLE
games/gnome-sudoku: update to 49.6

### DIFF
--- a/games/gnome-sudoku/Makefile
+++ b/games/gnome-sudoku/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gnome-sudoku
-PORTVERSION=	47.3
+PORTVERSION=	49.6
+PORTREVISION=	0
 CATEGORIES=	games gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -11,14 +12,13 @@ WWW=		https://wiki.gnome.org/GnomeSudoku
 LICENSE=	gpl3+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	itstool:textproc/itstool
+BUILD_DEPENDS=	blueprint-compiler>0:devel/blueprint-compiler \
+		itstool:textproc/itstool
 LIB_DEPENDS=	libgee-0.8.so:devel/libgee \
 		libqqwing.so:games/qqwing \
 		libjson-glib-1.0.so:devel/json-glib \
 		libgraphene-1.0.so:graphics/graphene
 RUN_DEPENDS=	dbus>0:devel/dbus
-
-PORTSCOUT=	limit:^47\.
 
 USES=		compiler:c++11-lang desktop-file-utils gettext gnome meson \
 		pkgconfig tar:xz vala:build

--- a/games/gnome-sudoku/distinfo
+++ b/games/gnome-sudoku/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1788918849
-SHA256 (gnome/gnome-sudoku-47.3.tar.xz) = f05cf1ef7635ca058ea237d9509eb3295e1def9e4d4e7a5d30b9151f7db90852
-SIZE (gnome/gnome-sudoku-47.3.tar.xz) = 420252
+TIMESTAMP = 1789137509
+SHA256 (gnome/gnome-sudoku-49.6.tar.xz) = 4960389b12a4445cc6a0eaab72872167e8452c8845b4c99a78a8224c608f555a
+SIZE (gnome/gnome-sudoku-49.6.tar.xz) = 452036


### PR DESCRIPTION
Updates GNOME Sudoku from 47.3 to 49.6.

- Resets PORTREVISION to 0.
- Adds the upstream-required blueprint-compiler build dependency.

Validation: bmake makesum, patch, build, fake, package, test (2/2), check-license, and git diff --check.

The local blueprint-compiler package database was inconsistent with its installed files, so the validated build used an isolated extraction of the already-built 0.22.2 package; no port-side workaround is included.

## Summary by Sourcery

Update the GNOME Sudoku port to the 49.6 release with the required build dependency.

Enhancements:
- Update GNOME Sudoku to version 49.6 and add its required Blueprint compiler build dependency.

Build:
- Reset PORTREVISION for the new upstream release and refresh the distribution checksums.