### PR TITLE
x11-toolkits/vte3: update to 0.82.4

### DIFF
--- a/x11-toolkits/vte3/Makefile
+++ b/x11-toolkits/vte3/Makefile
@@ -1,5 +1,6 @@
 PORTNAME=	vte
-PORTVERSION=	0.80.5
+PORTVERSION=	0.82.4
+PORTREVISION=	0
 CATEGORIES=	x11-toolkits gnome
 MASTER_SITES=	GNOME
 PKGNAMESUFFIX=	3
@@ -20,7 +21,7 @@ LIB_DEPENDS=	libpcre2-8.so:devel/pcre2 \
 
 PORTSCOUT=	limitw:1,even
 
-USES=		compiler:c++20-lang gettext-tools gnome localbase meson \
+USES=		compiler:c++23-lang gettext-tools gnome localbase meson \
 		pkgconfig python:build tar:xz vala:build
 USE_LDCONFIG=	yes
 USE_GNOME=	cairo gdkpixbuf gtk30 introspection:build

--- a/x11-toolkits/vte3/distinfo
+++ b/x11-toolkits/vte3/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1788842549
-SHA256 (gnome/vte-0.80.5.tar.xz) = 58a4e00ab5d4a95b4be4dc57b48308deafd72d6839dbbd076648fa353321cc41
-SIZE (gnome/vte-0.80.5.tar.xz) = 587680
+TIMESTAMP = 1789183054
+SHA256 (gnome/vte-0.82.4.tar.xz) = 6b1c06fb4df10c82661e3596130fc6bf77a2fa9f57d8432826b1d5eca23bf3e1
+SIZE (gnome/vte-0.82.4.tar.xz) = 6148520

--- a/x11-toolkits/vte3/pkg-plist
+++ b/x11-toolkits/vte3/pkg-plist
@@ -32,7 +32,7 @@ lib/girepository-1.0/Vte-2.%%API_VER%%.typelib
 %%GTK4%%lib/libvte-2.%%API_VER%%-gtk4.so.0
 lib/libvte-2.%%API_VER%%.so
 lib/libvte-2.%%API_VER%%.so.0
-lib/libvte-2.%%API_VER%%.so.0.8000.5
+lib/libvte-2.%%API_VER%%.so.0.8200.4
 %%GTK4%%libdata/pkgconfig/vte-2.%%API_VER%%-gtk4.pc
 libdata/pkgconfig/vte-2.%%API_VER%%.pc
 libexec/vte-urlencode-cwd


### PR DESCRIPTION
Updates VTE from 0.80.5 to 0.82.4.\n\n- requires C++23, matching the upstream Meson requirement\n- refreshes the installed GTK3 library filename to `libvte-2.91.so.0.8200.4`\n- retains the established GTK3/GTK4 options and GPLv3+/LGPLv3+ metadata\n- sets `PORTREVISION=0`\n\nValidation: bmake makesum, patch, build, fake, package, test (19/19 pass), check-license, and git diff --check. Both GTK3 and GTK4 library SONAMEs remain .so.0, so no dependent rebuild bump is needed. portlint -C reports only retained generated work/package artifacts and existing advisory warnings.

## Summary by Sourcery

Update the VTE3 port to the 0.82.4 release.

Enhancements:
- Update the VTE3 port to version 0.82.4 and align its build requirements with upstream C++23 support.

Build:
- Refresh the VTE3 distfile checksum and installed GTK3 library filename for the new release.