### PR TITLE
x11-toolkits/gtkmm30: update to 3.24.11

### DIFF
--- a/x11-toolkits/gtkmm30/Makefile
+++ b/x11-toolkits/gtkmm30/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	gtkmm
-DISTVERSION=	3.24.9
+DISTVERSION=	3.24.11
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	30
@@ -9,21 +10,20 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	C++ wrapper for Gtk+3
 WWW=		http://gtkmm.sourceforge.net/
 
-LICENSE=	lgpl2.1
+LICENSE=	lgpl2.1+
 
-PORTSCOUT=	limitw:1,even
-
-USES=		compiler:c++11-lang gnome localbase:ldflags meson \
+USES=		compiler:c++11-lang display:test gnome localbase:ldflags meson \
 		pkgconfig python:build tar:xz
 USE_GNOME=	gdkpixbuf gtk30 glibmm cairomm atkmm pangomm
 USE_LDCONFIG=	yes
 
+PORTSCOUT=	limitw:1,even
+
 MESON_ARGS=	-Dbuild-documentation=false \
 		-Dbuild-demos=false \
 		-Dcpp_std=c++11
+TEST_ENV=	${MAKE_ENV}
 
 PLIST_SUB=	API_VERSION="3.0"
-
-NO_TEST=	yes
 
 .include <bsd.port.mk>

--- a/x11-toolkits/gtkmm30/distinfo
+++ b/x11-toolkits/gtkmm30/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1720351007
-SHA256 (gnome/gtkmm-3.24.9.tar.xz) = 30d5bfe404571ce566a8e938c8bac17576420eb508f1e257837da63f14ad44ce
-SIZE (gnome/gtkmm-3.24.9.tar.xz) = 15122612
+TIMESTAMP = 1789179611
+SHA256 (gnome/gtkmm-3.24.11.tar.xz) = 19e383c82d5dd89db275e00b82864e90414d4c3fb3d100b2f996bcc2338a4cc7
+SIZE (gnome/gtkmm-3.24.11.tar.xz) = 13455720


### PR DESCRIPTION
Updates gtkmm30 to 3.24.11.

- Resets PORTREVISION for the new upstream release.
- Corrects the license metadata to LGPL-2.1-or-later.
- Enables and validates the upstream Meson tests under the mports managed Xvfb test hook (2/2 pass).

Validation: bmake makesum, patch, build, fake, package, test, check-license, portlint -C (only retained work/.mport artifact fatals), git diff --check.

## Summary by Sourcery

Update gtkmm30 to 3.24.11 with corrected licensing and enabled upstream test validation.

Enhancements:
- Update gtkmm30 to upstream version 3.24.11 and correct its LGPL license metadata.
- Enable and run the upstream Meson tests through the display test environment.

Tests:
- Validate the gtkmm30 test suite under the managed Xvfb test hook.