### PR TITLE
sysutils/gnome-power-manager: update to 50.0

### DIFF
--- a/sysutils/gnome-power-manager/Makefile
+++ b/sysutils/gnome-power-manager/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	gnome-power-manager
-PORTVERSION=	3.32.0
-PORTREVISION=	1
+PORTVERSION=	50.0
+PORTREVISION=	0
 CATEGORIES=	sysutils gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -9,17 +9,17 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	Power management system for the GNOME Desktop
 WWW=		https://projects.gnome.org/gnome-power-manager
 
-LICENSE=	gpl2
+LICENSE=	gpl2+
+LICENSE_FILE=	${WRKSRC}/COPYING
 
-BUILD_DEPENDS=	appstream-builder:devel/appstream-glib
 LIB_DEPENDS=	libupower-glib.so:sysutils/upower
 
-PORTSCOUT=	limitw:1,even
-
-USES=		gettext gnome localbase:ldflags meson pathfix pkgconfig tar:xz
+USES=		desktop-file-utils gettext-tools gnome localbase:ldflags meson \
+		pkgconfig tar:xz
 INSTALLS_ICONS=	yes
-USE_GNOME=	cairo gtk30 intlhack
-MESON_ARGS=	-Denable-tests=false
+USE_GNOME=	cairo gtk40 gtk-update-icon-cache
+
+PORTSCOUT=	limitw:1,even
 
 GLIB_SCHEMAS=	org.gnome.power-manager.gschema.xml
 
@@ -29,13 +29,4 @@ OPTIONS_SUB=	yes
 MANPAGES_BUILD_DEPENDS=	docbook2html:textproc/docbook-utils \
 			docbook-sgml>0:textproc/docbook-sgml
 
-post-patch-MANPAGES-off:
-	@${REINPLACE_CMD} -e "s|subdir('man')||g" \
-		${WRKSRC}/meson.build
-
-post-patch:
-	@${REINPLACE_CMD} -e 's|share/man/man1|man/man1|g' \
-		${WRKSRC}/man/meson.build
-
 .include <bsd.port.mk>
-

--- a/sysutils/gnome-power-manager/distinfo
+++ b/sysutils/gnome-power-manager/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1657827073
-SHA256 (gnome/gnome-power-manager-3.32.0.tar.xz) = 4f2ca1a756da5061b04042b5cf21008df1267806d76c8e0fb08422c6f8b02e37
-SIZE (gnome/gnome-power-manager-3.32.0.tar.xz) = 379136
+TIMESTAMP = 1789180467
+SHA256 (gnome/gnome-power-manager-50.0.tar.xz) = bf243d6389f8bfa71c958534ed2669b29965c47f55c3cbe4983b296d0f99e5d7
+SIZE (gnome/gnome-power-manager-50.0.tar.xz) = 384136

--- a/sysutils/gnome-power-manager/pkg-plist
+++ b/sysutils/gnome-power-manager/pkg-plist
@@ -19,6 +19,7 @@ share/locale/bn_IN/LC_MESSAGES/gnome-power-manager.mo
 share/locale/bs/LC_MESSAGES/gnome-power-manager.mo
 share/locale/ca/LC_MESSAGES/gnome-power-manager.mo
 share/locale/ca@valencia/LC_MESSAGES/gnome-power-manager.mo
+share/locale/ckb/LC_MESSAGES/gnome-power-manager.mo
 share/locale/cs/LC_MESSAGES/gnome-power-manager.mo
 share/locale/cy/LC_MESSAGES/gnome-power-manager.mo
 share/locale/da/LC_MESSAGES/gnome-power-manager.mo
@@ -49,6 +50,7 @@ share/locale/is/LC_MESSAGES/gnome-power-manager.mo
 share/locale/it/LC_MESSAGES/gnome-power-manager.mo
 share/locale/ja/LC_MESSAGES/gnome-power-manager.mo
 share/locale/ka/LC_MESSAGES/gnome-power-manager.mo
+share/locale/kab/LC_MESSAGES/gnome-power-manager.mo
 share/locale/km/LC_MESSAGES/gnome-power-manager.mo
 share/locale/kn/LC_MESSAGES/gnome-power-manager.mo
 share/locale/ko/LC_MESSAGES/gnome-power-manager.mo


### PR DESCRIPTION
Updates GNOME Power Manager from 3.32.0 to 50.0.

- Migrates the port from GTK3 to GTK4 and current gettext/desktop integration.
- Resets PORTREVISION and corrects GPL-2.0-or-later metadata.
- Removes obsolete source patches; adds the ckb and kab translations to the plist.

Validation: bmake makesum, patch, build, fake, package, test (1/1), check-license, git diff --check. portlint -C reports only retained work/.mport artifact fatals plus NLS and explicit PORTREVISION=0 advisories.

## Summary by Sourcery

Update the GNOME Power Manager port to the current GTK4-based 50.0 release.

New Features:
- Update GNOME Power Manager to version 50.0 with GTK4 support and refreshed desktop integration.

Enhancements:
- Correct the port's GPL-2.0-or-later licensing metadata and include its license file.
- Remove obsolete build-time dependencies, porting constraints, and source patching.

Chores:
- Add the newly included ckb and kab translations to the package plist.
- Reset PORTREVISION for the upstream version update.