### PR TITLE
devel/libsoup3: update to 3.7.2

### DIFF
--- a/devel/libsoup3/Makefile
+++ b/devel/libsoup3/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	libsoup
-PORTVERSION=	3.7.1
+PORTVERSION=	3.7.2
+PORTREVISION=	0
 CATEGORIES=	devel gnome
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	3
@@ -9,7 +10,7 @@ MAINTAINER=	ports@MidnightBSD.org
 COMMENT=	HTTP client/server library for GNOME
 WWW=		https://gitlab.gnome.org/GNOME/libsoup
 
-LICENSE=	lgpl
+LICENSE=	lgpl+
 LICENSE_FILE=	${WRKSRC}/COPYING
 
 BUILD_DEPENDS=	glib-networking>0:net/glib-networking \

--- a/devel/libsoup3/distinfo
+++ b/devel/libsoup3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1779822140
-SHA256 (gnome/libsoup-3.7.1.tar.xz) = 9c96e11bb91641fe21948013499ca716393c9e9336562f9ff849c41d4edab80e
-SIZE (gnome/libsoup-3.7.1.tar.xz) = 1586280
+TIMESTAMP = 1789182813
+SHA256 (gnome/libsoup-3.7.2.tar.xz) = 03b7085df85645228c6490b6bbfda8c2ce5394d0cd7184005f550a81225ac4aa
+SIZE (gnome/libsoup-3.7.2.tar.xz) = 1580868


### PR DESCRIPTION
Updates libsoup 3.7.1 to 3.7.2.\n\n- includes upstream HTTP/2 fixes and compression-dictionary support\n- retains the existing `TESTING_UNSAFE` policy unchanged\n- corrects the source-evidenced Library GPL v2-or-later metadata from `lgpl` to `lgpl+`\n- sets `PORTREVISION=0`\n\nValidation: bmake makesum, patch, build, fake, package, test target, check-license, git diff --check. The staged library remains `libsoup-3.0.so.0.7.3` with SONAME `libsoup-3.0.so.0`; no dependent rebuild bump is required. portlint -C reports only retained generated work/package artifacts plus existing advisory warnings.

## Summary by Sourcery

Update the libsoup3 port to the 3.7.2 release and align its package metadata with the upstream licensing.

Enhancements:
- Update libsoup3 to version 3.7.2 while preserving the existing library ABI and testing policy.

Chores:
- Correct the package license metadata to reflect LGPL-2.0-or-later and reset the port revision.