### PR TITLE
www/bluefish: update to 2.4.2

### DIFF
--- a/www/bluefish/Makefile
+++ b/www/bluefish/Makefile
@@ -1,6 +1,6 @@
 PORTNAME=	bluefish
-DISTVERSION=	2.4.0
-PORTREVISION=	1
+DISTVERSION=	2.4.2
+PORTREVISION=	0
 CATEGORIES=	www editors
 MASTER_SITES=	https://www.bennewitz.com/bluefish/stable/source/ \
 		SF
@@ -32,7 +32,6 @@ CONFIGURE_ARGS=	--disable-update-databases \
 		--with-icon-path=${PREFIX}/share/pixmaps
 INSTALL_TARGET=	install-strip
 INSTALLS_ICONS=	yes
-USE_LDCONFIG=	yes
 
 PORTSCOUT=	skipv:2.2.15fp
 

--- a/www/bluefish/distinfo
+++ b/www/bluefish/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1770018877
-SHA256 (bluefish-2.4.0.tar.bz2) = 3d0d0ac6553c83251a2031d4ea9e36a8c8947dd6e5e40a868e34ad0f5d2ea822
-SIZE (bluefish-2.4.0.tar.bz2) = 5012280
+TIMESTAMP = 1789181028
+SHA256 (bluefish-2.4.2.tar.bz2) = b2641f9ff8033719e02c519c5ddb4bdadbd7ff73ef252e9287d512c4770377c5
+SIZE (bluefish-2.4.2.tar.bz2) = 5185382

--- a/www/bluefish/pkg-plist
+++ b/www/bluefish/pkg-plist
@@ -80,6 +80,9 @@ share/applications/bluefish.desktop
 %%DATADIR%%/bflib/bflib_php5_with_examples.xml.gz
 %%DATADIR%%/bflib/bflib_python_2.3.xml.gz
 %%DATADIR%%/bflib/bflib_xhtml.xml.gz
+%%DATADIR%%/bluefish-breeze-dark.gresource
+%%DATADIR%%/bluefish-breeze.gresource
+%%DATADIR%%/bluefish.gresource
 %%DATADIR%%/bluefish_splash.png
 %%DATADIR%%/colorprofiles/Dark_theme
 %%DATADIR%%/colorprofiles/Light_theme
@@ -90,7 +93,9 @@ share/applications/bluefish.desktop
 %%DATADIR%%/jsmin.py
 %%DATADIR%%/json_prettyprint.py
 %%DATADIR%%/lorem-ipsum-generator
-%%DATADIR%%/plugins/htmlbar/ui/htmlbar_menu_ui.xml
+%%DATADIR%%/plugins/htmlbar/htmlbar-breeze-dark.gresource
+%%DATADIR%%/plugins/htmlbar/htmlbar-breeze.gresource
+%%DATADIR%%/plugins/htmlbar/htmlbar.gresource
 %%DATADIR%%/plugins/zencoding/__init__.py
 %%DATADIR%%/plugins/zencoding/actions/__init__.py
 %%DATADIR%%/plugins/zencoding/actions/basic.py


### PR DESCRIPTION
Updates Bluefish to 2.4.2, resets PORTREVISION, refreshes the staged resource plist, and removes stale USE_LDCONFIG (only plugins under lib/bluefish are installed).\n\nValidation: bmake makesum, patch, build, fake, package, test, check-license, staged plist audit, and git diff --check. portlint reports only the retained work directory as fatal plus NLS and explicit PORTREVISION advisories.

## Summary by Sourcery

Update the Bluefish port to version 2.4.2 and align its packaging metadata with the current installation layout.

Enhancements:
- Update Bluefish to the 2.4.2 release and refresh its staged package contents.
- Remove the obsolete shared-library cache configuration because the package only installs private plugins.

Chores:
- Reset PORTREVISION for the upstream version update.