### PR TITLE
x11/tecla: update to 48.0.2

### DIFF
--- a/x11/tecla/Makefile
+++ b/x11/tecla/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	tecla
-PORTVERSION=	47.0
+PORTVERSION=	48.0.2
+PORTREVISION=	0
 CATEGORIES=	x11 gnome
 MASTER_SITES=	GNOME
 DIST_SUBDIR=	gnome
@@ -14,6 +15,7 @@ LIB_DEPENDS=	libxkbcommon.so:x11/libxkbcommon \
 		libwayland-client.so:graphics/wayland
 
 USES=		gettext gnome meson pkgconfig tar:xz
-USE_GNOME=	glib20 gtk40 libadwaita
+USE_GNOME=	glib20 gtk40 gtk-update-icon-cache libadwaita
+INSTALLS_ICONS=	yes
 
 .include <bsd.port.mk>

--- a/x11/tecla/distinfo
+++ b/x11/tecla/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1744472395
-SHA256 (gnome/tecla-47.0.tar.xz) = 0790b99ec29137a54b546c510661a99aa6f039c8d75f10c08e928682c0804fe5
-SIZE (gnome/tecla-47.0.tar.xz) = 38072
+TIMESTAMP = 1789180769
+SHA256 (gnome/tecla-48.0.2.tar.xz) = 783d3464d2a2cf7eb1507649dbd9ff09ce24852c2a6c9a0d365db84063d3d401
+SIZE (gnome/tecla-48.0.2.tar.xz) = 41048

--- a/x11/tecla/pkg-plist
+++ b/x11/tecla/pkg-plist
@@ -23,6 +23,7 @@ share/locale/gl/LC_MESSAGES/tecla.mo
 share/locale/he/LC_MESSAGES/tecla.mo
 share/locale/hi/LC_MESSAGES/tecla.mo
 share/locale/hu/LC_MESSAGES/tecla.mo
+share/locale/ia/LC_MESSAGES/tecla.mo
 share/locale/id/LC_MESSAGES/tecla.mo
 share/locale/ie/LC_MESSAGES/tecla.mo
 share/locale/it/LC_MESSAGES/tecla.mo


### PR DESCRIPTION
Updates Tecla to 48.0.2, resets PORTREVISION, enables icon-cache handling, and adds the staged Interlingua locale.\n\nValidation: bmake makesum, patch, build, fake, package, test (upstream defines no tests), check-license, and git diff --check. portlint reports only retained work/package artifacts as fatal plus existing advisory warnings.

## Summary by Sourcery

Update the Tecla port to version 48.0.2 with refreshed package contents and desktop integration support.

New Features:
- Add installation support for Tecla’s icon cache and include the Interlingua locale in the package.

Enhancements:
- Update the Tecla port to release 48.0.2 and reset its port revision.